### PR TITLE
Add gcode properties to properties panel

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,92 @@
+﻿# terraForge — Workspace Instructions
+
+Cross-platform Electron + React app for controlling FluidNC-based pen plotters (TerraPen).
+Pipeline: SVG/PDF import → canvas editing → G-code generation → FluidNC machine control.
+
+## Architecture
+
+```
+src/main/          Electron main process — all system I/O (file, serial, network)
+src/preload/       contextBridge exposes window.terraForge IPC API
+src/renderer/src/  React UI: components/, store/, utils/
+src/workers/       gcodeEngine.ts, svgWorker.ts — heavy work off renderer thread
+src/machine/       FluidNC REST + WebSocket client (fluidnc.ts, serial.ts)
+src/tasks/         Background task orchestration (taskManager.ts)
+src/types/         Shared TypeScript interfaces — single source of truth
+```
+
+Full spec: [docs/terraForge-spec.md](../docs/terraForge-spec.md)
+Feature status: [docs/terraForge-features.md](../docs/terraForge-features.md)
+
+## Build & Test
+
+```sh
+npm run dev            # Electron dev server with hot reload
+npm run build          # Production build -> out/
+npm test               # Vitest unit + component tests (run after changes)
+npm run test:watch     # Watch mode
+npm run test:coverage  # With Istanbul coverage
+npm run test:e2e       # Playwright E2E (builds first)
+npm run typecheck      # TypeScript strict check across all tsconfigs
+```
+
+- Unit tests: `tests/unit/` — Node or jsdom depending on module
+- Component tests: `tests/component/` — jsdom + React Testing Library
+- E2E: `tests/e2e/*.spec.ts` — Playwright against real Electron build
+- Fix failing tests when making significant changes; update spec/features docs accordingly
+
+## Tech Stack — Hard Rules
+
+- **React 19 functional components only** — no class components
+- **Zustand** for state (canvasStore, machineStore, taskStore, consoleStore) — no Redux
+- **TailwindCSS** for styling — no CSS-in-JS
+- **TypeScript everywhere** — typed IPC boundaries, no `any` at system edges
+- **No Node APIs in renderer** — all file/network/serial access via `window.terraForge` IPC
+
+## IPC Contract (`window.terraForge`)
+
+```ts
+// Machine
+fluidnc.getStatus() | sendCommand(cmd) | pauseJob() | resumeJob() | abortJob()
+fluidnc.listFiles(path) | listSDFiles(path) | uploadFile() | deleteFile() | runFile()
+fluidnc.connectWebSocket(host, port, wsPort) | disconnectWebSocket()
+fluidnc.onStatusUpdate(cb) | onConsoleMessage(cb) | onFirmwareInfo(cb)
+
+// Serial
+serial.listPorts() | connect(path, baud) | disconnect() | send(data) | onData(cb)
+
+// File I/O
+fs.openSvgDialog() | openPdfDialog() | openFileDialog() | readFile() | writeFile() | saveGcodeDialog()
+
+// Jobs & Tasks
+jobs.generateGcode(taskId, objects, config, options)   // runs in Web Worker
+tasks.cancel(taskId) | onTaskUpdate(cb)
+
+// Config
+config.getMachineConfigs() | saveMachineConfig() | deleteMachineConfig() | exportConfigs() | importConfigs()
+```
+
+## Conventions
+
+**State management:**
+- Zustand stores use immer (enabled automatically via `immer` middleware)
+- Cancel callbacks for long-running tasks live in a **module-level Map**, never inside immer state
+
+**Types:**
+- All shared interfaces live in `src/types/index.ts` — do not scatter types across files
+- Key models: `MachineConfig`, `VectorObject`, `SvgImport`, `BackgroundTask`, `Job`
+
+**Long-running tasks:**
+- Must report progress (0-100 or `null`), support cancellation, and update task status in UI
+- G-code generation must run in `svgWorker.ts` — never block the renderer
+
+**IPC channels** follow `namespace:action` pattern (e.g., `fluidnc:getStatus`, `tasks:cancel`)
+
+## FluidNC Integration Rules
+
+Only use documented REST endpoints:
+`/command`, `/state`, `/files`, `/upload`, `/delete`, `/run`, `/pause`, `/resume`, `/abort`
+
+WebSocket `/ws` streams console output and machine status.
+
+**Never invent FluidNC endpoints.** If uncertain, consult docs/terraForge-spec.md.

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -195,6 +195,9 @@ function FsPane({
       setGcodeToolpath(toolpath);
       // Store the source so the canvas toolpath selection can restore it.
       setGcodeSource({ path: file.path, name: file.name, source });
+      // Auto-select the toolpath so the canvas, Properties panel, and
+      // Job panel are all in sync from the moment of preview.
+      selectToolpath(true);
       // Select this file as the queued job so Start Job is enabled immediately
       // and the file is highlighted in the browser.
       setSelectedJobFile({ path: file.path, source, name: file.name });

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -119,6 +119,7 @@ function FsPane({
   const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
   const setGcodeSource = useCanvasStore((s) => s.setGcodeSource);
+  const selectToolpath = useCanvasStore((s) => s.selectToolpath);
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
 
@@ -191,8 +192,11 @@ function FsPane({
       );
       const toolpath = parseGcode(text);
       setGcodeToolpath(toolpath);
-      // Remote preview is not a local file — clear any stored local source
-      setGcodeSource(null);
+      // Store the source so the canvas toolpath selection can restore it.
+      setGcodeSource({ path: file.path, name: file.name, source });
+      // Select this file as the queued job so Start Job is enabled immediately
+      // and the file is highlighted in the browser.
+      setSelectedJobFile({ path: file.path, source, name: file.name });
     } catch (err) {
       console.error("Preview failed:", err);
     } finally {
@@ -326,6 +330,9 @@ function FsPane({
                           ? null
                           : { path: file.path, source, name: file.name },
                       );
+                      // Deselect canvas toolpath when the file browser takes
+                      // ownership of the job-file selection.
+                      selectToolpath(false);
                     }
                   }}
                 >

--- a/src/renderer/src/components/JobControls.tsx
+++ b/src/renderer/src/components/JobControls.tsx
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 import { useMachineStore } from "../store/machineStore";
 import { useTaskStore } from "../store/taskStore";
+import { useCanvasStore } from "../store/canvasStore";
 
 const GCODE_EXTS = [
   ".gcode",
@@ -21,9 +22,23 @@ export function JobControls() {
   const status = useMachineStore((s) => s.status);
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const upsertTask = useTaskStore((s) => s.upsertTask);
+  const toolpathSelected = useCanvasStore((s) => s.toolpathSelected);
+  const gcodeSource = useCanvasStore((s) => s.gcodeSource);
+
+  // When the canvas toolpath is selected and has a local file source, use it
+  // as the job file even if nothing is explicitly set in the file browser.
+  const effectiveJobFile =
+    selectedJobFile ??
+    (toolpathSelected && gcodeSource
+      ? {
+          path: gcodeSource.path,
+          source: gcodeSource.source,
+          name: gcodeSource.name,
+        }
+      : null);
 
   const jobFileValid =
-    selectedJobFile != null && isGcodeFile(selectedJobFile.name);
+    effectiveJobFile != null && isGcodeFile(effectiveJobFile.name);
 
   const isRunning = status?.state === "Run";
   const isHeld = status?.state === "Hold";
@@ -94,17 +109,17 @@ export function JobControls() {
       {!isActive && (
         <div
           className="text-[9px] truncate px-0.5 -mt-1 mb-0.5"
-          title={selectedJobFile?.path ?? undefined}
+          title={effectiveJobFile?.path ?? undefined}
         >
-          {!selectedJobFile ? (
+          {!effectiveJobFile ? (
             <span className="italic text-gray-500">
               No file selected — pick one in File Browser
             </span>
           ) : jobFileValid ? (
             <span className="text-gray-300">
-              {selectedJobFile.source === "local" ? "🖥" : "📄"}{" "}
-              {selectedJobFile.name}
-              {selectedJobFile.source === "local" && (
+              {effectiveJobFile.source === "local" ? "🖥" : "📄"}{" "}
+              {effectiveJobFile.name}
+              {effectiveJobFile.source === "local" && (
                 <span className="text-gray-500 ml-1">
                   (local — will upload)
                 </span>
@@ -112,7 +127,7 @@ export function JobControls() {
             </span>
           ) : (
             <span className="text-amber-400">
-              ⚠ {selectedJobFile.name} — not a G-code file
+              ⚠ {effectiveJobFile.name} — not a G-code file
             </span>
           )}
         </div>
@@ -124,9 +139,9 @@ export function JobControls() {
           "▶ Start job",
           async () => {
             if (!jobFileValid) return;
-            if (selectedJobFile!.source === "local") {
+            if (effectiveJobFile!.source === "local") {
               // Local file: upload to SD card root first, then run
-              const { name, path: localPath } = selectedJobFile!;
+              const { name, path: localPath } = effectiveJobFile!;
               const remotePath = "/" + name;
               const taskId = uuid();
               upsertTask({
@@ -155,17 +170,17 @@ export function JobControls() {
               }
             } else {
               await window.terraForge.fluidnc.runFile(
-                selectedJobFile!.path,
-                selectedJobFile!.source as "fs" | "sd",
+                effectiveJobFile!.path,
+                effectiveJobFile!.source as "fs" | "sd",
               );
             }
           },
           "primary",
           !jobFileValid, // disabled unless a valid G-code file is selected
           jobFileValid
-            ? selectedJobFile!.source === "local"
-              ? `Upload ${selectedJobFile!.name} to SD card then run`
-              : `Run ${selectedJobFile!.name} on the machine`
+            ? effectiveJobFile!.source === "local"
+              ? `Upload ${effectiveJobFile!.name} to SD card then run`
+              : `Run ${effectiveJobFile!.name} on the machine`
             : "Select a G-code file in the File Browser first",
         )}
 

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -55,6 +55,8 @@ export function PlotCanvas() {
   const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
   const gcodeSource = useCanvasStore((s) => s.gcodeSource);
+  const toolpathSelected = useCanvasStore((s) => s.toolpathSelected);
+  const selectToolpath = useCanvasStore((s) => s.selectToolpath);
   const plotProgressCuts = useCanvasStore((s) => s.plotProgressCuts);
   const plotProgressRapids = useCanvasStore((s) => s.plotProgressRapids);
   const activeConfig = useMachineStore((s) => s.activeConfig);
@@ -250,7 +252,8 @@ export function PlotCanvas() {
   } | null>(null);
 
   // ── Toolpath selection ────────────────────────────────────────────────────────
-  const [toolpathSelected, setToolpathSelected] = useState(false);
+  // toolpathSelected and selectToolpath live in canvasStore so PropertiesPanel
+  // can react to canvas selection changes (and vice versa).
 
   // ── Keyboard shortcuts ────────────────────────────────────────────────────────
   useEffect(() => {
@@ -274,7 +277,6 @@ export function PlotCanvas() {
           removeImport(selectedImportId);
         } else if (toolpathSelected) {
           setGcodeToolpath(null);
-          setToolpathSelected(false);
           if (selectedJobFile?.source === "local") setSelectedJobFile(null);
         }
       }
@@ -282,7 +284,7 @@ export function PlotCanvas() {
       // Escape → deselect
       if (e.key === "Escape") {
         selectImport(null);
-        setToolpathSelected(false);
+        selectToolpath(false);
       }
 
       // Ctrl/Cmd + Shift + + / - → keyboard zoom
@@ -322,15 +324,13 @@ export function PlotCanvas() {
     toolpathSelected,
     removeImport,
     selectImport,
+    selectToolpath,
     setGcodeToolpath,
     zoomBy,
     fitToView,
   ]);
 
-  // Clear toolpath selection when toolpath is removed
-  useEffect(() => {
-    if (!gcodeToolpath) setToolpathSelected(false);
-  }, [gcodeToolpath]);
+  // Clear toolpath selection when toolpath is removed — handled by the store.
 
   // ── SVG coordinate helpers (map machine-mm → canvas SVG px) ─────────────────
   // Y: bottom-origins flip so mm=0 is at the bottom of the bed rectangle.
@@ -628,7 +628,7 @@ export function PlotCanvas() {
             return;
           }
           selectImport(null);
-          setToolpathSelected(false);
+          selectToolpath(false);
         }}
       >
         {/* Bed background */}
@@ -780,7 +780,7 @@ export function PlotCanvas() {
                       onClick={(e) => {
                         e.stopPropagation();
                         selectImport(null);
-                        setToolpathSelected(true);
+                        selectToolpath(true);
                         // Restore the local job file selection so the Job panel
                         // shows the filename again after a file-browser deselect.
                         if (gcodeSource)

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -332,6 +332,29 @@ export function PlotCanvas() {
 
   // Clear toolpath selection when toolpath is removed — handled by the store.
 
+  // ── Sync toolpathSelected ↔ selectedJobFile ───────────────────────────────────
+  // One central effect keeps the file browser and job panel in lock-step with
+  // the canvas toolpath selection (and vice versa).
+  //   selecting   → restore selectedJobFile from gcodeSource
+  //   deselecting → clear selectedJobFile only if it was pointing at gcodeSource
+  useEffect(() => {
+    if (toolpathSelected && gcodeSource) {
+      setSelectedJobFile({
+        path: gcodeSource.path,
+        name: gcodeSource.name,
+        source: gcodeSource.source,
+      });
+    } else if (!toolpathSelected && gcodeSource) {
+      const current = useMachineStore.getState().selectedJobFile;
+      if (current?.path === gcodeSource.path) {
+        setSelectedJobFile(null);
+      }
+    }
+    // Intentionally only re-run when toolpathSelected changes; gcodeSource
+    // changing means a new toolpath was loaded which resets toolpathSelected.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolpathSelected]);
+
   // ── SVG coordinate helpers (map machine-mm → canvas SVG px) ─────────────────
   // Y: bottom-origins flip so mm=0 is at the bottom of the bed rectangle.
   const getBedY = (mmY: number) =>
@@ -781,13 +804,7 @@ export function PlotCanvas() {
                         e.stopPropagation();
                         selectImport(null);
                         selectToolpath(true);
-                        // Restore the local job file selection so the Job panel
-                        // shows the filename again after a file-browser deselect.
-                        if (gcodeSource)
-                          setSelectedJobFile({
-                            ...gcodeSource,
-                            source: "local",
-                          });
+                        // selectedJobFile is synced by the toolpathSelected effect below.
                       }}
                     />
                   </g>

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -277,7 +277,7 @@ export function PlotCanvas() {
           removeImport(selectedImportId);
         } else if (toolpathSelected) {
           setGcodeToolpath(null);
-          if (selectedJobFile?.source === "local") setSelectedJobFile(null);
+          // selectedJobFile is cleared by the gcodeToolpath→null effect below.
         }
       }
 
@@ -330,7 +330,17 @@ export function PlotCanvas() {
     fitToView,
   ]);
 
-  // Clear toolpath selection when toolpath is removed — handled by the store.
+  // ── Clear selectedJobFile when the toolpath is removed ─────────────────────
+  // Detects the non-null → null transition so clearing the toolpath (via the
+  // ✕ button, Delete key, or any other path) always resets the job panel.
+  const prevGcodeToolpathRef = useRef(gcodeToolpath);
+  useEffect(() => {
+    const prev = prevGcodeToolpathRef.current;
+    prevGcodeToolpathRef.current = gcodeToolpath;
+    if (prev !== null && gcodeToolpath === null) {
+      setSelectedJobFile(null);
+    }
+  }, [gcodeToolpath, setSelectedJobFile]);
 
   // ── Sync toolpathSelected ↔ selectedJobFile ───────────────────────────────────
   // One central effect keeps the file browser and job panel in lock-step with

--- a/src/renderer/src/components/PropertiesPanel.tsx
+++ b/src/renderer/src/components/PropertiesPanel.tsx
@@ -16,6 +16,34 @@ import {
 } from "lucide-react";
 import { useCanvasStore } from "../store/canvasStore";
 import { useMachineStore } from "../store/machineStore";
+import type { GcodeToolpath } from "../utils/gcodeParser";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m < 60) return `${m}m ${s}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+function estimateDuration(tp: GcodeToolpath, fallbackFeedrate: number): string {
+  const fr = tp.feedrate > 0 ? tp.feedrate : fallbackFeedrate;
+  if (fr <= 0 || (tp.totalCutDistance === 0 && tp.totalRapidDistance === 0)) {
+    return "—";
+  }
+  // Rapid moves run at approximately 5× the job feedrate, capped at 10 000 mm/min
+  const rapidRate = Math.min(fr * 5, 10000);
+  const totalSec = Math.round(
+    (tp.totalCutDistance / fr + tp.totalRapidDistance / rapidRate) * 60,
+  );
+  return formatDuration(totalSec);
+}
 
 const ROT_STEPS = [1, 5, 15, 30, 45] as const;
 type RotStep = (typeof ROT_STEPS)[number];
@@ -31,6 +59,11 @@ export function PropertiesPanel() {
   const removePath = useCanvasStore((s) => s.removePath);
   const showCentreMarker = useCanvasStore((s) => s.showCentreMarker);
   const toggleCentreMarker = useCanvasStore((s) => s.toggleCentreMarker);
+  const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
+  const gcodeSource = useCanvasStore((s) => s.gcodeSource);
+  const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
+  const toolpathSelected = useCanvasStore((s) => s.toolpathSelected);
+  const selectToolpath = useCanvasStore((s) => s.selectToolpath);
   const activeConfig = useMachineStore((s) => s.activeConfig);
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -78,389 +111,382 @@ export function PropertiesPanel() {
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {imports.length === 0 ? (
+        {imports.length === 0 && !gcodeToolpath ? (
           <p className="text-xs text-gray-600 text-center py-6 px-3">
             No objects. Import an SVG.
           </p>
         ) : (
-          imports.map((imp) => {
-            const isSelected = imp.id === selectedImportId;
-            const isExpanded = expandedIds.has(imp.id);
+          <>
+            {/* ── G-code toolpath entry ──────────────────────────────── */}
+            {gcodeToolpath &&
+              (() => {
+                const cfg = activeConfig();
+                const fallbackFeedrate = cfg?.feedrate ?? 300;
+                const fileName = gcodeSource?.name ?? "G-code toolpath";
+                const duration = estimateDuration(
+                  gcodeToolpath,
+                  fallbackFeedrate,
+                );
+                return (
+                  <div className="border-b border-[#0f3460]/30">
+                    {/* Header row */}
+                    <div
+                      className={`flex items-center gap-1 px-2 py-1.5 cursor-pointer hover:bg-[#0f3460]/20 ${toolpathSelected ? "bg-[#0f3460]/20" : ""}`}
+                      onClick={() => selectToolpath(!toolpathSelected)}
+                    >
+                      <button
+                        className="text-gray-500 hover:text-gray-200 text-[10px] w-4 shrink-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          selectToolpath(!toolpathSelected);
+                        }}
+                      >
+                        {toolpathSelected ? "▾" : "▸"}
+                      </button>
+                      {/* G-code file icon */}
+                      <svg
+                        className="shrink-0 text-[#0ea5e9]"
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                        <polyline points="14 2 14 8 20 8" />
+                        <line x1="16" y1="13" x2="8" y2="13" />
+                        <line x1="16" y1="17" x2="8" y2="17" />
+                        <polyline points="10 9 9 9 8 9" />
+                      </svg>
+                      <span
+                        className="flex-1 min-w-0 text-[10px] truncate text-gray-300"
+                        title={fileName}
+                      >
+                        {fileName}
+                      </span>
+                      <button
+                        className="ml-1 text-gray-600 hover:text-[#e94560] shrink-0"
+                        title="Clear toolpath"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setGcodeToolpath(null);
+                        }}
+                      >
+                        ✕
+                      </button>
+                    </div>
 
-            return (
-              <div
-                key={imp.id}
-                className={`border-b border-[#0f3460]/30 ${isSelected ? "bg-[#0f3460]/20" : ""}`}
-              >
-                {/* Import header row */}
+                    {/* Expanded properties */}
+                    {toolpathSelected && (
+                      <div className="pl-6 pr-3 pb-2 pt-1 border-t border-[#0f3460]/20 space-y-1">
+                        <div className="flex justify-between text-[10px]">
+                          <span className="text-gray-500">Size</span>
+                          <span className="text-gray-300 font-mono">
+                            {formatBytes(gcodeToolpath.fileSizeBytes)}
+                          </span>
+                        </div>
+                        <div className="flex justify-between text-[10px]">
+                          <span className="text-gray-500">Lines</span>
+                          <span className="text-gray-300 font-mono">
+                            {gcodeToolpath.lineCount.toLocaleString()}
+                          </span>
+                        </div>
+                        <div className="flex justify-between text-[10px]">
+                          <span className="text-gray-500">Est. duration</span>
+                          <span className="text-gray-300 font-mono">
+                            {duration}
+                          </span>
+                        </div>
+                        {gcodeToolpath.feedrate > 0 && (
+                          <div className="flex justify-between text-[10px]">
+                            <span className="text-gray-500">Feedrate</span>
+                            <span className="text-gray-300 font-mono">
+                              {Math.round(gcodeToolpath.feedrate)} mm/min
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
+
+            {/* ── SVG import entries ─────────────────────────────────── */}
+            {imports.map((imp) => {
+              const isSelected = imp.id === selectedImportId;
+              const isExpanded = expandedIds.has(imp.id);
+
+              return (
                 <div
-                  className="flex items-center gap-1 px-2 py-1.5 cursor-pointer hover:bg-[#0f3460]/20"
-                  onClick={() => selectImport(isSelected ? null : imp.id)}
+                  key={imp.id}
+                  className={`border-b border-[#0f3460]/30 ${isSelected ? "bg-[#0f3460]/20" : ""}`}
                 >
-                  {/* Expand toggle */}
-                  <button
-                    className="text-gray-500 hover:text-gray-200 text-[10px] w-4 shrink-0"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleExpand(imp.id);
-                    }}
+                  {/* Import header row */}
+                  <div
+                    className="flex items-center gap-1 px-2 py-1.5 cursor-pointer hover:bg-[#0f3460]/20"
+                    onClick={() => selectImport(isSelected ? null : imp.id)}
                   >
-                    {isExpanded ? "▾" : "▸"}
-                  </button>
-
-                  {/* Visibility */}
-                  <span
-                    className="text-gray-500 hover:text-gray-200 text-[10px] cursor-pointer shrink-0"
-                    title="Toggle visibility"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      updateImport(imp.id, { visible: !imp.visible });
-                    }}
-                  >
-                    {imp.visible ? "👁" : "○"}
-                  </span>
-
-                  {/* Editable name */}
-                  {editingName?.id === imp.id ? (
-                    <input
-                      autoFocus
-                      value={editingName.value}
-                      className="flex-1 min-w-0 bg-[#1a1a2e] border border-[#e94560] rounded px-1 text-[10px] outline-none"
-                      onClick={(e) => e.stopPropagation()}
-                      onChange={(e) =>
-                        setEditingName({ id: imp.id, value: e.target.value })
-                      }
-                      onBlur={() => {
-                        updateImport(imp.id, { name: editingName!.value });
-                        setEditingName(null);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          updateImport(imp.id, { name: editingName!.value });
-                          setEditingName(null);
-                        }
-                        if (e.key === "Escape") setEditingName(null);
-                      }}
-                    />
-                  ) : (
-                    <span
-                      className="flex-1 min-w-0 text-[10px] truncate text-gray-300"
-                      title="Double-click to rename"
-                      onDoubleClick={(e) => {
+                    {/* Expand toggle */}
+                    <button
+                      className="text-gray-500 hover:text-gray-200 text-[10px] w-4 shrink-0"
+                      onClick={(e) => {
                         e.stopPropagation();
-                        setEditingName({ id: imp.id, value: imp.name });
+                        toggleExpand(imp.id);
                       }}
                     >
-                      {imp.name}
+                      {isExpanded ? "▾" : "▸"}
+                    </button>
+
+                    {/* Visibility */}
+                    <span
+                      className="text-gray-500 hover:text-gray-200 text-[10px] cursor-pointer shrink-0"
+                      title="Toggle visibility"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        updateImport(imp.id, { visible: !imp.visible });
+                      }}
+                    >
+                      {imp.visible ? "👁" : "○"}
                     </span>
+
+                    {/* Editable name */}
+                    {editingName?.id === imp.id ? (
+                      <input
+                        autoFocus
+                        value={editingName.value}
+                        className="flex-1 min-w-0 bg-[#1a1a2e] border border-[#e94560] rounded px-1 text-[10px] outline-none"
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={(e) =>
+                          setEditingName({ id: imp.id, value: e.target.value })
+                        }
+                        onBlur={() => {
+                          updateImport(imp.id, { name: editingName!.value });
+                          setEditingName(null);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            updateImport(imp.id, { name: editingName!.value });
+                            setEditingName(null);
+                          }
+                          if (e.key === "Escape") setEditingName(null);
+                        }}
+                      />
+                    ) : (
+                      <span
+                        className="flex-1 min-w-0 text-[10px] truncate text-gray-300"
+                        title="Double-click to rename"
+                        onDoubleClick={(e) => {
+                          e.stopPropagation();
+                          setEditingName({ id: imp.id, value: imp.name });
+                        }}
+                      >
+                        {imp.name}
+                      </span>
+                    )}
+
+                    <span className="text-[9px] text-gray-600 shrink-0 ml-1">
+                      {imp.paths.length}p
+                    </span>
+                    <button
+                      className="ml-1 text-gray-600 hover:text-[#e94560] shrink-0"
+                      title="Delete import"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        removeImport(imp.id);
+                      }}
+                    >
+                      ✕
+                    </button>
+                  </div>
+
+                  {/* Expanded path list */}
+                  {isExpanded && (
+                    <div className="pl-6 pb-1 border-t border-[#0f3460]/20">
+                      {imp.paths.map((p) => (
+                        <div
+                          key={p.id}
+                          className="flex items-center gap-1 py-0.5 text-[9px]"
+                        >
+                          <span
+                            className="text-gray-500 hover:text-gray-200 cursor-pointer"
+                            onClick={() =>
+                              updatePath(imp.id, p.id, { visible: !p.visible })
+                            }
+                            title="Toggle path visibility"
+                          >
+                            {p.visible ? "👁" : "○"}
+                          </span>
+                          <span className="flex-1 min-w-0 text-gray-500 truncate">
+                            {p.layer ?? `path ${p.id.slice(0, 6)}`}
+                          </span>
+                          <button
+                            className="text-gray-600 hover:text-[#e94560]"
+                            title="Remove path"
+                            onClick={() => removePath(imp.id, p.id)}
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      ))}
+                    </div>
                   )}
 
-                  <span className="text-[9px] text-gray-600 shrink-0 ml-1">
-                    {imp.paths.length}p
-                  </span>
-                  <button
-                    className="ml-1 text-gray-600 hover:text-[#e94560] shrink-0"
-                    title="Delete import"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      removeImport(imp.id);
-                    }}
-                  >
-                    ✕
-                  </button>
-                </div>
-
-                {/* Expanded path list */}
-                {isExpanded && (
-                  <div className="pl-6 pb-1 border-t border-[#0f3460]/20">
-                    {imp.paths.map((p) => (
-                      <div
-                        key={p.id}
-                        className="flex items-center gap-1 py-0.5 text-[9px]"
-                      >
-                        <span
-                          className="text-gray-500 hover:text-gray-200 cursor-pointer"
-                          onClick={() =>
-                            updatePath(imp.id, p.id, { visible: !p.visible })
-                          }
-                          title="Toggle path visibility"
-                        >
-                          {p.visible ? "👁" : "○"}
-                        </span>
-                        <span className="flex-1 min-w-0 text-gray-500 truncate">
-                          {p.layer ?? `path ${p.id.slice(0, 6)}`}
-                        </span>
-                        <button
-                          className="text-gray-600 hover:text-[#e94560]"
-                          title="Remove path"
-                          onClick={() => removePath(imp.id, p.id)}
-                        >
-                          ✕
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-
-                {/* Properties form — shown when import is selected */}
-                {isSelected && (
-                  <div className="px-3 pb-3 pt-2 border-t border-[#0f3460]/30">
-                    {(() => {
-                      const objW = imp.svgWidth * (imp.scaleX ?? imp.scale);
-                      const objH = imp.svgHeight * (imp.scaleY ?? imp.scale);
-                      const cfg = activeConfig();
-                      const bedW = cfg?.bedWidth ?? 220;
-                      const bedH = cfg?.bedHeight ?? 200;
-                      return (
-                        <>
-                          {/* X / Y — two columns (unconstrained: G-code clips to bed) */}
-                          <div className="grid grid-cols-2 gap-2 mb-0">
-                            {numField(
-                              "X (mm)",
-                              imp.x,
-                              (v) => updateImport(imp.id, { x: v }),
-                              0.5,
-                            )}
-                            {numField(
-                              "Y (mm)",
-                              imp.y,
-                              (v) => updateImport(imp.id, { y: v }),
-                              0.5,
-                            )}
-                          </div>
-
-                          {/* Alignment row — between position and size */}
-                          {(() => {
-                            const btnCls =
-                              "p-1 text-gray-500 hover:text-gray-100 rounded hover:bg-[#0f3460]/40 transition-colors";
-                            const alignH = (x: number) =>
-                              updateImport(imp.id, {
-                                x: Math.round(x * 1000) / 1000,
-                              });
-                            const alignV = (y: number) =>
-                              updateImport(imp.id, {
-                                y: Math.round(y * 1000) / 1000,
-                              });
-                            return (
-                              <div className="flex items-center gap-0.5 mb-2">
-                                <button
-                                  className={btnCls}
-                                  title="Align left edge to bed left (X = 0)"
-                                  onClick={() => alignH(0)}
-                                >
-                                  <AlignHorizontalJustifyStart size={13} />
-                                </button>
-                                <button
-                                  className={btnCls}
-                                  title={`Centre horizontally (X = ${Math.round(((bedW - objW) / 2) * 10) / 10} mm)`}
-                                  onClick={() => alignH((bedW - objW) / 2)}
-                                >
-                                  <AlignHorizontalJustifyCenter size={13} />
-                                </button>
-                                <button
-                                  className={btnCls}
-                                  title={`Align right edge to bed right (X = ${Math.round((bedW - objW) * 10) / 10} mm)`}
-                                  onClick={() => alignH(bedW - objW)}
-                                >
-                                  <AlignHorizontalJustifyEnd size={13} />
-                                </button>
-                                <div className="w-px h-3 bg-[#0f3460] mx-0.5" />
-                                <button
-                                  className={btnCls}
-                                  title={`Align top edge to bed top (Y = ${Math.round((bedH - objH) * 10) / 10} mm)`}
-                                  onClick={() => alignV(bedH - objH)}
-                                >
-                                  <AlignVerticalJustifyStart size={13} />
-                                </button>
-                                <button
-                                  className={btnCls}
-                                  title={`Centre vertically (Y = ${Math.round(((bedH - objH) / 2) * 10) / 10} mm)`}
-                                  onClick={() => alignV((bedH - objH) / 2)}
-                                >
-                                  <AlignVerticalJustifyCenter size={13} />
-                                </button>
-                                <button
-                                  className={btnCls}
-                                  title="Align bottom edge to bed bottom (Y = 0)"
-                                  onClick={() => alignV(0)}
-                                >
-                                  <AlignVerticalJustifyEnd size={13} />
-                                </button>
-                              </div>
-                            );
-                          })()}
-
-                          {/* W / H — flex row with lock button between the two inputs */}
-                          <div className="flex items-end gap-1 mb-0">
-                            {/* W */}
-                            <div className="flex-1 min-w-0 mb-2">
-                              <label className="block text-[10px] text-gray-400 mb-0.5">
-                                W (mm)
-                              </label>
-                              <input
-                                type="number"
-                                value={Math.round(objW * 1000) / 1000}
-                                step={0.5}
-                                min={0.001}
-                                onChange={(e) => {
-                                  const v = Math.max(0.001, +e.target.value);
-                                  if (ratioLocked) {
-                                    updateImport(imp.id, {
-                                      scale: v / imp.svgWidth,
-                                      scaleX: undefined,
-                                      scaleY: undefined,
-                                    });
-                                  } else {
-                                    updateImport(imp.id, {
-                                      scaleX: v / imp.svgWidth,
-                                    });
-                                  }
-                                }}
-                                className="w-full bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-xs text-gray-200 focus:border-[#e94560] outline-none"
-                              />
-                            </div>
-                            {/* Ratio lock button */}
-                            <button
-                              className={`mb-2 p-1.5 rounded transition-colors ${
-                                ratioLocked
-                                  ? "text-[#e94560] hover:text-[#e94560] hover:bg-[#0f3460]/40"
-                                  : "text-gray-600 hover:text-gray-300 hover:bg-[#0f3460]/40"
-                              }`}
-                              title={
-                                ratioLocked
-                                  ? "Ratio locked — click to unlock"
-                                  : "Ratio unlocked — click to lock"
-                              }
-                              onClick={() => {
-                                if (ratioLocked) {
-                                  // Unlock: split into independent scaleX/scaleY (currently identical)
-                                  setRatioLocked(false);
-                                  updateImport(imp.id, {
-                                    scaleX: imp.scaleX ?? imp.scale,
-                                    scaleY: imp.scaleY ?? imp.scale,
-                                  });
-                                } else {
-                                  // Lock: snap back to uniform scale based on current W
-                                  setRatioLocked(true);
-                                  updateImport(imp.id, {
-                                    scale: imp.scaleX ?? imp.scale,
-                                    scaleX: undefined,
-                                    scaleY: undefined,
-                                  });
-                                }
-                              }}
-                            >
-                              {ratioLocked ? (
-                                // Lucide lock icon
-                                <svg
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="2"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                >
-                                  <rect
-                                    width="18"
-                                    height="11"
-                                    x="3"
-                                    y="11"
-                                    rx="2"
-                                    ry="2"
-                                  />
-                                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-                                </svg>
-                              ) : (
-                                // Lucide unlock icon
-                                <svg
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="2"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                >
-                                  <rect
-                                    width="18"
-                                    height="11"
-                                    x="3"
-                                    y="11"
-                                    rx="2"
-                                    ry="2"
-                                  />
-                                  <path d="M7 11V7a5 5 0 0 1 9.9-1" />
-                                </svg>
+                  {/* Properties form — shown when import is selected */}
+                  {isSelected && (
+                    <div className="px-3 pb-3 pt-2 border-t border-[#0f3460]/30">
+                      {(() => {
+                        const objW = imp.svgWidth * (imp.scaleX ?? imp.scale);
+                        const objH = imp.svgHeight * (imp.scaleY ?? imp.scale);
+                        const cfg = activeConfig();
+                        const bedW = cfg?.bedWidth ?? 220;
+                        const bedH = cfg?.bedHeight ?? 200;
+                        return (
+                          <>
+                            {/* X / Y — two columns (unconstrained: G-code clips to bed) */}
+                            <div className="grid grid-cols-2 gap-2 mb-0">
+                              {numField(
+                                "X (mm)",
+                                imp.x,
+                                (v) => updateImport(imp.id, { x: v }),
+                                0.5,
                               )}
-                            </button>
-                            {/* H */}
-                            <div className="flex-1 min-w-0 mb-2">
-                              <label className="block text-[10px] text-gray-400 mb-0.5">
-                                H (mm)
-                              </label>
-                              <input
-                                type="number"
-                                value={Math.round(objH * 1000) / 1000}
-                                step={0.5}
-                                min={0.001}
-                                onChange={(e) => {
-                                  const v = Math.max(0.001, +e.target.value);
+                              {numField(
+                                "Y (mm)",
+                                imp.y,
+                                (v) => updateImport(imp.id, { y: v }),
+                                0.5,
+                              )}
+                            </div>
+
+                            {/* Alignment row — between position and size */}
+                            {(() => {
+                              const btnCls =
+                                "p-1 text-gray-500 hover:text-gray-100 rounded hover:bg-[#0f3460]/40 transition-colors";
+                              const alignH = (x: number) =>
+                                updateImport(imp.id, {
+                                  x: Math.round(x * 1000) / 1000,
+                                });
+                              const alignV = (y: number) =>
+                                updateImport(imp.id, {
+                                  y: Math.round(y * 1000) / 1000,
+                                });
+                              return (
+                                <div className="flex items-center gap-0.5 mb-2">
+                                  <button
+                                    className={btnCls}
+                                    title="Align left edge to bed left (X = 0)"
+                                    onClick={() => alignH(0)}
+                                  >
+                                    <AlignHorizontalJustifyStart size={13} />
+                                  </button>
+                                  <button
+                                    className={btnCls}
+                                    title={`Centre horizontally (X = ${Math.round(((bedW - objW) / 2) * 10) / 10} mm)`}
+                                    onClick={() => alignH((bedW - objW) / 2)}
+                                  >
+                                    <AlignHorizontalJustifyCenter size={13} />
+                                  </button>
+                                  <button
+                                    className={btnCls}
+                                    title={`Align right edge to bed right (X = ${Math.round((bedW - objW) * 10) / 10} mm)`}
+                                    onClick={() => alignH(bedW - objW)}
+                                  >
+                                    <AlignHorizontalJustifyEnd size={13} />
+                                  </button>
+                                  <div className="w-px h-3 bg-[#0f3460] mx-0.5" />
+                                  <button
+                                    className={btnCls}
+                                    title={`Align top edge to bed top (Y = ${Math.round((bedH - objH) * 10) / 10} mm)`}
+                                    onClick={() => alignV(bedH - objH)}
+                                  >
+                                    <AlignVerticalJustifyStart size={13} />
+                                  </button>
+                                  <button
+                                    className={btnCls}
+                                    title={`Centre vertically (Y = ${Math.round(((bedH - objH) / 2) * 10) / 10} mm)`}
+                                    onClick={() => alignV((bedH - objH) / 2)}
+                                  >
+                                    <AlignVerticalJustifyCenter size={13} />
+                                  </button>
+                                  <button
+                                    className={btnCls}
+                                    title="Align bottom edge to bed bottom (Y = 0)"
+                                    onClick={() => alignV(0)}
+                                  >
+                                    <AlignVerticalJustifyEnd size={13} />
+                                  </button>
+                                </div>
+                              );
+                            })()}
+
+                            {/* W / H — flex row with lock button between the two inputs */}
+                            <div className="flex items-end gap-1 mb-0">
+                              {/* W */}
+                              <div className="flex-1 min-w-0 mb-2">
+                                <label className="block text-[10px] text-gray-400 mb-0.5">
+                                  W (mm)
+                                </label>
+                                <input
+                                  type="number"
+                                  value={Math.round(objW * 1000) / 1000}
+                                  step={0.5}
+                                  min={0.001}
+                                  onChange={(e) => {
+                                    const v = Math.max(0.001, +e.target.value);
+                                    if (ratioLocked) {
+                                      updateImport(imp.id, {
+                                        scale: v / imp.svgWidth,
+                                        scaleX: undefined,
+                                        scaleY: undefined,
+                                      });
+                                    } else {
+                                      updateImport(imp.id, {
+                                        scaleX: v / imp.svgWidth,
+                                      });
+                                    }
+                                  }}
+                                  className="w-full bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-xs text-gray-200 focus:border-[#e94560] outline-none"
+                                />
+                              </div>
+                              {/* Ratio lock button */}
+                              <button
+                                className={`mb-2 p-1.5 rounded transition-colors ${
+                                  ratioLocked
+                                    ? "text-[#e94560] hover:text-[#e94560] hover:bg-[#0f3460]/40"
+                                    : "text-gray-600 hover:text-gray-300 hover:bg-[#0f3460]/40"
+                                }`}
+                                title={
+                                  ratioLocked
+                                    ? "Ratio locked — click to unlock"
+                                    : "Ratio unlocked — click to lock"
+                                }
+                                onClick={() => {
                                   if (ratioLocked) {
+                                    // Unlock: split into independent scaleX/scaleY (currently identical)
+                                    setRatioLocked(false);
                                     updateImport(imp.id, {
-                                      scale: v / imp.svgHeight,
-                                      scaleX: undefined,
-                                      scaleY: undefined,
+                                      scaleX: imp.scaleX ?? imp.scale,
+                                      scaleY: imp.scaleY ?? imp.scale,
                                     });
                                   } else {
+                                    // Lock: snap back to uniform scale based on current W
+                                    setRatioLocked(true);
                                     updateImport(imp.id, {
-                                      scaleY: v / imp.svgHeight,
+                                      scale: imp.scaleX ?? imp.scale,
+                                      scaleX: undefined,
+                                      scaleY: undefined,
                                     });
                                   }
                                 }}
-                                className="w-full bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-xs text-gray-200 focus:border-[#e94560] outline-none"
-                              />
-                            </div>
-                          </div>
-                          {/* Scale — full width */}
-                          {numField(
-                            "Scale",
-                            imp.scale,
-                            (v) =>
-                              updateImport(imp.id, {
-                                scale: Math.max(0.001, v),
-                              }),
-                            0.05,
-                            0.001,
-                          )}
-                          {/* Scale shortcut row: fit to bed | 1:1 reset */}
-                          {(() => {
-                            const fitScale = Math.min(
-                              bedW / (imp.svgWidth || 1),
-                              bedH / (imp.svgHeight || 1),
-                            );
-                            return (
-                              <div className="flex items-center gap-0.5 mb-2 -mt-1">
-                                {/* Fit to bed */}
-                                <button
-                                  className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
-                                  title={`Fit to bed (scale ${Math.round(fitScale * 1000) / 1000})`}
-                                  onClick={() => {
-                                    setRatioLocked(true);
-                                    updateImport(imp.id, {
-                                      scale: fitScale,
-                                      scaleX: undefined,
-                                      scaleY: undefined,
-                                      x: 0,
-                                      y: 0,
-                                    });
-                                  }}
-                                >
+                              >
+                                {ratioLocked ? (
+                                  // Lucide lock icon
                                   <svg
-                                    width="14"
-                                    height="14"
+                                    width="12"
+                                    height="12"
                                     viewBox="0 0 24 24"
                                     fill="none"
                                     stroke="currentColor"
@@ -468,28 +494,21 @@ export function PropertiesPanel() {
                                     strokeLinecap="round"
                                     strokeLinejoin="round"
                                   >
-                                    <path d="M8 3H5a2 2 0 0 0-2 2v3" />
-                                    <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
-                                    <path d="M3 16v3a2 2 0 0 0 2 2h3" />
-                                    <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+                                    <rect
+                                      width="18"
+                                      height="11"
+                                      x="3"
+                                      y="11"
+                                      rx="2"
+                                      ry="2"
+                                    />
+                                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                                   </svg>
-                                </button>
-                                {/* Reset to 1:1 */}
-                                <button
-                                  className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
-                                  title="Reset scale to 1:1 (1 SVG unit = 1 mm)"
-                                  onClick={() => {
-                                    setRatioLocked(true);
-                                    updateImport(imp.id, {
-                                      scale: 1,
-                                      scaleX: undefined,
-                                      scaleY: undefined,
-                                    });
-                                  }}
-                                >
+                                ) : (
+                                  // Lucide unlock icon
                                   <svg
-                                    width="14"
-                                    height="14"
+                                    width="12"
+                                    height="12"
                                     viewBox="0 0 24 24"
                                     fill="none"
                                     stroke="currentColor"
@@ -497,199 +516,316 @@ export function PropertiesPanel() {
                                     strokeLinecap="round"
                                     strokeLinejoin="round"
                                   >
-                                    <path d="M8 3v3a2 2 0 0 1-2 2H3" />
-                                    <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
-                                    <path d="M3 16h3a2 2 0 0 1 2 2v3" />
-                                    <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+                                    <rect
+                                      width="18"
+                                      height="11"
+                                      x="3"
+                                      y="11"
+                                      rx="2"
+                                      ry="2"
+                                    />
+                                    <path d="M7 11V7a5 5 0 0 1 9.9-1" />
                                   </svg>
-                                </button>
+                                )}
+                              </button>
+                              {/* H */}
+                              <div className="flex-1 min-w-0 mb-2">
+                                <label className="block text-[10px] text-gray-400 mb-0.5">
+                                  H (mm)
+                                </label>
+                                <input
+                                  type="number"
+                                  value={Math.round(objH * 1000) / 1000}
+                                  step={0.5}
+                                  min={0.001}
+                                  onChange={(e) => {
+                                    const v = Math.max(0.001, +e.target.value);
+                                    if (ratioLocked) {
+                                      updateImport(imp.id, {
+                                        scale: v / imp.svgHeight,
+                                        scaleX: undefined,
+                                        scaleY: undefined,
+                                      });
+                                    } else {
+                                      updateImport(imp.id, {
+                                        scaleY: v / imp.svgHeight,
+                                      });
+                                    }
+                                  }}
+                                  className="w-full bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-xs text-gray-200 focus:border-[#e94560] outline-none"
+                                />
                               </div>
-                            );
-                          })()}
-                          {/* Rotation — full width */}
-                          {numField(
-                            "Rotation (°)",
-                            imp.rotation,
-                            (v) => updateImport(imp.id, { rotation: v }),
-                            1,
-                          )}
-                          {/* Rotation shortcut row: CCW | CW | step flyout | magnet cycle */}
-                          <div className="flex items-center gap-0.5 mb-2">
-                            {/* CCW — borderless icon button */}
-                            <button
-                              className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
-                              title={`Rotate ${rotStep}° counter-clockwise`}
-                              onClick={() =>
+                            </div>
+                            {/* Scale — full width */}
+                            {numField(
+                              "Scale",
+                              imp.scale,
+                              (v) =>
                                 updateImport(imp.id, {
-                                  rotation: imp.rotation - rotStep,
-                                })
-                              }
-                            >
-                              <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              >
-                                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                                <path d="M3 3v5h5" />
-                              </svg>
-                            </button>
-
-                            {/* CW — borderless icon button */}
-                            <button
-                              className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
-                              title={`Rotate ${rotStep}° clockwise`}
-                              onClick={() =>
-                                updateImport(imp.id, {
-                                  rotation: imp.rotation + rotStep,
-                                })
-                              }
-                            >
-                              <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              >
-                                <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
-                                <path d="M21 3v5h-5" />
-                              </svg>
-                            </button>
-
-                            {/* Step flyout trigger */}
-                            <div className="relative">
+                                  scale: Math.max(0.001, v),
+                                }),
+                              0.05,
+                              0.001,
+                            )}
+                            {/* Scale shortcut row: fit to bed | 1:1 reset */}
+                            {(() => {
+                              const fitScale = Math.min(
+                                bedW / (imp.svgWidth || 1),
+                                bedH / (imp.svgHeight || 1),
+                              );
+                              return (
+                                <div className="flex items-center gap-0.5 mb-2 -mt-1">
+                                  {/* Fit to bed */}
+                                  <button
+                                    className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
+                                    title={`Fit to bed (scale ${Math.round(fitScale * 1000) / 1000})`}
+                                    onClick={() => {
+                                      setRatioLocked(true);
+                                      updateImport(imp.id, {
+                                        scale: fitScale,
+                                        scaleX: undefined,
+                                        scaleY: undefined,
+                                        x: 0,
+                                        y: 0,
+                                      });
+                                    }}
+                                  >
+                                    <svg
+                                      width="14"
+                                      height="14"
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      strokeWidth="2"
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                    >
+                                      <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+                                      <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+                                      <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+                                      <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+                                    </svg>
+                                  </button>
+                                  {/* Reset to 1:1 */}
+                                  <button
+                                    className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
+                                    title="Reset scale to 1:1 (1 SVG unit = 1 mm)"
+                                    onClick={() => {
+                                      setRatioLocked(true);
+                                      updateImport(imp.id, {
+                                        scale: 1,
+                                        scaleX: undefined,
+                                        scaleY: undefined,
+                                      });
+                                    }}
+                                  >
+                                    <svg
+                                      width="14"
+                                      height="14"
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      strokeWidth="2"
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                    >
+                                      <path d="M8 3v3a2 2 0 0 1-2 2H3" />
+                                      <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
+                                      <path d="M3 16h3a2 2 0 0 1 2 2v3" />
+                                      <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+                                    </svg>
+                                  </button>
+                                </div>
+                              );
+                            })()}
+                            {/* Rotation — full width */}
+                            {numField(
+                              "Rotation (°)",
+                              imp.rotation,
+                              (v) => updateImport(imp.id, { rotation: v }),
+                              1,
+                            )}
+                            {/* Rotation shortcut row: CCW | CW | step flyout | magnet cycle */}
+                            <div className="flex items-center gap-0.5 mb-2">
+                              {/* CCW — borderless icon button */}
                               <button
-                                className="flex items-center gap-0.5 px-1.5 py-1 text-[10px] text-gray-400 hover:text-gray-100 rounded hover:bg-[#0f3460]/40 transition-colors"
-                                title="Change rotation step"
-                                onClick={() => setStepFlyoutOpen((o) => !o)}
+                                className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
+                                title={`Rotate ${rotStep}° counter-clockwise`}
+                                onClick={() =>
+                                  updateImport(imp.id, {
+                                    rotation: imp.rotation - rotStep,
+                                  })
+                                }
                               >
-                                {rotStep}°
                                 <svg
-                                  width="10"
-                                  height="10"
+                                  width="14"
+                                  height="14"
                                   viewBox="0 0 24 24"
                                   fill="none"
                                   stroke="currentColor"
-                                  strokeWidth="2.5"
+                                  strokeWidth="2"
                                   strokeLinecap="round"
                                   strokeLinejoin="round"
                                 >
-                                  <path d="m6 9 6 6 6-6" />
+                                  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                                  <path d="M3 3v5h5" />
                                 </svg>
                               </button>
-                              {stepFlyoutOpen && (
-                                <>
-                                  {/* Invisible backdrop to close on outside click */}
-                                  <div
-                                    className="fixed inset-0 z-10"
-                                    onClick={() => setStepFlyoutOpen(false)}
-                                  />
-                                  <div className="absolute bottom-full left-0 mb-1 bg-[#16213e] border border-[#0f3460] rounded shadow-xl z-20 py-0.5 min-w-[4rem]">
-                                    {ROT_STEPS.map((s) => (
-                                      <button
-                                        key={s}
-                                        className={`block w-full text-left px-3 py-1 text-[10px] transition-colors ${
-                                          rotStep === s
-                                            ? "text-gray-100 bg-[#0f3460]"
-                                            : "text-gray-400 hover:text-gray-100 hover:bg-[#0f3460]/50"
-                                        }`}
-                                        onClick={() => {
-                                          setRotStep(s);
-                                          setStepFlyoutOpen(false);
-                                        }}
-                                      >
-                                        {s}°
-                                      </button>
-                                    ))}
-                                  </div>
-                                </>
-                              )}
+
+                              {/* CW — borderless icon button */}
+                              <button
+                                className="p-1.5 text-gray-400 hover:text-gray-100 transition-colors rounded hover:bg-[#0f3460]/40"
+                                title={`Rotate ${rotStep}° clockwise`}
+                                onClick={() =>
+                                  updateImport(imp.id, {
+                                    rotation: imp.rotation + rotStep,
+                                  })
+                                }
+                              >
+                                <svg
+                                  width="14"
+                                  height="14"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                >
+                                  <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+                                  <path d="M21 3v5h-5" />
+                                </svg>
+                              </button>
+
+                              {/* Step flyout trigger */}
+                              <div className="relative">
+                                <button
+                                  className="flex items-center gap-0.5 px-1.5 py-1 text-[10px] text-gray-400 hover:text-gray-100 rounded hover:bg-[#0f3460]/40 transition-colors"
+                                  title="Change rotation step"
+                                  onClick={() => setStepFlyoutOpen((o) => !o)}
+                                >
+                                  {rotStep}°
+                                  <svg
+                                    width="10"
+                                    height="10"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2.5"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                  >
+                                    <path d="m6 9 6 6 6-6" />
+                                  </svg>
+                                </button>
+                                {stepFlyoutOpen && (
+                                  <>
+                                    {/* Invisible backdrop to close on outside click */}
+                                    <div
+                                      className="fixed inset-0 z-10"
+                                      onClick={() => setStepFlyoutOpen(false)}
+                                    />
+                                    <div className="absolute bottom-full left-0 mb-1 bg-[#16213e] border border-[#0f3460] rounded shadow-xl z-20 py-0.5 min-w-[4rem]">
+                                      {ROT_STEPS.map((s) => (
+                                        <button
+                                          key={s}
+                                          className={`block w-full text-left px-3 py-1 text-[10px] transition-colors ${
+                                            rotStep === s
+                                              ? "text-gray-100 bg-[#0f3460]"
+                                              : "text-gray-400 hover:text-gray-100 hover:bg-[#0f3460]/50"
+                                          }`}
+                                          onClick={() => {
+                                            setRotStep(s);
+                                            setStepFlyoutOpen(false);
+                                          }}
+                                        >
+                                          {s}°
+                                        </button>
+                                      ))}
+                                    </div>
+                                  </>
+                                )}
+                              </div>
+
+                              <span className="flex-1" />
+
+                              {/* Centre-of-rotation marker toggle */}
+                              <button
+                                className={`p-1.5 transition-colors rounded hover:bg-[#0f3460]/40 ${
+                                  showCentreMarker
+                                    ? "text-[#e94560] hover:text-[#e94560]"
+                                    : "text-gray-600 hover:text-gray-300"
+                                }`}
+                                title={
+                                  showCentreMarker
+                                    ? "Hide centre marker"
+                                    : "Show centre marker"
+                                }
+                                onClick={toggleCentreMarker}
+                              >
+                                {/* Lucide crosshair icon */}
+                                <svg
+                                  width="14"
+                                  height="14"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                >
+                                  <circle cx="12" cy="12" r="10" />
+                                  <line x1="22" y1="12" x2="18" y2="12" />
+                                  <line x1="6" y1="12" x2="2" y2="12" />
+                                  <line x1="12" y1="6" x2="12" y2="2" />
+                                  <line x1="12" y1="22" x2="12" y2="18" />
+                                </svg>
+                              </button>
+
+                              {/* Magnet — cycles through angle presets */}
+                              <button
+                                className="p-1.5 text-gray-400 hover:text-[#e94560] transition-colors rounded hover:bg-[#0f3460]/40"
+                                title={`Snap to next preset (${ROT_PRESETS.join("° · ")}°)`}
+                                onClick={() => {
+                                  const norm =
+                                    ((imp.rotation % 360) + 360) % 360;
+                                  const idx = ROT_PRESETS.findIndex(
+                                    (p) => Math.abs(p - norm) < 1,
+                                  );
+                                  const next =
+                                    ROT_PRESETS[
+                                      idx < 0
+                                        ? 0
+                                        : (idx + 1) % ROT_PRESETS.length
+                                    ];
+                                  updateImport(imp.id, { rotation: next });
+                                }}
+                              >
+                                <svg
+                                  width="14"
+                                  height="14"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                >
+                                  <path d="m6 15-4-4 6.75-6.77a7.79 7.79 0 0 1 11 11L13 22l-4-4 6.39-6.36a2.14 2.14 0 0 0-3-3Z" />
+                                  <path d="m5 8 4 4" />
+                                  <path d="m12 15 4 4" />
+                                </svg>
+                              </button>
                             </div>
-
-                            <span className="flex-1" />
-
-                            {/* Centre-of-rotation marker toggle */}
-                            <button
-                              className={`p-1.5 transition-colors rounded hover:bg-[#0f3460]/40 ${
-                                showCentreMarker
-                                  ? "text-[#e94560] hover:text-[#e94560]"
-                                  : "text-gray-600 hover:text-gray-300"
-                              }`}
-                              title={
-                                showCentreMarker
-                                  ? "Hide centre marker"
-                                  : "Show centre marker"
-                              }
-                              onClick={toggleCentreMarker}
-                            >
-                              {/* Lucide crosshair icon */}
-                              <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              >
-                                <circle cx="12" cy="12" r="10" />
-                                <line x1="22" y1="12" x2="18" y2="12" />
-                                <line x1="6" y1="12" x2="2" y2="12" />
-                                <line x1="12" y1="6" x2="12" y2="2" />
-                                <line x1="12" y1="22" x2="12" y2="18" />
-                              </svg>
-                            </button>
-
-                            {/* Magnet — cycles through angle presets */}
-                            <button
-                              className="p-1.5 text-gray-400 hover:text-[#e94560] transition-colors rounded hover:bg-[#0f3460]/40"
-                              title={`Snap to next preset (${ROT_PRESETS.join("° · ")}°)`}
-                              onClick={() => {
-                                const norm = ((imp.rotation % 360) + 360) % 360;
-                                const idx = ROT_PRESETS.findIndex(
-                                  (p) => Math.abs(p - norm) < 1,
-                                );
-                                const next =
-                                  ROT_PRESETS[
-                                    idx < 0 ? 0 : (idx + 1) % ROT_PRESETS.length
-                                  ];
-                                updateImport(imp.id, { rotation: next });
-                              }}
-                            >
-                              <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              >
-                                <path d="m6 15-4-4 6.75-6.77a7.79 7.79 0 0 1 11 11L13 22l-4-4 6.39-6.36a2.14 2.14 0 0 0-3-3Z" />
-                                <path d="m5 8 4 4" />
-                                <path d="m12 15 4 4" />
-                              </svg>
-                            </button>
-                          </div>
-                        </>
-                      );
-                    })()}
-                  </div>
-                )}
-              </div>
-            );
-          })
+                          </>
+                        );
+                      })()}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </>
         )}
       </div>
     </div>

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -537,7 +537,7 @@ export function Toolbar() {
       const text = await window.terraForge.fs.readFile(filePath);
       const toolpath = parseGcode(text);
       setGcodeToolpath(toolpath);
-      setGcodeSource({ path: filePath, name });
+      setGcodeSource({ path: filePath, name, source: "local" });
       // Selecting this as the queued job (local source — will upload on Start)
       setSelectedJobFile({ path: filePath, source: "local", name });
       upsertTask({

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -197,6 +197,7 @@ export function Toolbar() {
   const addImport = useCanvasStore((s) => s.addImport);
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
   const setGcodeSource = useCanvasStore((s) => s.setGcodeSource);
+  const selectToolpath = useCanvasStore((s) => s.selectToolpath);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const registerCancelCallback = useTaskStore((s) => s.registerCancelCallback);
   const unregisterCancelCallback = useTaskStore(
@@ -538,6 +539,9 @@ export function Toolbar() {
       const toolpath = parseGcode(text);
       setGcodeToolpath(toolpath);
       setGcodeSource({ path: filePath, name, source: "local" });
+      // Auto-select the toolpath so the canvas, Properties panel, and
+      // Job panel are all in sync from the moment of import.
+      selectToolpath(true);
       // Selecting this as the queued job (local source — will upload on Start)
       setSelectedJobFile({ path: filePath, source: "local", name });
       upsertTask({

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -8,10 +8,15 @@ interface CanvasState {
   selectedImportId: string | null;
   selectedPathId: string | null;
   gcodeToolpath: GcodeToolpath | null;
-  /** Persists the local file info for a canvas-imported G-code file so it can
-   *  be restored in selectedJobFile whenever the user re-selects the toolpath.
+  /** Persists the file info for the currently loaded G-code toolpath so it
+   *  can be restored into selectedJobFile when the user re-selects the toolpath
+   *  on the canvas.  source mirrors SelectedJobFile.source.
    *  Automatically cleared when gcodeToolpath is set to null. */
-  gcodeSource: { path: string; name: string } | null;
+  gcodeSource: {
+    path: string;
+    name: string;
+    source: "local" | "fs" | "sd";
+  } | null;
   showCentreMarker: boolean;
   /** Live plot-progress overlay paths (machine-coord SVG path d strings).
    *  Built incrementally by usePlotProgress as the machine reports its position.
@@ -36,7 +41,9 @@ interface CanvasState {
   clearImports: () => void;
   selectedImport: () => SvgImport | undefined;
   setGcodeToolpath: (tp: GcodeToolpath | null) => void;
-  setGcodeSource: (src: { path: string; name: string } | null) => void;
+  setGcodeSource: (
+    src: { path: string; name: string; source: "local" | "fs" | "sd" } | null,
+  ) => void;
   toggleCentreMarker: () => void;
   toVectorObjects: () => VectorObject[];
   /** Update the live plot-progress overlay paths. */

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -28,7 +28,11 @@ interface CanvasState {
     patch: Partial<SvgPath>,
   ) => void;
   removePath: (importId: string, pathId: string) => void;
+  /** Whether the G-code toolpath is currently selected on the canvas. */
+  toolpathSelected: boolean;
   selectImport: (id: string | null) => void;
+  /** Select or deselect the G-code toolpath.  Deselects any SVG import. */
+  selectToolpath: (selected: boolean) => void;
   clearImports: () => void;
   selectedImport: () => SvgImport | undefined;
   setGcodeToolpath: (tp: GcodeToolpath | null) => void;
@@ -48,6 +52,7 @@ export const useCanvasStore = create<CanvasState>()(
     selectedPathId: null,
     gcodeToolpath: null,
     gcodeSource: null,
+    toolpathSelected: false,
     showCentreMarker: true,
     plotProgressCuts: "",
     plotProgressRapids: "",
@@ -92,6 +97,18 @@ export const useCanvasStore = create<CanvasState>()(
       set((state) => {
         state.selectedImportId = id;
         state.selectedPathId = null;
+        // Selecting an SVG import clears toolpath selection (and vice-versa).
+        if (id !== null) state.toolpathSelected = false;
+      }),
+
+    selectToolpath: (selected) =>
+      set((state) => {
+        state.toolpathSelected = selected;
+        // Selecting the toolpath clears any SVG import selection.
+        if (selected) {
+          state.selectedImportId = null;
+          state.selectedPathId = null;
+        }
       }),
 
     clearImports: () =>
@@ -112,6 +129,7 @@ export const useCanvasStore = create<CanvasState>()(
         // Auto-clear the stored local-file source when the toolpath is removed.
         if (tp === null) {
           state.gcodeSource = null;
+          state.toolpathSelected = false;
           state.plotProgressCuts = "";
           state.plotProgressRapids = "";
         }

--- a/src/renderer/src/utils/gcodeParser.ts
+++ b/src/renderer/src/utils/gcodeParser.ts
@@ -38,6 +38,14 @@ export interface GcodeToolpath {
    *  Optional so that hand-crafted test objects without this field still
    *  satisfy the type (additive addition). */
   segments?: GcodeSegment[];
+  /** Approximate file size in bytes (gcode string byte length). */
+  fileSizeBytes: number;
+  /** Total length of all feed (G1/G2/G3) move segments in mm. */
+  totalCutDistance: number;
+  /** Total length of all rapid (G0) move segments in mm. */
+  totalRapidDistance: number;
+  /** Last F-word feedrate seen in the file, in mm/min. 0 if none specified. */
+  feedrate: number;
 }
 
 export function parseGcode(gcode: string): GcodeToolpath {
@@ -58,6 +66,9 @@ export function parseGcode(gcode: string): GcodeToolpath {
   let boundsInit = false;
   let lineCount = 0;
   let lastWasCut = false;
+  let feedrate = 0;
+  let totalCutDistance = 0;
+  let totalRapidDistance = 0;
 
   const updateBounds = (nx: number, ny: number) => {
     if (!boundsInit) {
@@ -111,17 +122,22 @@ export function parseGcode(gcode: string): GcodeToolpath {
     const getW = (l: string) => words.find(([wl]) => wl === l)?.[1];
     const xw = getW("X");
     const yw = getW("Y");
+    const fw = getW("F");
 
     // Skip lines with no X/Y motion
     if (xw === undefined && yw === undefined) continue;
 
     const scale = inMillimeters ? 1 : 25.4;
+    // Update feedrate if an F word is present (convert in/min → mm/min when G20)
+    if (fw !== undefined) feedrate = fw * scale;
     const nx =
       xw !== undefined ? (isAbsolute ? xw * scale : x + xw * scale) : x;
     const ny =
       yw !== undefined ? (isAbsolute ? yw * scale : y + yw * scale) : y;
 
     updateBounds(nx, ny);
+
+    const segDist = Math.sqrt((nx - x) ** 2 + (ny - y) ** 2);
 
     // Record the segment for live plot-progress tracking
     segments.push({
@@ -133,12 +149,14 @@ export function parseGcode(gcode: string): GcodeToolpath {
 
     if (motionMode === 0) {
       // Rapid — always start a new sub-path segment
+      totalRapidDistance += segDist;
       rapidParts.push(
         `M ${x.toFixed(3)} ${y.toFixed(3)} L ${nx.toFixed(3)} ${ny.toFixed(3)}`,
       );
       lastWasCut = false;
     } else {
       // Feed (G1) or arc (G2/G3 approximated as straight line)
+      totalCutDistance += segDist;
       if (!lastWasCut) {
         cutParts.push(`M ${x.toFixed(3)} ${y.toFixed(3)}`);
       }
@@ -156,5 +174,9 @@ export function parseGcode(gcode: string): GcodeToolpath {
     bounds: { minX, maxX, minY, maxY },
     lineCount,
     segments,
+    fileSizeBytes: gcode.length,
+    totalCutDistance,
+    totalRapidDistance,
+    feedrate,
   };
 }

--- a/tests/component/FileBrowserPanel.test.tsx
+++ b/tests/component/FileBrowserPanel.test.tsx
@@ -321,6 +321,39 @@ describe("FileBrowserPanel", () => {
     );
     // No dialog should have appeared
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    // Preview should also select the file as the queued job
+    const jobFile = useMachineStore.getState().selectedJobFile;
+    expect(jobFile).not.toBeNull();
+    expect(jobFile!.name).toBe("first.gcode");
+    expect(jobFile!.path).toBe("/first.gcode");
+    expect(jobFile!.source).toBe("sd");
+  });
+
+  it("sets selectedJobFile when a remote file is previewed (enables Start Job)", async () => {
+    (
+      window.terraForge.fluidnc.listSDFiles as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([
+      { name: "job.gcode", path: "/job.gcode", size: 512, isDirectory: false },
+    ]);
+    (
+      window.terraForge.fluidnc.listFiles as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([]);
+    (
+      window.terraForge.fluidnc.fetchFileText as ReturnType<typeof vi.fn>
+    ).mockResolvedValue("G1 X50 Y50 F2000\n");
+    useMachineStore.setState({ connected: true });
+    render(<FileBrowserPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("job.gcode")).toBeInTheDocument(),
+    );
+    expect(useMachineStore.getState().selectedJobFile).toBeNull();
+    const previewBtns = screen.getAllByTitle("Preview toolpath");
+    await userEvent.click(previewBtns[0]);
+    await waitFor(() => {
+      const jf = useMachineStore.getState().selectedJobFile;
+      expect(jf).not.toBeNull();
+      expect(jf!.name).toBe("job.gcode");
+    });
   });
 
   // ── Error display ─────────────────────────────────────────────────────

--- a/tests/component/JobControls.test.tsx
+++ b/tests/component/JobControls.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMachineStore } from "@renderer/store/machineStore";
 import { useTaskStore } from "@renderer/store/taskStore";
+import { useCanvasStore } from "@renderer/store/canvasStore";
 import { JobControls } from "@renderer/components/JobControls";
 
 beforeEach(() => {
@@ -13,6 +14,11 @@ beforeEach(() => {
     connected: false,
     wsLive: false,
     selectedJobFile: null,
+  });
+  useCanvasStore.setState({
+    gcodeToolpath: null,
+    gcodeSource: null,
+    toolpathSelected: false,
   });
   useTaskStore.setState({ tasks: {} });
   vi.clearAllMocks();
@@ -274,5 +280,72 @@ describe("JobControls", () => {
     });
     render(<JobControls />);
     expect(screen.getByText("▶ Start job")).toBeDisabled();
+  });
+
+  // ── Canvas toolpath selection ───────────────────────────────────────────
+
+  it("enables Start Job when toolpath is selected on canvas with a local gcodeSource", () => {
+    useMachineStore.setState({ connected: true, selectedJobFile: null });
+    useCanvasStore.setState({
+      toolpathSelected: true,
+      gcodeSource: {
+        path: "C:\\files\\art.gcode",
+        name: "art.gcode",
+        source: "local" as const,
+      },
+    });
+    render(<JobControls />);
+    expect(screen.getByText("▶ Start job")).not.toBeDisabled();
+  });
+
+  it("shows canvas toolpath file name in indicator when toolpath selected with no explicit job file", () => {
+    useMachineStore.setState({ connected: true, selectedJobFile: null });
+    useCanvasStore.setState({
+      toolpathSelected: true,
+      gcodeSource: {
+        path: "C:\\files\\art.gcode",
+        name: "art.gcode",
+        source: "local" as const,
+      },
+    });
+    render(<JobControls />);
+    expect(screen.getByText(/art\.gcode/)).toBeInTheDocument();
+    expect(screen.getByText(/will upload/)).toBeInTheDocument();
+  });
+
+  it("Start Job remains disabled when toolpath not selected and no job file set", () => {
+    useMachineStore.setState({ connected: true, selectedJobFile: null });
+    useCanvasStore.setState({
+      toolpathSelected: false,
+      gcodeSource: {
+        path: "C:\\files\\art.gcode",
+        name: "art.gcode",
+        source: "local" as const,
+      },
+    });
+    render(<JobControls />);
+    expect(screen.getByText("▶ Start job")).toBeDisabled();
+  });
+
+  it("uploads then runs canvas-selected local toolpath when Start clicked", async () => {
+    useMachineStore.setState({ connected: true, selectedJobFile: null });
+    useCanvasStore.setState({
+      toolpathSelected: true,
+      gcodeSource: {
+        path: "C:\\files\\art.gcode",
+        name: "art.gcode",
+        source: "local" as const,
+      },
+    });
+    (
+      window.terraForge.fluidnc.uploadFile as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(undefined);
+    render(<JobControls />);
+    await userEvent.click(screen.getByText("▶ Start job"));
+    expect(window.terraForge.fluidnc.uploadFile).toHaveBeenCalled();
+    expect(window.terraForge.fluidnc.runFile).toHaveBeenCalledWith(
+      "/art.gcode",
+      "sd",
+    );
   });
 });

--- a/tests/component/PropertiesPanel.test.tsx
+++ b/tests/component/PropertiesPanel.test.tsx
@@ -280,7 +280,11 @@ describe("PropertiesPanel", () => {
     const tp = createGcodeToolpath({ fileSizeBytes: 2048, lineCount: 150 });
     useCanvasStore.setState({
       gcodeToolpath: tp,
-      gcodeSource: { path: "/tmp/test.gcode", name: "test.gcode" },
+      gcodeSource: {
+        path: "/tmp/test.gcode",
+        name: "test.gcode",
+        source: "local" as const,
+      },
     });
     render(<PropertiesPanel />);
     expect(screen.getByText("test.gcode")).toBeInTheDocument();

--- a/tests/component/PropertiesPanel.test.tsx
+++ b/tests/component/PropertiesPanel.test.tsx
@@ -8,6 +8,7 @@ import {
   createSvgImport,
   createSvgPath,
   createMachineConfig,
+  createGcodeToolpath,
 } from "../helpers/factories";
 
 beforeEach(() => {
@@ -16,6 +17,7 @@ beforeEach(() => {
     selectedImportId: null,
     selectedPathId: null,
     gcodeToolpath: null,
+    toolpathSelected: false,
   });
   useMachineStore.setState({
     configs: [],
@@ -270,5 +272,134 @@ describe("PropertiesPanel", () => {
       screen.getByTitle("Align bottom edge to bed bottom (Y = 0)"),
     );
     expect(useCanvasStore.getState().imports[0].y).toBe(0);
+  });
+
+  // ── G-code toolpath panel ──────────────────────────────────────────────────
+
+  it("shows gcode entry when a toolpath is loaded", () => {
+    const tp = createGcodeToolpath({ fileSizeBytes: 2048, lineCount: 150 });
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: { path: "/tmp/test.gcode", name: "test.gcode" },
+    });
+    render(<PropertiesPanel />);
+    expect(screen.getByText("test.gcode")).toBeInTheDocument();
+  });
+
+  it("shows gcode properties expanded by default", () => {
+    const tp = createGcodeToolpath({ fileSizeBytes: 1024, lineCount: 80 });
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: false,
+    });
+    render(<PropertiesPanel />);
+    // Collapsed when not selected — stats hidden
+    expect(screen.queryByText("Lines")).not.toBeInTheDocument();
+    useCanvasStore.setState({ toolpathSelected: true });
+  });
+
+  it("shows file size formatted in KB", () => {
+    const tp = createGcodeToolpath({ fileSizeBytes: 2048 });
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: true,
+    });
+    render(<PropertiesPanel />);
+    expect(screen.getByText("2.0 KB")).toBeInTheDocument();
+  });
+
+  it("shows estimated duration based on feedrate and distances", () => {
+    // 3000 mm at 3000 mm/min = 1 min cut; rapid negligible
+    const tp = createGcodeToolpath({
+      totalCutDistance: 3000,
+      totalRapidDistance: 0,
+      feedrate: 3000,
+    });
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: true,
+    });
+    render(<PropertiesPanel />);
+    expect(screen.getByText("Est. duration")).toBeInTheDocument();
+    expect(screen.getByText("1m 0s")).toBeInTheDocument();
+  });
+
+  it("shows feedrate row when feedrate is non-zero", () => {
+    const tp = createGcodeToolpath({ feedrate: 2500 });
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: true,
+    });
+    render(<PropertiesPanel />);
+    expect(screen.getByText("Feedrate")).toBeInTheDocument();
+    expect(screen.getByText("2500 mm/min")).toBeInTheDocument();
+  });
+
+  it("hides feedrate row when feedrate is 0", () => {
+    const tp = createGcodeToolpath({ feedrate: 0 });
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: true,
+    });
+    render(<PropertiesPanel />);
+    expect(screen.queryByText("Feedrate")).not.toBeInTheDocument();
+  });
+
+  it("expands gcode properties when header clicked (sets toolpathSelected)", async () => {
+    const tp = createGcodeToolpath();
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: false,
+    });
+    render(<PropertiesPanel />);
+    // Stats are initially hidden (not selected)
+    expect(screen.queryByText("Lines")).not.toBeInTheDocument();
+    // Click the collapse toggle button (▸ = collapsed)
+    await userEvent.click(screen.getByText("▸"));
+    expect(useCanvasStore.getState().toolpathSelected).toBe(true);
+    expect(screen.getByText("Lines")).toBeInTheDocument();
+  });
+
+  it("collapses gcode properties when header clicked while selected", async () => {
+    const tp = createGcodeToolpath();
+    useCanvasStore.setState({
+      gcodeToolpath: tp,
+      gcodeSource: null,
+      toolpathSelected: true,
+    });
+    render(<PropertiesPanel />);
+    // Stats are visible while selected
+    expect(screen.getByText("Lines")).toBeInTheDocument();
+    // Click the expand toggle button (▾ = expanded/selected)
+    await userEvent.click(screen.getByText("▾"));
+    expect(useCanvasStore.getState().toolpathSelected).toBe(false);
+    expect(screen.queryByText("Lines")).not.toBeInTheDocument();
+  });
+
+  it("clears the toolpath when the ✕ button is clicked", async () => {
+    const tp = createGcodeToolpath();
+    useCanvasStore.setState({ gcodeToolpath: tp, gcodeSource: null });
+    render(<PropertiesPanel />);
+    await userEvent.click(screen.getByTitle("Clear toolpath"));
+    expect(useCanvasStore.getState().gcodeToolpath).toBeNull();
+  });
+
+  it("shows 'no objects' placeholder only when no imports AND no toolpath", () => {
+    useCanvasStore.setState({ imports: [], gcodeToolpath: null });
+    render(<PropertiesPanel />);
+    expect(screen.getByText(/No objects/i)).toBeInTheDocument();
+  });
+
+  it("hides 'no objects' placeholder when a toolpath is loaded with no imports", () => {
+    const tp = createGcodeToolpath();
+    useCanvasStore.setState({ imports: [], gcodeToolpath: tp });
+    render(<PropertiesPanel />);
+    expect(screen.queryByText(/No objects/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -11,6 +11,7 @@ import type {
   MachineStatus,
   GcodeOptions,
 } from "../../src/types";
+import type { GcodeToolpath } from "../../src/renderer/src/utils/gcodeParser";
 
 let _idCounter = 0;
 function testId(): string {
@@ -123,6 +124,22 @@ export function createGcodeOptions(
     returnToHome: false,
     customStartGcode: "",
     customEndGcode: "",
+    ...overrides,
+  };
+}
+
+export function createGcodeToolpath(
+  overrides?: Partial<GcodeToolpath>,
+): GcodeToolpath {
+  return {
+    cuts: "M 0.000 0.000 L 100.000 100.000",
+    rapids: "M 0.000 0.000 L 50.000 50.000",
+    bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100 },
+    lineCount: 10,
+    fileSizeBytes: 128,
+    totalCutDistance: 141.421,
+    totalRapidDistance: 70.711,
+    feedrate: 3000,
     ...overrides,
   };
 }

--- a/tests/unit/gcodeParser.test.ts
+++ b/tests/unit/gcodeParser.test.ts
@@ -205,4 +205,69 @@ describe("parseGcode", () => {
     expect(r.lineCount).toBeGreaterThanOrEqual(1002);
     expect(r.cuts).toContain("L 1000.000 1000.000");
   });
+
+  // ── fileSizeBytes ─────────────────────────────────────────────────────────
+
+  it("reports fileSizeBytes equal to gcode string length", () => {
+    const gcode = "G1 X10 Y10\n";
+    const r = parse(gcode);
+    expect(r.fileSizeBytes).toBe(gcode.length);
+  });
+
+  it("reports fileSizeBytes of 0 for empty input", () => {
+    const r = parse("");
+    expect(r.fileSizeBytes).toBe(0);
+  });
+
+  // ── totalCutDistance / totalRapidDistance ─────────────────────────────────
+
+  it("accumulates totalCutDistance for G1 moves", () => {
+    // 3-4-5 right triangle: move from (0,0) to (3,4) → distance = 5
+    const r = parse("G1 X3 Y4\n");
+    expect(r.totalCutDistance).toBeCloseTo(5, 3);
+    expect(r.totalRapidDistance).toBe(0);
+  });
+
+  it("accumulates totalRapidDistance for G0 moves", () => {
+    const r = parse("G0 X3 Y4\n");
+    expect(r.totalRapidDistance).toBeCloseTo(5, 3);
+    expect(r.totalCutDistance).toBe(0);
+  });
+
+  it("accumulates distances across multiple moves", () => {
+    // G0 from (0,0) to (10,0) = 10 mm rapid
+    // G1 from (10,0) to (10,10) = 10 mm cut
+    const r = parse("G0 X10 Y0\nG1 X10 Y10\n");
+    expect(r.totalRapidDistance).toBeCloseTo(10, 3);
+    expect(r.totalCutDistance).toBeCloseTo(10, 3);
+  });
+
+  it("converts inch distances to mm for totalCutDistance", () => {
+    // G20: 1 inch = 25.4 mm
+    const r = parse("G20\nG1 X1 Y0\n");
+    expect(r.totalCutDistance).toBeCloseTo(25.4, 3);
+  });
+
+  // ── feedrate ──────────────────────────────────────────────────────────────
+
+  it("returns feedrate 0 when no F word is present", () => {
+    const r = parse("G1 X10 Y10\n");
+    expect(r.feedrate).toBe(0);
+  });
+
+  it("captures feedrate from F word in mm/min", () => {
+    const r = parse("G1 F3000 X10 Y10\n");
+    expect(r.feedrate).toBe(3000);
+  });
+
+  it("converts inch feedrate to mm/min when G20 active", () => {
+    // 100 in/min = 2540 mm/min
+    const r = parse("G20\nG1 F100 X1 Y0\n");
+    expect(r.feedrate).toBeCloseTo(2540, 1);
+  });
+
+  it("captures the last seen feedrate value", () => {
+    const r = parse("G1 F1000 X5 Y5\nG1 F2000 X10 Y10\n");
+    expect(r.feedrate).toBe(2000);
+  });
 });

--- a/tests/unit/stores/canvasStore.test.ts
+++ b/tests/unit/stores/canvasStore.test.ts
@@ -128,7 +128,11 @@ describe("canvasStore", () => {
   // ── setGcodeSource ──────────────────────────────────────────────────────
 
   it("stores and clears gcodeSource", () => {
-    const src = { path: "/home/user/job.gcode", name: "job.gcode" };
+    const src = {
+      path: "/home/user/job.gcode",
+      name: "job.gcode",
+      source: "local" as const,
+    };
     useCanvasStore.getState().setGcodeSource(src);
     expect(useCanvasStore.getState().gcodeSource).toEqual(src);
     useCanvasStore.getState().setGcodeSource(null);
@@ -140,7 +144,11 @@ describe("canvasStore", () => {
     useCanvasStore.getState().setGcodeToolpath(tp as any);
     useCanvasStore
       .getState()
-      .setGcodeSource({ path: "/job.gcode", name: "job.gcode" });
+      .setGcodeSource({
+        path: "/job.gcode",
+        name: "job.gcode",
+        source: "sd" as const,
+      });
     expect(useCanvasStore.getState().gcodeSource).not.toBeNull();
     useCanvasStore.getState().setGcodeToolpath(null);
     expect(useCanvasStore.getState().gcodeSource).toBeNull();
@@ -150,7 +158,11 @@ describe("canvasStore", () => {
     const tp = { segments: [], bounds: { minX: 0, minY: 0, maxX: 0, maxY: 0 } };
     useCanvasStore
       .getState()
-      .setGcodeSource({ path: "/job.gcode", name: "job.gcode" });
+      .setGcodeSource({
+        path: "/job.gcode",
+        name: "job.gcode",
+        source: "sd" as const,
+      });
     useCanvasStore.getState().setGcodeToolpath(tp as any);
     expect(useCanvasStore.getState().gcodeSource).not.toBeNull();
   });


### PR DESCRIPTION
This pull request introduces a unified selection model for the G-code toolpath and SVG imports in the plotter UI, and enhances the properties panel with detailed G-code toolpath statistics. The changes ensure that toolpath selection is globally managed in the state store, allowing both the canvas and properties panel to stay in sync, and add new fields to the G-code parser for richer toolpath metadata.

<img width="287" height="220" alt="image" src="https://github.com/user-attachments/assets/507bcbe9-f036-458c-9f27-07fa7dfc69cd" />

**Selection Model & State Management**

- Moved `toolpathSelected` and `selectToolpath` from local component state in `PlotCanvas` to the global `canvasStore` so that selection state is shared between the canvas and the properties panel. Selecting the toolpath now deselects any SVG import, and vice versa. [[1]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR58-R59) [[2]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bL253-R256) [[3]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bL277-R287) [[4]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR327-R333) [[5]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bL631-R631) [[6]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bL783-R783) [[7]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R31-R35) [[8]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R55) [[9]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R100-R111) [[10]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R132)

**Properties Panel Enhancements**

- The properties panel now displays a collapsible entry for the G-code toolpath when loaded, showing file name, size, line count, estimated duration, and feedrate. The toolpath can be selected/deselected and cleared from this panel. [[1]](diffhunk://#diff-495a5392542d25f73dc96ab8da8c9088a6c571d7829a2f1bcf37bd2f96107ae0R19-R46) [[2]](diffhunk://#diff-495a5392542d25f73dc96ab8da8c9088a6c571d7829a2f1bcf37bd2f96107ae0R62-R66) [[3]](diffhunk://#diff-495a5392542d25f73dc96ab8da8c9088a6c571d7829a2f1bcf37bd2f96107ae0L81-R218) [[4]](diffhunk://#diff-495a5392542d25f73dc96ab8da8c9088a6c571d7829a2f1bcf37bd2f96107ae0L658-R799) [[5]](diffhunk://#diff-495a5392542d25f73dc96ab8da8c9088a6c571d7829a2f1bcf37bd2f96107ae0L692-R828)

**G-code Toolpath Metadata**

- Extended the `GcodeToolpath` type and parser to include `fileSizeBytes`, `totalCutDistance`, `totalRapidDistance`, and `feedrate`, enabling richer toolpath statistics and job duration estimation. [[1]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8R41-R48) [[2]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8R69-R71) [[3]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8R125-R141)

**Documentation**

- Added a comprehensive `.github/copilot-instructions.md` file detailing the workspace architecture, build/test commands, tech stack rules, IPC API, conventions, and FluidNC integration guidelines.