### PR TITLE
Load gcode preview on job start and other UX improvements in that area

### DIFF
--- a/src/machine/fluidnc.ts
+++ b/src/machine/fluidnc.ts
@@ -589,8 +589,24 @@ export class FluidNCClient extends EventEmitter {
   disconnectWebSocket(): void {
     this.fwMajor = null;
     this.fwInfo = null;
+    this.wsEnabled = false;
+    this.wsGeneration++; // invalidate in-flight reconnect timers
+    if (this.wsReconnectTimer) {
+      clearTimeout(this.wsReconnectTimer);
+      this.wsReconnectTimer = null;
+    }
+    if (this.ws) {
+      // Use ws.close() (graceful WS close frame) rather than ws.terminate()
+      // (TCP RST).  An abrupt RST on process exit can wedge the ESP32's WS
+      // server slot so it refuses new connections until power-cycled.
+      try {
+        this.ws.close(1000);
+      } catch {
+        /* already dead */
+      }
+      this.ws = null;
+    }
     this.emit("firmware", null);
-    this.killWs();
   }
 
   /** Hard-stop: cancel reconnect timer, terminate socket, bump generation. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,14 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") app.quit();
 });
 
+// Gracefully close the FluidNC WebSocket before the process exits so the
+// machine receives a proper WS close frame instead of a TCP RST.  A TCP RST
+// (from os-level socket teardown on process kill) can wedge the ESP32's WS
+// server slot, requiring a power cycle to recover.
+app.on("before-quit", () => {
+  fluidnc.disconnectWebSocket();
+});
+
 // ─── Singletons ───────────────────────────────────────────────────────────────
 
 const fluidnc = new FluidNCClient();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,39 +79,51 @@ const taskManager = new TaskManager();
 // Tracks which transport is currently active so IPC handlers can route correctly.
 let connectionType: "wifi" | "serial" | null = null;
 
+// Guard against sending to a webContents that has been destroyed (e.g. the
+// window closed during the before-quit flush of FluidNC events).
+function safeSend(channel: string, ...args: unknown[]): void {
+  if (
+    !mainWindow ||
+    mainWindow.isDestroyed() ||
+    mainWindow.webContents.isDestroyed()
+  )
+    return;
+  mainWindow.webContents.send(channel, ...args);
+}
+
 // ─── Push events to renderer ──────────────────────────────────────────────────
 
 taskManager.on("task-update", (task: BackgroundTask) => {
-  mainWindow?.webContents.send("task:update", task);
+  safeSend("task:update", task);
 });
 
 // Wi-Fi events
 fluidnc.on("status", (status: MachineStatus) => {
-  mainWindow?.webContents.send("fluidnc:status", status);
+  safeSend("fluidnc:status", status);
 });
 
 fluidnc.on("console", (message: string) => {
-  mainWindow?.webContents.send("fluidnc:console", message);
+  safeSend("fluidnc:console", message);
 });
 
 fluidnc.on("ping", () => {
-  mainWindow?.webContents.send("fluidnc:ping");
+  safeSend("fluidnc:ping");
 });
 
 fluidnc.on("firmware", (info: string | null) => {
-  mainWindow?.webContents.send("fluidnc:firmware", info);
+  safeSend("fluidnc:firmware", info);
 });
 
 // Serial events — status goes to the same channel as Wi-Fi status so the
 // renderer doesn't need to care which transport is active.
 // Also emit a ping so the 15s watchdog timer stays alive over serial.
 serial.on("status", (status: MachineStatus) => {
-  mainWindow?.webContents.send("fluidnc:status", status);
-  mainWindow?.webContents.send("fluidnc:ping");
+  safeSend("fluidnc:status", status);
+  safeSend("fluidnc:ping");
 });
 
 serial.on("data", (data: string) => {
-  mainWindow?.webContents.send("serial:data", data);
+  safeSend("serial:data", data);
 });
 
 // ─── Machine Config Persistence ───────────────────────────────────────────────
@@ -367,15 +379,15 @@ ipcMain.handle(
         remotePath,
         (progress) => {
           taskManager.update(taskId, { progress });
-          mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+          safeSend("task:update", taskManager.get(taskId));
         },
         remoteFilename, // ← override multipart filename so SD card gets the right name
       );
       taskManager.complete(taskId);
-      mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+      safeSend("task:update", taskManager.get(taskId));
     } catch (err: unknown) {
       taskManager.fail(taskId, String(err));
-      mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+      safeSend("task:update", taskManager.get(taskId));
       throw err;
     } finally {
       await unlink(tempPath).catch(() => {});
@@ -394,7 +406,7 @@ ipcMain.handle(
     try {
       await fluidnc.uploadFile(localPath, remotePath, (progress) => {
         taskManager.update(taskId, { progress });
-        mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+        safeSend("task:update", taskManager.get(taskId));
       });
       taskManager.complete(taskId);
     } catch (err: unknown) {
@@ -424,7 +436,7 @@ ipcMain.handle(
         filesystem,
         (progress) => {
           taskManager.update(taskId, { progress });
-          mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+          safeSend("task:update", taskManager.get(taskId));
         },
       );
       taskManager.complete(taskId);
@@ -445,7 +457,7 @@ ipcMain.handle(
     connectionType = "serial";
     // Start polling `?` for status reports (same cadence as WS $RI=500).
     serial.startStatusPolling(500);
-    mainWindow?.webContents.send(
+    safeSend(
       "serial:data",
       `[terraForge] Serial connected to ${path} @ ${baudRate ?? 115200} baud`,
     );
@@ -625,16 +637,16 @@ ipcMain.on(
   "jobs:gcodeProgress",
   (_e, taskId: string, progress: number | null) => {
     taskManager.update(taskId, { progress });
-    mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+    safeSend("task:update", taskManager.get(taskId));
   },
 );
 
 ipcMain.on("jobs:gcodeComplete", (_e, taskId: string) => {
   taskManager.complete(taskId);
-  mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+  safeSend("task:update", taskManager.get(taskId));
 });
 
 ipcMain.on("jobs:gcodeFailed", (_e, taskId: string, error: string) => {
   taskManager.fail(taskId, error);
-  mainWindow?.webContents.send("task:update", taskManager.get(taskId));
+  safeSend("task:update", taskManager.get(taskId));
 });

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -134,7 +134,9 @@ export default function App() {
           ref={jogPanelRef}
           className="fixed z-[100] bg-[#16213e] border border-[#0f3460] rounded-lg shadow-2xl overflow-hidden"
           style={
-            jogPos ? { left: jogPos.x, top: jogPos.y } : { right: 240, top: 58 }
+            jogPos
+              ? { left: jogPos.x, top: jogPos.y }
+              : { right: 240, top: 124 }
           }
           onPointerMove={onJogDragMove}
           onPointerUp={onJogDragEnd}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,29 +18,43 @@ export default function App() {
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const appendLine = useConsoleStore((s) => s.appendLine);
 
-  const [showJog, setShowJog] = useState(false);
-  const [jogDelta, setJogDelta] = useState({ dx: 0, dy: 0 });
+  const [showJog, setShowJog] = useState(true);
+  // null = use CSS default (aligned with right panel + 16px gap); set when user first drags
+  const [jogPos, setJogPos] = useState<{ x: number; y: number } | null>(null);
+  const jogPanelRef = useRef<HTMLDivElement>(null);
   const jogDragRef = useRef<{
     mouseX: number;
     mouseY: number;
-    startDx: number;
-    startDy: number;
+    startX: number;
+    startY: number;
   } | null>(null);
 
   const startJogDrag = (e: React.PointerEvent<HTMLDivElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
+    // Resolve current pixel position from either state or the element's bounding rect
+    const panel = jogPanelRef.current;
+    const rect = panel?.getBoundingClientRect();
     jogDragRef.current = {
       mouseX: e.clientX,
       mouseY: e.clientY,
-      startDx: jogDelta.dx,
-      startDy: jogDelta.dy,
+      startX: rect?.left ?? window.innerWidth - 270,
+      startY: rect?.top ?? 48,
     };
+    // Anchor position state so subsequent moves work correctly
+    if (!jogPos && rect) {
+      setJogPos({ x: rect.left, y: rect.top });
+    }
   };
   const onJogDragMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!jogDragRef.current) return;
-    setJogDelta({
-      dx: jogDragRef.current.startDx + e.clientX - jogDragRef.current.mouseX,
-      dy: jogDragRef.current.startDy + e.clientY - jogDragRef.current.mouseY,
+    if (!jogDragRef.current || !jogPanelRef.current) return;
+    const { offsetWidth: w, offsetHeight: h } = jogPanelRef.current;
+    const newX =
+      jogDragRef.current.startX + e.clientX - jogDragRef.current.mouseX;
+    const newY =
+      jogDragRef.current.startY + e.clientY - jogDragRef.current.mouseY;
+    setJogPos({
+      x: Math.max(0, Math.min(window.innerWidth - w, newX)),
+      y: Math.max(0, Math.min(window.innerHeight - h, newY)),
     });
   };
   const onJogDragEnd = () => {
@@ -101,27 +115,6 @@ export default function App() {
           <PlotCanvas />
           {/* Toast stack — absolute within canvas area, clear of side panels */}
           <TaskBar />
-          {/* Jog panel — absolute right-4 top-4 matches zoom controls */}
-          {showJog && (
-            <div
-              className="absolute z-50 right-4 top-4 bg-[#16213e] border border-[#0f3460] rounded-lg shadow-2xl overflow-hidden"
-              style={{
-                transform: `translate(${jogDelta.dx}px, ${jogDelta.dy}px)`,
-              }}
-              onPointerMove={onJogDragMove}
-              onPointerUp={onJogDragEnd}
-              onPointerCancel={onJogDragEnd}
-            >
-              <div
-                className="h-2.5 w-full cursor-grab active:cursor-grabbing bg-[#0f3460]/50 hover:bg-[#0f3460] transition-colors"
-                title="Drag to move"
-                onPointerDown={startJogDrag}
-              />
-              <div className="p-4">
-                <JogControls onClose={() => setShowJog(false)} />
-              </div>
-            </div>
-          )}
         </main>
 
         {/* Right panel — object properties */}
@@ -134,6 +127,29 @@ export default function App() {
       <div className="h-40 bg-[#16213e] border-t border-[#0f3460] shrink-0">
         <ConsolePanel />
       </div>
+
+      {/* Jog panel — fixed to viewport so it floats above all panels */}
+      {showJog && (
+        <div
+          ref={jogPanelRef}
+          className="fixed z-[100] bg-[#16213e] border border-[#0f3460] rounded-lg shadow-2xl overflow-hidden"
+          style={
+            jogPos ? { left: jogPos.x, top: jogPos.y } : { right: 240, top: 58 }
+          }
+          onPointerMove={onJogDragMove}
+          onPointerUp={onJogDragEnd}
+          onPointerCancel={onJogDragEnd}
+        >
+          <div
+            className="h-2.5 w-full cursor-grab active:cursor-grabbing bg-[#0f3460]/50 hover:bg-[#0f3460] transition-colors"
+            title="Drag to move"
+            onPointerDown={startJogDrag}
+          />
+          <div className="p-4">
+            <JogControls onClose={() => setShowJog(false)} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Toolbar } from "./components/Toolbar";
 import { FileBrowserPanel } from "./components/FileBrowserPanel";
 import { PlotCanvas } from "./components/PlotCanvas";
 import { PropertiesPanel } from "./components/PropertiesPanel";
 import { ConsolePanel } from "./components/ConsolePanel";
 import { TaskBar } from "./components/TaskBar";
+import { JogControls } from "./components/JogControls";
 import { useMachineStore } from "./store/machineStore";
 import { useTaskStore } from "./store/taskStore";
 import { useConsoleStore } from "./store/consoleStore";
@@ -16,6 +17,35 @@ export default function App() {
   const setFwInfo = useMachineStore((s) => s.setFwInfo);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const appendLine = useConsoleStore((s) => s.appendLine);
+
+  const [showJog, setShowJog] = useState(true);
+  const [jogDelta, setJogDelta] = useState({ dx: 0, dy: 0 });
+  const jogDragRef = useRef<{
+    mouseX: number;
+    mouseY: number;
+    startDx: number;
+    startDy: number;
+  } | null>(null);
+
+  const startJogDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    jogDragRef.current = {
+      mouseX: e.clientX,
+      mouseY: e.clientY,
+      startDx: jogDelta.dx,
+      startDy: jogDelta.dy,
+    };
+  };
+  const onJogDragMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!jogDragRef.current) return;
+    setJogDelta({
+      dx: jogDragRef.current.startDx + e.clientX - jogDragRef.current.mouseX,
+      dy: jogDragRef.current.startDy + e.clientY - jogDragRef.current.mouseY,
+    });
+  };
+  const onJogDragEnd = () => {
+    jogDragRef.current = null;
+  };
 
   // ─── Bootstrap ─────────────────────────────────────────────────────────────
 
@@ -57,7 +87,7 @@ export default function App() {
   return (
     <div className="flex flex-col h-screen bg-[#1a1a2e] text-gray-200 overflow-hidden">
       {/* Top toolbar */}
-      <Toolbar />
+      <Toolbar showJog={showJog} onToggleJog={() => setShowJog((v) => !v)} />
 
       {/* Main work area */}
       <div className="flex flex-1 overflow-hidden">
@@ -67,10 +97,31 @@ export default function App() {
         </aside>
 
         {/* Centre — plot canvas */}
-        <main className="flex-1 overflow-hidden relative">
+        <main className="flex-1 overflow-visible relative">
           <PlotCanvas />
           {/* Toast stack — absolute within canvas area, clear of side panels */}
           <TaskBar />
+          {/* Jog panel — absolute right-4 top-4 matches zoom controls */}
+          {showJog && (
+            <div
+              className="absolute z-50 right-4 top-4 bg-[#16213e] border border-[#0f3460] rounded-lg shadow-2xl overflow-hidden"
+              style={{
+                transform: `translate(${jogDelta.dx}px, ${jogDelta.dy}px)`,
+              }}
+              onPointerMove={onJogDragMove}
+              onPointerUp={onJogDragEnd}
+              onPointerCancel={onJogDragEnd}
+            >
+              <div
+                className="h-2.5 w-full cursor-grab active:cursor-grabbing bg-[#0f3460]/50 hover:bg-[#0f3460] transition-colors"
+                title="Drag to move"
+                onPointerDown={startJogDrag}
+              />
+              <div className="p-4">
+                <JogControls onClose={() => setShowJog(false)} />
+              </div>
+            </div>
+          )}
         </main>
 
         {/* Right panel — object properties */}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const appendLine = useConsoleStore((s) => s.appendLine);
 
-  const [showJog, setShowJog] = useState(true);
+  const [showJog, setShowJog] = useState(false);
   const [jogDelta, setJogDelta] = useState({ dx: 0, dy: 0 });
   const jogDragRef = useRef<{
     mouseX: number;

--- a/src/renderer/src/components/ConsolePanel.tsx
+++ b/src/renderer/src/components/ConsolePanel.tsx
@@ -99,7 +99,7 @@ export function ConsolePanel() {
                   {status.state}
                 </span>
               ))}
-            {status && (
+            {status?.wpos && (
               <span className="text-xs text-gray-500">
                 X:{status.wpos.x.toFixed(2)} Y:{status.wpos.y.toFixed(2)} Z:
                 {status.wpos.z.toFixed(2)}

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -214,6 +214,14 @@ function FsPane({
   const doPreview = async (file: RemoteFile) => {
     setPendingPreviewFile(null);
     setPreviewing(file.path);
+    const previewTaskId = uuid();
+    upsertTask({
+      id: previewTaskId,
+      type: "gcode-preview",
+      label: `Loading preview for ${file.name}…`,
+      progress: null,
+      status: "running",
+    });
     try {
       const text = await window.terraForge.fluidnc.fetchFileText(
         file.path,
@@ -229,8 +237,23 @@ function FsPane({
       // Select this file as the queued job so Start Job is enabled immediately
       // and the file is highlighted in the browser.
       setSelectedJobFile({ path: file.path, source, name: file.name });
+      upsertTask({
+        id: previewTaskId,
+        type: "gcode-preview",
+        label: `Preview loaded`,
+        progress: 100,
+        status: "completed",
+      });
     } catch (err) {
       console.error("Preview failed:", err);
+      upsertTask({
+        id: previewTaskId,
+        type: "gcode-preview",
+        label: `Preview failed`,
+        progress: null,
+        status: "error",
+        error: String(err),
+      });
     } finally {
       setPreviewing(null);
     }

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -114,6 +114,7 @@ function FsPane({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [previewing, setPreviewing] = useState<string | null>(null);
+  const [runningFile, setRunningFile] = useState<string | null>(null);
   const [pendingPreviewFile, setPendingPreviewFile] =
     useState<RemoteFile | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RemoteFile | null>(null);
@@ -122,8 +123,12 @@ function FsPane({
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
   const setGcodeSource = useCanvasStore((s) => s.setGcodeSource);
   const selectToolpath = useCanvasStore((s) => s.selectToolpath);
+  const setGcodePreviewLoading = useCanvasStore(
+    (s) => s.setGcodePreviewLoading,
+  );
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
+  const status = useMachineStore((s) => s.status);
 
   const navigate = useCallback(
     async (target: string) => {
@@ -152,6 +157,16 @@ function FsPane({
       setError(null);
     }
   }, [connected]);
+
+  // Refresh the current directory whenever FluidNC reports a file-system change.
+  useEffect(() => {
+    if (!connected) return;
+    return window.terraForge.fluidnc.onConsoleMessage((msg) => {
+      if (msg.includes("[MSG:Files changed]")) {
+        navigate(path);
+      }
+    });
+  }, [connected, navigate, path]);
 
   const handleDownload = async (file: RemoteFile) => {
     const localPath = isGcodeFile(file.name)
@@ -221,6 +236,16 @@ function FsPane({
   // loaded — so that plot-progress tracing works from the moment it starts.
   const handleRun = async (file: RemoteFile) => {
     if (gcodeSource?.path !== file.path || !gcodeToolpath) {
+      setRunningFile(file.path);
+      const previewTaskId = uuid();
+      upsertTask({
+        id: previewTaskId,
+        type: "gcode-preview",
+        label: `Loading preview for ${file.name}…`,
+        progress: null,
+        status: "running",
+      });
+      setGcodePreviewLoading(true);
       try {
         const text = await window.terraForge.fluidnc.fetchFileText(
           file.path,
@@ -230,8 +255,25 @@ function FsPane({
         setGcodeToolpath(toolpath);
         setGcodeSource({ path: file.path, name: file.name, source });
         selectToolpath(true);
+        upsertTask({
+          id: previewTaskId,
+          type: "gcode-preview",
+          label: `Preview loaded`,
+          progress: 100,
+          status: "completed",
+        });
       } catch {
         // Toolpath load failed — run anyway, just without tracing
+        upsertTask({
+          id: previewTaskId,
+          type: "gcode-preview",
+          label: `Preview load failed`,
+          progress: null,
+          status: "error",
+        });
+      } finally {
+        setRunningFile(null);
+        setGcodePreviewLoading(false);
       }
     }
     window.terraForge.fluidnc.runFile(file.path, source);
@@ -350,6 +392,10 @@ function FsPane({
                 selectedJobFile?.path === file.path &&
                 selectedJobFile?.source === source;
 
+              const anyJobActive =
+                (status?.state === "Run" || status?.state === "Hold") &&
+                selectedJobFile?.source === source;
+
               return (
                 <div
                   key={file.path}
@@ -396,56 +442,110 @@ function FsPane({
                       ›
                     </span>
                   ) : (
-                    <div className="hidden group-hover:flex gap-0.5 shrink-0">
-                      {isGcodeFile(file.name) && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handlePreview(file);
-                          }}
-                          title="Preview toolpath"
-                          disabled={previewing === file.path}
-                          className="text-[9px] px-1 py-0.5 rounded bg-[#0d2a3a] hover:bg-[#0e3d5a] disabled:opacity-50"
+                    (() => {
+                      const isThisRunning =
+                        selectedJobFile?.path === file.path &&
+                        selectedJobFile?.source === source &&
+                        status?.state === "Run";
+                      const isThisHeld =
+                        selectedJobFile?.path === file.path &&
+                        selectedJobFile?.source === source &&
+                        status?.state === "Hold";
+                      const isActiveJob = isThisRunning || isThisHeld;
+                      const isLoadingThis = runningFile === file.path;
+                      return (
+                        <div
+                          className={`gap-0.5 shrink-0 ${isActiveJob || isLoadingThis ? "flex" : "hidden group-hover:flex"}`}
                         >
-                          {previewing === file.path ? "…" : "👁"}
-                        </button>
-                      )}
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRun(file);
-                        }}
-                        title="Run job now"
-                        className="text-[9px] px-1 py-0.5 rounded bg-[#e94560] hover:bg-[#c73d56] text-white"
-                      >
-                        ▶
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDownload(file);
-                        }}
-                        disabled={serialMode}
-                        title={
-                          serialMode
-                            ? "File download not available over serial"
-                            : "Download"
-                        }
-                        className="text-[9px] px-1 py-0.5 rounded bg-[#0f3460] hover:bg-[#1a4a8a] disabled:opacity-40"
-                      >
-                        ↓
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setDeleteTarget(file);
-                        }}
-                        title="Delete"
-                        className="text-[9px] px-1 py-0.5 rounded bg-[#3a1a1a] hover:bg-[#6a2020]"
-                      >
-                        ✕
-                      </button>
-                    </div>
+                          {isGcodeFile(file.name) && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handlePreview(file);
+                              }}
+                              title="Preview toolpath"
+                              disabled={
+                                previewing === file.path || anyJobActive
+                              }
+                              className="text-[9px] px-1 py-0.5 rounded bg-[#0d2a3a] hover:bg-[#0e3d5a] disabled:opacity-50"
+                            >
+                              {previewing === file.path ? "…" : "👁"}
+                            </button>
+                          )}
+                          {isThisRunning ? (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                window.terraForge.fluidnc.pauseJob();
+                              }}
+                              title="Pause job"
+                              className="text-[9px] px-1 py-0.5 rounded bg-[#e94560] hover:bg-[#c73d56] text-white"
+                            >
+                              ⏸
+                            </button>
+                          ) : isThisHeld ? (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                window.terraForge.fluidnc.resumeJob();
+                              }}
+                              title="Resume job"
+                              className="text-[9px] px-1 py-0.5 rounded bg-[#e94560] hover:bg-[#c73d56] text-white"
+                            >
+                              ▶
+                            </button>
+                          ) : (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleRun(file);
+                              }}
+                              title={
+                                anyJobActive
+                                  ? "A job is already running"
+                                  : "Run job now"
+                              }
+                              disabled={isLoadingThis || anyJobActive}
+                              className="text-[9px] px-1 py-0.5 rounded bg-[#e94560] hover:bg-[#c73d56] disabled:opacity-50 text-white"
+                            >
+                              ▶
+                            </button>
+                          )}
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleDownload(file);
+                            }}
+                            disabled={serialMode || anyJobActive}
+                            title={
+                              anyJobActive
+                                ? "Unavailable while a job is running"
+                                : serialMode
+                                  ? "File download not available over serial"
+                                  : "Download"
+                            }
+                            className="text-[9px] px-1 py-0.5 rounded bg-[#0f3460] hover:bg-[#1a4a8a] disabled:opacity-40"
+                          >
+                            ↓
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeleteTarget(file);
+                            }}
+                            disabled={anyJobActive}
+                            title={
+                              anyJobActive
+                                ? "Unavailable while a job is running"
+                                : "Delete"
+                            }
+                            className="text-[9px] px-1 py-0.5 rounded bg-[#3a1a1a] hover:bg-[#6a2020] disabled:opacity-40"
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      );
+                    })()
                   )}
                 </div>
               );

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -118,6 +118,7 @@ function FsPane({
     useState<RemoteFile | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RemoteFile | null>(null);
   const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
+  const gcodeSource = useCanvasStore((s) => s.gcodeSource);
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
   const setGcodeSource = useCanvasStore((s) => s.setGcodeSource);
   const selectToolpath = useCanvasStore((s) => s.selectToolpath);
@@ -214,6 +215,26 @@ function FsPane({
       return;
     }
     doPreview(file);
+  };
+
+  // Run the file on the machine, loading its toolpath first if not already
+  // loaded — so that plot-progress tracing works from the moment it starts.
+  const handleRun = async (file: RemoteFile) => {
+    if (gcodeSource?.path !== file.path || !gcodeToolpath) {
+      try {
+        const text = await window.terraForge.fluidnc.fetchFileText(
+          file.path,
+          label === "sdcard" ? "sdcard" : "internal",
+        );
+        const toolpath = parseGcode(text);
+        setGcodeToolpath(toolpath);
+        setGcodeSource({ path: file.path, name: file.name, source });
+        selectToolpath(true);
+      } catch {
+        // Toolpath load failed — run anyway, just without tracing
+      }
+    }
+    window.terraForge.fluidnc.runFile(file.path, source);
   };
 
   const atRoot = path === "/";
@@ -392,7 +413,7 @@ function FsPane({
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          window.terraForge.fluidnc.runFile(file.path, source);
+                          handleRun(file);
                         }}
                         title="Run job now"
                         className="text-[9px] px-1 py-0.5 rounded bg-[#e94560] hover:bg-[#c73d56] text-white"

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -115,6 +115,10 @@ function FsPane({
   const [error, setError] = useState<string | null>(null);
   const [previewing, setPreviewing] = useState<string | null>(null);
   const [runningFile, setRunningFile] = useState<string | null>(null);
+  // Path of the file that was actually dispatched to the machine via runFile.
+  // Separate from selectedJobFile so that clicking another file in the browser
+  // while a job is active doesn't make that file show pause/resume controls.
+  const [activeJobPath, setActiveJobPath] = useState<string | null>(null);
   const [pendingPreviewFile, setPendingPreviewFile] =
     useState<RemoteFile | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RemoteFile | null>(null);
@@ -167,6 +171,13 @@ function FsPane({
       }
     });
   }, [connected, navigate, path]);
+
+  // Clear activeJobPath when the machine is no longer running or held.
+  useEffect(() => {
+    if (status?.state !== "Run" && status?.state !== "Hold") {
+      setActiveJobPath(null);
+    }
+  }, [status?.state]);
 
   const handleDownload = async (file: RemoteFile) => {
     const localPath = isGcodeFile(file.name)
@@ -287,6 +298,7 @@ function FsPane({
     // Brief pause so the user can read the preview-loaded toast
     // before the job begins (cosmetic only).
     await new Promise((r) => setTimeout(r, 1000));
+    setActiveJobPath(file.path);
     try {
       await window.terraForge.fluidnc.runFile(file.path, source);
       upsertTask({
@@ -297,6 +309,7 @@ function FsPane({
         status: "completed",
       });
     } catch (err) {
+      setActiveJobPath(null);
       upsertTask({
         id: jobTaskId,
         type: "job-start",
@@ -423,7 +436,7 @@ function FsPane({
 
               const anyJobActive =
                 (status?.state === "Run" || status?.state === "Hold") &&
-                selectedJobFile?.source === source;
+                activeJobPath !== null;
 
               return (
                 <div
@@ -474,12 +487,10 @@ function FsPane({
                   ) : (
                     (() => {
                       const isThisRunning =
-                        selectedJobFile?.path === file.path &&
-                        selectedJobFile?.source === source &&
+                        activeJobPath === file.path &&
                         status?.state === "Run";
                       const isThisHeld =
-                        selectedJobFile?.path === file.path &&
-                        selectedJobFile?.source === source &&
+                        activeJobPath === file.path &&
                         status?.state === "Hold";
                       const isActiveJob = isThisRunning || isThisHeld;
                       const isLoadingThis = runningFile === file.path;

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -284,6 +284,9 @@ function FsPane({
         setGcodePreviewLoading(false);
       }
     }
+    // Brief pause so the user can read the preview-loaded toast
+    // before the job begins (cosmetic only).
+    await new Promise((r) => setTimeout(r, 1000));
     try {
       await window.terraForge.fluidnc.runFile(file.path, source);
       upsertTask({

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -121,6 +121,7 @@ function FsPane({
   const [activeJobPath, setActiveJobPath] = useState<string | null>(null);
   const [pendingPreviewFile, setPendingPreviewFile] =
     useState<RemoteFile | null>(null);
+  const [pendingRunFile, setPendingRunFile] = useState<RemoteFile | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RemoteFile | null>(null);
   const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
   const gcodeSource = useCanvasStore((s) => s.gcodeSource);
@@ -245,7 +246,8 @@ function FsPane({
 
   // Run the file on the machine, loading its toolpath first if not already
   // loaded — so that plot-progress tracing works from the moment it starts.
-  const handleRun = async (file: RemoteFile) => {
+  const doRun = async (file: RemoteFile) => {
+    setPendingRunFile(null);
     const jobTaskId = uuid();
     upsertTask({
       id: jobTaskId,
@@ -321,6 +323,15 @@ function FsPane({
     }
   };
 
+  const handleRun = (file: RemoteFile) => {
+    // If a different toolpath is already loaded, warn before replacing it.
+    if (gcodeToolpath && gcodeSource?.path !== file.path) {
+      setPendingRunFile(file);
+      return;
+    }
+    doRun(file);
+  };
+
   const atRoot = path === "/";
   const bgAccent = accentColor === "blue" ? "bg-[#0a1628]" : "bg-[#1a0d1a]";
   const borderAccent =
@@ -334,6 +345,15 @@ function FsPane({
 
   return (
     <div className={`flex flex-col h-full border-b ${borderAccent}`}>
+      {pendingRunFile && (
+        <ConfirmDialog
+          title="Replace Toolpath & Run?"
+          message={`This will replace the current toolpath with "${pendingRunFile.name}" and start the job immediately.`}
+          confirmLabel="Run"
+          onConfirm={() => doRun(pendingRunFile)}
+          onCancel={() => setPendingRunFile(null)}
+        />
+      )}
       {pendingPreviewFile && (
         <ConfirmDialog
           title="Replace Toolpath?"

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -235,6 +235,14 @@ function FsPane({
   // Run the file on the machine, loading its toolpath first if not already
   // loaded — so that plot-progress tracing works from the moment it starts.
   const handleRun = async (file: RemoteFile) => {
+    const jobTaskId = uuid();
+    upsertTask({
+      id: jobTaskId,
+      type: "job-start",
+      label: `Starting ${file.name}…`,
+      progress: null,
+      status: "running",
+    });
     if (gcodeSource?.path !== file.path || !gcodeToolpath) {
       setRunningFile(file.path);
       const previewTaskId = uuid();
@@ -276,7 +284,25 @@ function FsPane({
         setGcodePreviewLoading(false);
       }
     }
-    window.terraForge.fluidnc.runFile(file.path, source);
+    try {
+      await window.terraForge.fluidnc.runFile(file.path, source);
+      upsertTask({
+        id: jobTaskId,
+        type: "job-start",
+        label: `${file.name} started`,
+        progress: 100,
+        status: "completed",
+      });
+    } catch (err) {
+      upsertTask({
+        id: jobTaskId,
+        type: "job-start",
+        label: `Failed to start ${file.name}`,
+        progress: null,
+        status: "error",
+        error: String(err),
+      });
+    }
   };
 
   const atRoot = path === "/";

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -428,6 +428,7 @@ function FsPane({
               return (
                 <div
                   key={file.path}
+                  data-testid={`file-row-${file.name}`}
                   className={`flex items-center group px-3 py-1 cursor-pointer border-b border-[#0f3460]/20 transition-colors ${
                     isSelectedForJob
                       ? "bg-[#1a3a6e] hover:bg-[#1f4480]"
@@ -484,6 +485,7 @@ function FsPane({
                       const isLoadingThis = runningFile === file.path;
                       return (
                         <div
+                          data-testid={`file-actions-${file.name}`}
                           className={`gap-0.5 shrink-0 ${isActiveJob || isLoadingThis ? "flex" : "hidden group-hover:flex"}`}
                         >
                           {isGcodeFile(file.name) && (

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -487,11 +487,9 @@ function FsPane({
                   ) : (
                     (() => {
                       const isThisRunning =
-                        activeJobPath === file.path &&
-                        status?.state === "Run";
+                        activeJobPath === file.path && status?.state === "Run";
                       const isThisHeld =
-                        activeJobPath === file.path &&
-                        status?.state === "Hold";
+                        activeJobPath === file.path && status?.state === "Hold";
                       const isActiveJob = isThisRunning || isThisHeld;
                       const isLoadingThis = runningFile === file.path;
                       return (

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -173,12 +173,27 @@ function FsPane({
     });
   }, [connected, navigate, path]);
 
-  // Clear activeJobPath when the machine is no longer running or held.
+  // Keep a ref so the status-change effect can read selectedJobFile without
+  // adding it to the dependency array (which would cause it to fire — and
+  // potentially overwrite activeJobPath — whenever the user selects a row).
+  const selectedJobFileRef = useRef(selectedJobFile);
+  selectedJobFileRef.current = selectedJobFile;
+
+  // Track which file path is actively running on the machine.
+  // Only fires on status state transitions so clicking a different row while
+  // a job is running cannot overwrite the already-set activeJobPath.
   useEffect(() => {
-    if (status?.state !== "Run" && status?.state !== "Hold") {
+    if (status?.state === "Run" || status?.state === "Hold") {
+      setActiveJobPath((prev) => {
+        if (prev !== null) return prev; // already set — keep it
+        const jf = selectedJobFileRef.current;
+        return jf?.source === source ? jf.path : null;
+      });
+    } else {
       setActiveJobPath(null);
     }
-  }, [status?.state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status?.state, source]);
 
   const handleDownload = async (file: RemoteFile) => {
     const localPath = isGcodeFile(file.name)
@@ -472,14 +487,18 @@ function FsPane({
             )}
 
             {files.map((file) => {
-              const isSelectedForJob =
-                !file.isDirectory &&
-                selectedJobFile?.path === file.path &&
-                selectedJobFile?.source === source;
-
               const anyJobActive =
                 (status?.state === "Run" || status?.state === "Hold") &&
                 activeJobPath !== null;
+
+              // While a job is running, keep the highlight on the active file
+              // regardless of what selectedJobFile the user may have clicked.
+              const isSelectedForJob =
+                !file.isDirectory &&
+                (anyJobActive
+                  ? activeJobPath === file.path
+                  : selectedJobFile?.path === file.path &&
+                    selectedJobFile?.source === source);
 
               return (
                 <div

--- a/src/renderer/src/components/JobControls.tsx
+++ b/src/renderer/src/components/JobControls.tsx
@@ -4,6 +4,7 @@ import { ConfirmDialog } from "./ConfirmDialog";
 import { useMachineStore } from "../store/machineStore";
 import { useTaskStore } from "../store/taskStore";
 import { useCanvasStore } from "../store/canvasStore";
+import { parseGcode } from "../utils/gcodeParser";
 
 const GCODE_EXTS = [
   ".gcode",
@@ -26,6 +27,10 @@ export function JobControls() {
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const toolpathSelected = useCanvasStore((s) => s.toolpathSelected);
   const gcodeSource = useCanvasStore((s) => s.gcodeSource);
+  const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
+  const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
+  const setGcodeSource = useCanvasStore((s) => s.setGcodeSource);
+  const selectToolpath = useCanvasStore((s) => s.selectToolpath);
 
   // When the canvas toolpath is selected and has a local file source, use it
   // as the job file even if nothing is explicitly set in the file browser.
@@ -172,6 +177,30 @@ export function JobControls() {
                 });
               }
             } else {
+              // Load the toolpath before running so plot-progress tracing works
+              // from the start — especially if the SVG layer was deleted after
+              // generation or the file was never explicitly previewed.
+              if (
+                gcodeSource?.path !== effectiveJobFile!.path ||
+                !gcodeToolpath
+              ) {
+                try {
+                  const text = await window.terraForge.fluidnc.fetchFileText(
+                    effectiveJobFile!.path,
+                    effectiveJobFile!.source === "sd" ? "sdcard" : "internal",
+                  );
+                  const toolpath = parseGcode(text);
+                  setGcodeToolpath(toolpath);
+                  setGcodeSource({
+                    path: effectiveJobFile!.path,
+                    name: effectiveJobFile!.name,
+                    source: effectiveJobFile!.source as "fs" | "sd",
+                  });
+                  selectToolpath(true);
+                } catch {
+                  // Toolpath load failed — run anyway, just without tracing
+                }
+              }
               await window.terraForge.fluidnc.runFile(
                 effectiveJobFile!.path,
                 effectiveJobFile!.source as "fs" | "sd",

--- a/src/renderer/src/components/JobControls.tsx
+++ b/src/renderer/src/components/JobControls.tsx
@@ -257,6 +257,9 @@ export function JobControls() {
                     setGcodePreviewLoading(false);
                   }
                 }
+                // Brief pause so the user can read the preview-loaded toast
+                // before the job begins (cosmetic only).
+                await new Promise((r) => setTimeout(r, 1000));
                 await window.terraForge.fluidnc.runFile(
                   effectiveJobFile!.path,
                   effectiveJobFile!.source as "fs" | "sd",

--- a/src/renderer/src/components/JobControls.tsx
+++ b/src/renderer/src/components/JobControls.tsx
@@ -180,6 +180,13 @@ export function JobControls() {
                   remotePath,
                 );
                 await window.terraForge.fluidnc.runFile(remotePath, "sd");
+                upsertTask({
+                  id: uuid(),
+                  type: "job-start",
+                  label: `${name} started`,
+                  progress: 100,
+                  status: "completed",
+                });
               } catch (err) {
                 upsertTask({
                   id: taskId,
@@ -191,60 +198,86 @@ export function JobControls() {
                 });
               }
             } else {
-              // Load the toolpath before running so plot-progress tracing works
-              // from the start — especially if the SVG layer was deleted after
-              // generation or the file was never explicitly previewed.
-              if (
-                gcodeSource?.path !== effectiveJobFile!.path ||
-                !gcodeToolpath
-              ) {
-                const previewTaskId = uuid();
-                const name = effectiveJobFile!.name;
-                upsertTask({
-                  id: previewTaskId,
-                  type: "gcode-preview",
-                  label: `Loading preview for ${name}…`,
-                  progress: null,
-                  status: "running",
-                });
-                setGcodePreviewLoading(true);
-                try {
-                  const text = await window.terraForge.fluidnc.fetchFileText(
-                    effectiveJobFile!.path,
-                    effectiveJobFile!.source === "sd" ? "sdcard" : "internal",
-                  );
-                  const toolpath = parseGcode(text);
-                  setGcodeToolpath(toolpath);
-                  setGcodeSource({
-                    path: effectiveJobFile!.path,
-                    name: effectiveJobFile!.name,
-                    source: effectiveJobFile!.source as "fs" | "sd",
-                  });
-                  selectToolpath(true);
+              const jobTaskId = uuid();
+              upsertTask({
+                id: jobTaskId,
+                type: "job-start",
+                label: `Starting ${effectiveJobFile!.name}…`,
+                progress: null,
+                status: "running",
+              });
+              try {
+                // Load the toolpath before running so plot-progress tracing works
+                // from the start — especially if the SVG layer was deleted after
+                // generation or the file was never explicitly previewed.
+                if (
+                  gcodeSource?.path !== effectiveJobFile!.path ||
+                  !gcodeToolpath
+                ) {
+                  const previewTaskId = uuid();
+                  const name = effectiveJobFile!.name;
                   upsertTask({
                     id: previewTaskId,
                     type: "gcode-preview",
-                    label: `Preview loaded`,
-                    progress: 100,
-                    status: "completed",
-                  });
-                } catch {
-                  // Toolpath load failed — run anyway, just without tracing
-                  upsertTask({
-                    id: previewTaskId,
-                    type: "gcode-preview",
-                    label: `Preview load failed`,
+                    label: `Loading preview for ${name}…`,
                     progress: null,
-                    status: "error",
+                    status: "running",
                   });
-                } finally {
-                  setGcodePreviewLoading(false);
+                  setGcodePreviewLoading(true);
+                  try {
+                    const text = await window.terraForge.fluidnc.fetchFileText(
+                      effectiveJobFile!.path,
+                      effectiveJobFile!.source === "sd" ? "sdcard" : "internal",
+                    );
+                    const toolpath = parseGcode(text);
+                    setGcodeToolpath(toolpath);
+                    setGcodeSource({
+                      path: effectiveJobFile!.path,
+                      name: effectiveJobFile!.name,
+                      source: effectiveJobFile!.source as "fs" | "sd",
+                    });
+                    selectToolpath(true);
+                    upsertTask({
+                      id: previewTaskId,
+                      type: "gcode-preview",
+                      label: `Preview loaded`,
+                      progress: 100,
+                      status: "completed",
+                    });
+                  } catch {
+                    // Toolpath load failed — run anyway, just without tracing
+                    upsertTask({
+                      id: previewTaskId,
+                      type: "gcode-preview",
+                      label: `Preview load failed`,
+                      progress: null,
+                      status: "error",
+                    });
+                  } finally {
+                    setGcodePreviewLoading(false);
+                  }
                 }
+                await window.terraForge.fluidnc.runFile(
+                  effectiveJobFile!.path,
+                  effectiveJobFile!.source as "fs" | "sd",
+                );
+                upsertTask({
+                  id: jobTaskId,
+                  type: "job-start",
+                  label: `${effectiveJobFile!.name} started`,
+                  progress: 100,
+                  status: "completed",
+                });
+              } catch (err) {
+                upsertTask({
+                  id: jobTaskId,
+                  type: "job-start",
+                  label: `Failed to start ${effectiveJobFile!.name}`,
+                  progress: null,
+                  status: "error",
+                  error: String(err),
+                });
               }
-              await window.terraForge.fluidnc.runFile(
-                effectiveJobFile!.path,
-                effectiveJobFile!.source as "fs" | "sd",
-              );
             }
           },
           "primary",

--- a/src/renderer/src/components/JobControls.tsx
+++ b/src/renderer/src/components/JobControls.tsx
@@ -43,6 +43,10 @@ export function JobControls() {
           name: gcodeSource.name,
         }
       : null);
+  const gcodePreviewLoading = useCanvasStore((s) => s.gcodePreviewLoading);
+  const setGcodePreviewLoading = useCanvasStore(
+    (s) => s.setGcodePreviewLoading,
+  );
   const [showAbortConfirm, setShowAbortConfirm] = useState(false);
 
   const jobFileValid =
@@ -87,6 +91,16 @@ export function JobControls() {
       <span className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-1">
         Job
       </span>
+
+      {/* Preview-loading bar — visible while fetching toolpath before start */}
+      {!isActive && gcodePreviewLoading && (
+        <div className="flex flex-col gap-1 mb-1">
+          <div className="w-full h-2 bg-[#0f3460] rounded-full overflow-hidden">
+            <div className="h-full w-1/3 bg-[#e94560] animate-pulse" />
+          </div>
+          <div className="text-[9px] text-gray-500">Loading preview…</div>
+        </div>
+      )}
 
       {/* Progress bar — visible while active */}
       {isActive && (
@@ -184,6 +198,16 @@ export function JobControls() {
                 gcodeSource?.path !== effectiveJobFile!.path ||
                 !gcodeToolpath
               ) {
+                const previewTaskId = uuid();
+                const name = effectiveJobFile!.name;
+                upsertTask({
+                  id: previewTaskId,
+                  type: "gcode-preview",
+                  label: `Loading preview for ${name}…`,
+                  progress: null,
+                  status: "running",
+                });
+                setGcodePreviewLoading(true);
                 try {
                   const text = await window.terraForge.fluidnc.fetchFileText(
                     effectiveJobFile!.path,
@@ -197,8 +221,24 @@ export function JobControls() {
                     source: effectiveJobFile!.source as "fs" | "sd",
                   });
                   selectToolpath(true);
+                  upsertTask({
+                    id: previewTaskId,
+                    type: "gcode-preview",
+                    label: `Preview loaded`,
+                    progress: 100,
+                    status: "completed",
+                  });
                 } catch {
                   // Toolpath load failed — run anyway, just without tracing
+                  upsertTask({
+                    id: previewTaskId,
+                    type: "gcode-preview",
+                    label: `Preview load failed`,
+                    progress: null,
+                    status: "error",
+                  });
+                } finally {
+                  setGcodePreviewLoading(false);
                 }
               }
               await window.terraForge.fluidnc.runFile(
@@ -208,7 +248,7 @@ export function JobControls() {
             }
           },
           "primary",
-          !jobFileValid, // disabled unless a valid G-code file is selected
+          !jobFileValid || gcodePreviewLoading,
           jobFileValid
             ? effectiveJobFile!.source === "local"
               ? `Upload ${effectiveJobFile!.name} to SD card then run`

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -64,6 +64,8 @@ export function PlotCanvas() {
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
   const machineStatus = useMachineStore((s) => s.status);
   const connected = useMachineStore((s) => s.connected);
+  const isJobActive =
+    machineStatus?.state === "Run" || machineStatus?.state === "Hold";
 
   // Activate live plot-progress tracking whenever a toolpath is loaded
   // and the machine is running a job.
@@ -275,7 +277,7 @@ export function PlotCanvas() {
       if (e.key === "Delete" || e.key === "Backspace") {
         if (selectedImportId) {
           removeImport(selectedImportId);
-        } else if (toolpathSelected) {
+        } else if (toolpathSelected && !isJobActive) {
           setGcodeToolpath(null);
           // selectedJobFile is cleared by the gcodeToolpath→null effect below.
         }
@@ -322,6 +324,7 @@ export function PlotCanvas() {
   }, [
     selectedImportId,
     toolpathSelected,
+    isJobActive,
     removeImport,
     selectImport,
     selectToolpath,
@@ -936,40 +939,42 @@ export function PlotCanvas() {
               ).map(([cx, cy], i) => (
                 <circle key={i} cx={cx} cy={cy} r={TP_PIP} fill="#38bdf8" />
               ))}
-              <g
-                transform={`translate(${delSx},${delSy})`}
-                style={{ cursor: "pointer", pointerEvents: "all" }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setGcodeToolpath(null);
-                  if (selectedJobFile?.source === "local")
-                    setSelectedJobFile(null);
-                }}
-              >
-                <svg
-                  x={-TP_HALF}
-                  y={-TP_HALF}
-                  width={TP_HALF * 2}
-                  height={TP_HALF * 2}
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+              {!isJobActive && (
+                <g
+                  transform={`translate(${delSx},${delSy})`}
+                  style={{ cursor: "pointer", pointerEvents: "all" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setGcodeToolpath(null);
+                    if (selectedJobFile?.source === "local")
+                      setSelectedJobFile(null);
+                  }}
                 >
-                  <rect
-                    width="18"
-                    height="18"
-                    x="3"
-                    y="3"
-                    rx="2"
-                    ry="2"
-                    fill="#e94560"
-                    stroke="none"
-                  />
-                  <path d="m15 9-6 6" stroke="white" strokeWidth={2.5} />
-                  <path d="m9 9 6 6" stroke="white" strokeWidth={2.5} />
-                </svg>
-              </g>
+                  <svg
+                    x={-TP_HALF}
+                    y={-TP_HALF}
+                    width={TP_HALF * 2}
+                    height={TP_HALF * 2}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect
+                      width="18"
+                      height="18"
+                      x="3"
+                      y="3"
+                      rx="2"
+                      ry="2"
+                      fill="#e94560"
+                      stroke="none"
+                    />
+                    <path d="m15 9-6 6" stroke="white" strokeWidth={2.5} />
+                    <path d="m9 9 6 6" stroke="white" strokeWidth={2.5} />
+                  </svg>
+                </g>
+              )}
             </svg>
           );
         })()}

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -356,7 +356,13 @@ export function PlotCanvas() {
       });
     } else if (!toolpathSelected && gcodeSource) {
       const current = useMachineStore.getState().selectedJobFile;
-      if (current?.path === gcodeSource.path) {
+      // Only clear selectedJobFile when the toolpath came from a local file.
+      // Remote-file selections (sd/fs) from the file browser should persist
+      // independently of canvas toolpath selection state.
+      if (
+        current?.path === gcodeSource.path &&
+        gcodeSource.source === "local"
+      ) {
         setSelectedJobFile(null);
       }
     }
@@ -974,7 +980,7 @@ export function PlotCanvas() {
         containerSize.w > 0 &&
         (() => {
           // Keep WCO up to date (FluidNC sends it periodically, not every packet).
-          const wcoMatch = machineStatus.raw.match(
+          const wcoMatch = machineStatus.raw?.match(
             /WCO:([-\d.]+),([-\d.]+),([-\d.]+)/,
           );
           if (wcoMatch) {
@@ -985,12 +991,13 @@ export function PlotCanvas() {
             };
           }
           // Prefer WPos: when FluidNC sends it; otherwise derive from MPos − WCO.
-          const hasWPos = /WPos:/.test(machineStatus.raw);
+          const hasWPos =
+            /WPos:/.test(machineStatus.raw ?? "") && machineStatus.wpos != null;
           const penX = hasWPos
-            ? machineStatus.wpos.x
+            ? machineStatus.wpos!.x
             : machineStatus.mpos.x - penWcoRef.current.x;
           const penY = hasWPos
-            ? machineStatus.wpos.y
+            ? machineStatus.wpos!.y
             : machineStatus.mpos.y - penWcoRef.current.y;
           // Convert machine-mm → canvas SVG px (same transform used by the toolpath g).
           const svgX = isCenter
@@ -1031,7 +1038,7 @@ export function PlotCanvas() {
         containerSize.w > 0 &&
         (() => {
           // Keep WCO up to date (FluidNC sends it periodically, not every packet).
-          const wcoMatch = machineStatus.raw.match(
+          const wcoMatch = machineStatus.raw?.match(
             /WCO:([-\d.]+),([-\d.]+),([-\d.]+)/,
           );
           if (wcoMatch) {
@@ -1042,12 +1049,13 @@ export function PlotCanvas() {
             };
           }
           // Prefer WPos: when FluidNC reports it; otherwise derive from MPos − WCO.
-          const hasWPos = /WPos:/.test(machineStatus.raw);
+          const hasWPos =
+            /WPos:/.test(machineStatus.raw ?? "") && machineStatus.wpos != null;
           const penX = hasWPos
-            ? machineStatus.wpos.x
+            ? machineStatus.wpos!.x
             : machineStatus.mpos.x - penWcoRef.current.x;
           const penY = hasWPos
-            ? machineStatus.wpos.y
+            ? machineStatus.wpos!.y
             : machineStatus.mpos.y - penWcoRef.current.y;
           // Convert machine-mm → canvas SVG px (mirrors the toolpath <g> transform).
           const svgX = isCenter

--- a/src/renderer/src/components/PropertiesPanel.tsx
+++ b/src/renderer/src/components/PropertiesPanel.tsx
@@ -65,6 +65,9 @@ export function PropertiesPanel() {
   const toolpathSelected = useCanvasStore((s) => s.toolpathSelected);
   const selectToolpath = useCanvasStore((s) => s.selectToolpath);
   const activeConfig = useMachineStore((s) => s.activeConfig);
+  const machineStatus = useMachineStore((s) => s.status);
+  const isJobActive =
+    machineStatus?.state === "Run" || machineStatus?.state === "Hold";
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [editingName, setEditingName] = useState<{
@@ -168,8 +171,17 @@ export function PropertiesPanel() {
                         {fileName}
                       </span>
                       <button
-                        className="ml-1 text-gray-600 hover:text-[#e94560] shrink-0"
-                        title="Clear toolpath"
+                        className={`ml-1 shrink-0 ${
+                          isJobActive
+                            ? "text-gray-700 opacity-30 cursor-not-allowed"
+                            : "text-gray-600 hover:text-[#e94560]"
+                        }`}
+                        title={
+                          isJobActive
+                            ? "Cannot clear toolpath while job is running"
+                            : "Clear toolpath"
+                        }
+                        disabled={isJobActive}
                         onClick={(e) => {
                           e.stopPropagation();
                           setGcodeToolpath(null);

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -12,7 +12,6 @@ import {
   DEFAULT_HATCH_SPACING_MM,
   DEFAULT_HATCH_ANGLE_DEG,
 } from "../../../types";
-import { JogControls } from "./JogControls";
 import { MachineConfigDialog } from "./MachineConfigDialog";
 import { GcodeOptionsDialog } from "./GcodeOptionsDialog";
 import type { GcodePrefs } from "./GcodeOptionsDialog";
@@ -263,7 +262,12 @@ function getBBox(el: Element): {
   };
 }
 
-export function Toolbar() {
+interface ToolbarProps {
+  showJog: boolean;
+  onToggleJog: () => void;
+}
+
+export function Toolbar({ showJog, onToggleJog }: ToolbarProps) {
   const configs = useMachineStore((s) => s.configs);
   const activeConfigId = useMachineStore((s) => s.activeConfigId);
   const setActiveConfigId = useMachineStore((s) => s.setActiveConfigId);
@@ -289,42 +293,10 @@ export function Toolbar() {
     null,
   );
 
-  const [showJog, setShowJog] = useState(false);
   const [showGcodeDialog, setShowGcodeDialog] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
-  const [jogPos, setJogPos] = useState(() => ({
-    x: Math.max(0, window.innerWidth - 300),
-    y: 60,
-  }));
-  const jogDragRef = useRef<{
-    startX: number;
-    startY: number;
-    panelX: number;
-    panelY: number;
-  } | null>(null);
   const [generating, setGenerating] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
-
-  const startJogDrag = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.currentTarget.setPointerCapture(e.pointerId);
-    jogDragRef.current = {
-      startX: e.clientX,
-      startY: e.clientY,
-      panelX: jogPos.x,
-      panelY: jogPos.y,
-    };
-  };
-  const onJogPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!jogDragRef.current) return;
-    const { startX, startY, panelX, panelY } = jogDragRef.current;
-    setJogPos({
-      x: panelX + e.clientX - startX,
-      y: panelY + e.clientY - startY,
-    });
-  };
-  const onJogPointerUp = () => {
-    jogDragRef.current = null;
-  };
 
   const handleConnect = async () => {
     const cfg = activeConfig();
@@ -966,31 +938,11 @@ export function Toolbar() {
 
       {/* Jog toggle */}
       <button
-        onClick={() => setShowJog((v) => !v)}
+        onClick={onToggleJog}
         className={`px-3 py-1 rounded text-sm transition-colors ${showJog ? "bg-[#e94560]" : "bg-[#0f3460] hover:bg-[#1a4a8a]"}`}
       >
         Jog
       </button>
-
-      {showJog && (
-        <div
-          className="fixed z-50 bg-[#16213e] border border-[#0f3460] rounded-lg shadow-2xl overflow-hidden"
-          style={{ left: jogPos.x, top: jogPos.y }}
-          onPointerMove={onJogPointerMove}
-          onPointerUp={onJogPointerUp}
-          onPointerCancel={onJogPointerUp}
-        >
-          {/* Drag handle */}
-          <div
-            className="h-2.5 w-full cursor-grab active:cursor-grabbing bg-[#0f3460]/50 hover:bg-[#0f3460] transition-colors"
-            title="Drag to move"
-            onPointerDown={startJogDrag}
-          />
-          <div className="p-4">
-            <JogControls onClose={() => setShowJog(false)} />
-          </div>
-        </div>
-      )}
 
       {/* Connection status indicator */}
       <div className="ml-auto flex items-center gap-3">

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -263,11 +263,14 @@ function getBBox(el: Element): {
 }
 
 interface ToolbarProps {
-  showJog: boolean;
-  onToggleJog: () => void;
+  showJog?: boolean;
+  onToggleJog?: () => void;
 }
 
-export function Toolbar({ showJog, onToggleJog }: ToolbarProps) {
+export function Toolbar({
+  showJog = false,
+  onToggleJog = () => {},
+}: ToolbarProps = {}) {
   const configs = useMachineStore((s) => s.configs);
   const activeConfigId = useMachineStore((s) => s.activeConfigId);
   const setActiveConfigId = useMachineStore((s) => s.setActiveConfigId);

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -773,6 +773,11 @@ export function Toolbar() {
           status: "completed",
         });
 
+        // ── Load toolpath preview into canvas (enables tracing during job) ──
+        const toolpath = parseGcode(msg.gcode);
+        setGcodeToolpath(toolpath);
+        selectToolpath(true);
+
         // ── Upload to SD card (if opted in and connected) ─────────────────
         if (prefs.uploadToSd && useMachineStore.getState().connected) {
           const uploadTaskId = uuid();
@@ -789,6 +794,11 @@ export function Toolbar() {
               source: "sd",
               name: defaultFilename,
             });
+            setGcodeSource({
+              path: remotePath,
+              name: defaultFilename,
+              source: "sd",
+            });
           } catch {
             // Upload error is already surfaced via the upload task toast
           }
@@ -800,6 +810,11 @@ export function Toolbar() {
             await window.terraForge.fs.saveGcodeDialog(defaultFilename);
           if (savePath) {
             await window.terraForge.fs.writeFile(savePath, msg.gcode);
+            setGcodeSource({
+              path: savePath,
+              name: defaultFilename,
+              source: "local",
+            });
           }
         }
       } else if (msg.type === "cancelled") {

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -53,6 +53,9 @@ interface CanvasState {
   ) => void;
   toggleCentreMarker: () => void;
   toVectorObjects: () => VectorObject[];
+  /** True while a G-code preview is being fetched/parsed before a job starts. */
+  gcodePreviewLoading: boolean;
+  setGcodePreviewLoading: (loading: boolean) => void;
   /** Update the live plot-progress overlay paths. */
   setPlotProgress: (cuts: string, rapids: string) => void;
   /** Reset progress overlay (called when toolpath changes or job clears). */
@@ -77,6 +80,11 @@ export const useCanvasStore = create<CanvasState>()(
     showCentreMarker: true,
     plotProgressCuts: "",
     plotProgressRapids: "",
+    gcodePreviewLoading: false,
+    setGcodePreviewLoading: (loading) =>
+      set((state) => {
+        state.gcodePreviewLoading = loading;
+      }),
 
     addImport: (imp) =>
       set((state) => {

--- a/src/renderer/src/utils/usePlotProgress.ts
+++ b/src/renderer/src/utils/usePlotProgress.ts
@@ -248,7 +248,7 @@ export function usePlotProgress(): void {
     const prevState = prevStateRef.current;
 
     // ── Keep WCO up to date (sent periodically by FluidNC, not every packet) ─
-    const wcoMatch = raw.match(/WCO:([-\d.]+),([-\d.]+),([-\d.]+)/);
+    const wcoMatch = raw?.match(/WCO:([-\d.]+),([-\d.]+),([-\d.]+)/);
     if (wcoMatch) {
       wcoRef.current = { x: +wcoMatch[1], y: +wcoMatch[2], z: +wcoMatch[3] };
     }
@@ -256,7 +256,7 @@ export function usePlotProgress(): void {
     // ── Compute true work position ─────────────────────────────────────────
     // Prefer WPos: if FluidNC sends it (controlled by $10 bitmask).
     // Otherwise derive from MPos − WCO (correct after "Set Zero").
-    const wposRaw = raw.match(/WPos:([-\d.]+),([-\d.]+),([-\d.]+)/);
+    const wposRaw = raw?.match(/WPos:([-\d.]+),([-\d.]+),([-\d.]+)/);
     const wpos = wposRaw
       ? { x: +wposRaw[1], y: +wposRaw[2] }
       : { x: mpos.x - wcoRef.current.x, y: mpos.y - wcoRef.current.y };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,6 +158,7 @@ export interface GcodeOptions {
 export type TaskType =
   | "svg-parse"
   | "gcode-generate"
+  | "gcode-preview"
   | "file-upload"
   | "file-download"
   | "file-delete"

--- a/tests/component/JobControls.test.tsx
+++ b/tests/component/JobControls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMachineStore } from "@renderer/store/machineStore";
 import { useTaskStore } from "@renderer/store/taskStore";
@@ -186,9 +186,14 @@ describe("JobControls", () => {
     });
     render(<JobControls />);
     await userEvent.click(screen.getByText("▶ Start job"));
-    expect(window.terraForge.fluidnc.runFile).toHaveBeenCalledWith(
-      "/test.gcode",
-      "sd",
+    // fetchFileText + 600ms cosmetic pause precede runFile — wait for it
+    await waitFor(
+      () =>
+        expect(window.terraForge.fluidnc.runFile).toHaveBeenCalledWith(
+          "/test.gcode",
+          "sd",
+        ),
+      { timeout: 2000 },
     );
   });
 

--- a/tests/component/Toolbar.test.tsx
+++ b/tests/component/Toolbar.test.tsx
@@ -268,13 +268,10 @@ describe("Toolbar", () => {
       activeConfigId: cfg.id,
       connected: true,
     });
-    render(<Toolbar />);
-    // Click Jog to show panel
+    const onToggleJog = vi.fn();
+    render(<Toolbar showJog={false} onToggleJog={onToggleJog} />);
     await userEvent.click(screen.getByText("Jog"));
-    expect(screen.getByText("Jog Controls")).toBeInTheDocument();
-    // Click again to hide
-    await userEvent.click(screen.getByText("Jog"));
-    expect(screen.queryByText("Jog Controls")).not.toBeInTheDocument();
+    expect(onToggleJog).toHaveBeenCalledTimes(1);
   });
 
   // ── Settings dialog toggle ────────────────────────────────────────────

--- a/tests/e2e/gcode-preview.spec.ts
+++ b/tests/e2e/gcode-preview.spec.ts
@@ -1,0 +1,364 @@
+/**
+ * E2E: G-code auto-preview + file browser job controls.
+ *
+ * Covers four feature areas introduced together:
+ *
+ * 1. GcodeOptionsDialog defaults — "Upload to SD card" is on, "Save to
+ *    computer" is off, so the common workflow (generate → upload) works with
+ *    zero extra clicks.
+ *
+ * 2. G-code import auto-loads toolpath — importing a .gcode file immediately
+ *    parses and displays its toolpath and queues it as the active job.
+ *
+ * 3. Auto-preview before start — when the user clicks "Start job" for a
+ *    remote file that has no toolpath loaded yet (e.g. the SVG layer was
+ *    deleted after generation, or the file was selected from the file browser
+ *    without first clicking Preview), the app automatically fetches the file
+ *    from the machine, parses it, and loads the preview *before* issuing the
+ *    run command.  The "Loading preview…" bar is visible during this phase.
+ *
+ * 4. File browser job-button states — while a job is running the selected
+ *    file's action buttons are permanently visible and the play ▶ button
+ *    becomes a pause ⏸ button.  Other gcode files have their action buttons
+ *    (preview, play, download, delete) disabled for the duration of the job.
+ *
+ * Tests in groups 3 and 4 use IPC mocking to simulate a connected machine
+ * and a running job without requiring real hardware.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  fixturePath,
+  mockOpenDialog,
+  mockIpcInvoke,
+  pushRendererEvent,
+} from "./helpers";
+import type { ElectronApplication, Page } from "playwright";
+
+// ── Shared app instance ────────────────────────────────────────────────────────
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userDataDir: string;
+
+// ── Test fixtures ──────────────────────────────────────────────────────────────
+
+/** Machine config returned by the mocked getMachineConfigs IPC handler. */
+const TEST_CONFIG = {
+  id: "e2e-machine",
+  name: "E2E Test Machine",
+  connection: {
+    type: "wifi" as const,
+    host: "127.0.0.1",
+    port: 80,
+    wsPort: 81,
+  },
+  bedWidth: 300,
+  bedHeight: 300,
+  penUpCommand: "M3 S0",
+  penDownCommand: "M3 S1",
+  penType: "solenoid" as const,
+  maxSpeed: 3000,
+  travelSpeed: 3000,
+};
+
+/** Two .gcode files returned by the mocked SD-card listing. */
+const SD_FILES = [
+  { name: "job.gcode", path: "/job.gcode", size: 1024, isDirectory: false },
+  { name: "other.gcode", path: "/other.gcode", size: 512, isDirectory: false },
+];
+
+/** Minimal G-code content returned when the app fetches a remote file. */
+const REMOTE_GCODE =
+  "G21\nG90\nG0 Z5\nM3 S0\nG0 X0 Y0\nG1 X50 Y50 F1000\nM3 S0\nG0 X0 Y0\nM2\n";
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp());
+
+  // ── Static IPC mocks (JSON-serializable, set up before reload) ─────────────
+  // Provide the test machine config so the toolbar dropdown is populated.
+  await mockIpcInvoke(electronApp, "config:getMachineConfigs", [TEST_CONFIG]);
+
+  // Connect succeeds immediately — no real machine required.
+  await mockIpcInvoke(electronApp, "fluidnc:connectWebSocket", undefined);
+
+  // SD card file listing returns our two test files.
+  await mockIpcInvoke(electronApp, "fluidnc:listSDFiles", SD_FILES);
+  await mockIpcInvoke(electronApp, "fluidnc:listFiles", []);
+
+  // runFile resolves immediately (we check state *before* this is called).
+  await mockIpcInvoke(electronApp, "fluidnc:runFile", undefined);
+  await mockIpcInvoke(electronApp, "fluidnc:pauseJob", undefined);
+
+  // fetchFileText has a 1.5 s delay so the "Loading preview…" bar is visible
+  // long enough for assertions to catch it.
+  await electronApp.evaluate(({ ipcMain }, gcode) => {
+    ipcMain.removeHandler("fluidnc:fetchFileText");
+    ipcMain.handle(
+      "fluidnc:fetchFileText",
+      () => new Promise<string>((res) => setTimeout(() => res(gcode), 1500)),
+    );
+  }, REMOTE_GCODE);
+
+  // Reload so the app re-runs its mount effect with the mocked configs.
+  await window.reload();
+  await window.waitForLoadState("domcontentloaded");
+  await window.locator("text=terraForge").first().waitFor({ timeout: 15_000 });
+
+  // ── Connect to the mocked machine ─────────────────────────────────────────
+  // Select the test machine in the toolbar dropdown.
+  await window.locator("select").selectOption({ label: TEST_CONFIG.name });
+
+  // Click Connect — the mocked handler resolves immediately.
+  await window.locator("button:has-text('Connect')").click();
+
+  // Wait for the toolbar to show "Connected" / the SD card pane to refresh.
+  await expect(window.locator("text=Connected").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // The SD card list is populated by the connection trigger — wait for files.
+  await expect(window.locator("text=job.gcode").first()).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test.afterAll(async () => {
+  if (electronApp) await closeApp(electronApp, userDataDir);
+});
+
+// ── Group 1: GcodeOptionsDialog defaults ─────────────────────────────────────
+
+test("GcodeOptionsDialog: 'Upload to SD card' is checked by default", async () => {
+  // Import an SVG so the Generate G-code button is enabled.
+  await mockOpenDialog(electronApp, fixturePath("sample.svg"));
+  await window.locator("button:has-text('Import')").click();
+  await expect(window.locator("text=sample").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await window.locator("button:has-text('Generate G-code')").click();
+  await expect(window.locator("button:has-text('Cancel')")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const uploadCheckbox = window.locator(
+    "label:has-text('Upload to SD card') input[type='checkbox']",
+  );
+  await expect(uploadCheckbox).toBeChecked();
+
+  await window.locator("button:has-text('Cancel')").click();
+});
+
+test("GcodeOptionsDialog: 'Save to computer' is unchecked by default", async () => {
+  await window.locator("button:has-text('Generate G-code')").click();
+  await expect(window.locator("button:has-text('Cancel')")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const saveCheckbox = window.locator(
+    "label:has-text('Save to computer') input[type='checkbox']",
+  );
+  await expect(saveCheckbox).not.toBeChecked();
+
+  await window.locator("button:has-text('Cancel')").click();
+});
+
+// ── Group 2: G-code import auto-loads toolpath ────────────────────────────────
+
+test("importing a .gcode file loads its toolpath and shows the canvas preview", async () => {
+  await mockOpenDialog(electronApp, fixturePath("sample.gcode"));
+  await window.locator("button:has-text('Import')").click();
+
+  // After import, the canvas should display the G-code toolpath overlay.
+  // The toolpath is rendered as a polyline/path inside the SVG canvas.
+  const canvas = window.locator("svg").first();
+  await expect(canvas).toBeVisible({ timeout: 10_000 });
+
+  // The Job panel must show the imported filename.
+  await expect(window.locator("text=sample.gcode").first()).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("imported .gcode file is shown with '(local — will upload)' source indicator", async () => {
+  // The Job panel's file indicator shows this text for locally-sourced files.
+  const indicator = window.locator("text=local — will upload").first();
+  await expect(indicator).toBeVisible({ timeout: 5_000 });
+});
+
+test("Start job button is enabled after importing a .gcode file", async () => {
+  // Machine is connected; a valid .gcode file is selected — Start should be enabled.
+  // (The button is disabled until connected AND a valid file is selected.)
+  const startBtn = window.locator("button:has-text('Start job')");
+  await expect(startBtn).toBeEnabled({ timeout: 5_000 });
+});
+
+// ── Group 3: Auto-preview before start ───────────────────────────────────────
+//
+// The auto-preview path in JobControls is triggered when the selected job file
+// is a remote file (source "sd"/"fs") and its toolpath has not been loaded yet.
+// We simulate this by clicking a remote file in the SD-card file browser to
+// set it as the selected job WITHOUT loading its toolpath, then clicking Start.
+
+test("clicking a remote gcode file in the file browser selects it as the job", async () => {
+  // Use the data-testid row to avoid ambiguous text matches.
+  const jobRow = window.locator("[data-testid='file-row-job.gcode']");
+
+  // If the row is already selected (blue highlight), clicking would deselect it.
+  // Ensure it ends up selected regardless of prior state.
+  const isBlueBg = await jobRow.evaluate((el) =>
+    el.className.includes("bg-[#1a3a6e]"),
+  );
+  if (!isBlueBg) {
+    await jobRow.click();
+    await window.waitForTimeout(200);
+  }
+
+  // The Job panel should now show the filename (overriding the local import).
+  await expect(window.locator("text=job.gcode").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // It should NOT show the "(local — will upload)" indicator for a remote file.
+  await expect(window.locator("text=local — will upload")).not.toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+test("clicking Start job for a remote file without a prior toolpath shows 'Loading preview…'", async () => {
+  // Ensure job.gcode is the selected job file (from previous test).
+  // The fetchFileText mock adds a 1.5 s delay, giving us time to assert.
+  const startBtn = window.locator("button:has-text('Start job')");
+  await expect(startBtn).toBeEnabled({ timeout: 5_000 });
+
+  await startBtn.click();
+
+  // The "Loading preview…" bar should appear in the Job panel while the
+  // toolpath is being fetched from the machine.
+  const loadingBar = window.locator("text=Loading preview…").first();
+  await expect(loadingBar).toBeVisible({ timeout: 5_000 });
+});
+
+test("'Loading preview…' bar disappears once the toolpath has been fetched", async () => {
+  // After the 1.5 s mock delay the preview is loaded and the bar clears.
+  const loadingBar = window.locator("text=Loading preview…").first();
+  await expect(loadingBar).not.toBeVisible({ timeout: 10_000 });
+});
+
+// ── Group 4: File browser job-button states during a running job ──────────────
+//
+// Machine status is injected via the fluidnc:status IPC channel.  After the
+// status push the machineStore's status.state becomes "Run", which changes
+// which buttons the file browser renders for the running file vs other files.
+
+test("file browser: play ▶ becomes pause ⏸ for the running file", async () => {
+  // Ensure job.gcode is selected.  If the row already has the blue highlight,
+  // leave it alone; otherwise click to select and wait for the highlight.
+  const jobRow = window.locator("[data-testid='file-row-job.gcode']");
+  const isBlueBg = await jobRow.evaluate((el) =>
+    el.className.includes("bg-[#1a3a6e]"),
+  );
+  if (!isBlueBg) {
+    await jobRow.click();
+    // Wait for the selection to register (blue highlight appears).
+    await window.waitForFunction(
+      () =>
+        document
+          .querySelector("[data-testid='file-row-job.gcode']")
+          ?.className.includes("bg-[#1a3a6e]"),
+      { timeout: 5_000 },
+    );
+  }
+
+  // Simulate a running job.
+  await pushRendererEvent(electronApp, "fluidnc:status", {
+    state: "Run",
+    mpos: { x: 10, y: 10, z: 0 },
+  });
+
+  // The pause ⏸ button should now be visible in job.gcode's action container.
+  const pauseBtn = window.locator(
+    "[data-testid='file-actions-job.gcode'] button[title='Pause job']",
+  );
+  await expect(pauseBtn).toBeVisible({ timeout: 5_000 });
+});
+
+test("file browser: play ▶ button is not shown for the running file", async () => {
+  // The ▶ "Run job now" button should not be present — it's replaced by ⏸.
+  const playBtn = window.locator(
+    "[data-testid='file-actions-job.gcode'] button[title='Run job now']",
+  );
+  await expect(playBtn).not.toBeVisible({ timeout: 3_000 });
+});
+
+test("file browser: action buttons are visible without hover for the running file", async () => {
+  // The action container is flex (not hidden group-hover:flex) while the job runs.
+  const actionsDiv = window.locator("[data-testid='file-actions-job.gcode']");
+  await expect(actionsDiv).toBeVisible({ timeout: 3_000 });
+
+  const pauseBtn = actionsDiv.locator("button[title='Pause job']");
+  await expect(pauseBtn).toBeVisible({ timeout: 3_000 });
+});
+
+test("file browser: other gcode files have their download button disabled during a running job", async () => {
+  // Hover to reveal hidden action buttons, then check the title changes to
+  // "Unavailable while a job is running" and the button is disabled.
+  const otherRow = window.locator("[data-testid='file-row-other.gcode']");
+  await otherRow.hover();
+
+  const downloadBtn = window
+    .locator(
+      "[data-testid='file-actions-other.gcode'] button[title='Unavailable while a job is running']",
+    )
+    .first();
+  await expect(downloadBtn).toBeDisabled({ timeout: 3_000 });
+});
+
+test("file browser: other gcode files have their delete button disabled during a running job", async () => {
+  const otherRow = window.locator("[data-testid='file-row-other.gcode']");
+  await otherRow.hover();
+
+  // All action buttons for the non-running file should be disabled.
+  const actionsDiv = window.locator("[data-testid='file-actions-other.gcode']");
+  const buttons = actionsDiv.locator("button");
+  const count = await buttons.count();
+  expect(count).toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    await expect(buttons.nth(i)).toBeDisabled({ timeout: 3_000 });
+  }
+});
+
+test("file browser: other gcode files have their preview button disabled during a running job", async () => {
+  const otherRow = window.locator("[data-testid='file-row-other.gcode']");
+  await otherRow.hover();
+
+  const previewBtn = window.locator(
+    "[data-testid='file-actions-other.gcode'] button[title='Preview toolpath']",
+  );
+  const count = await previewBtn.count();
+  if (count > 0) {
+    await expect(previewBtn.first()).toBeDisabled({ timeout: 3_000 });
+  }
+});
+
+// ── Group 5: Post-job: play returns when job ends ────────────────────────────
+
+test("file browser: pause ⏸ reverts to play ▶ when the job ends (Idle)", async () => {
+  // Simulate the machine returning to Idle.
+  await pushRendererEvent(electronApp, "fluidnc:status", {
+    state: "Idle",
+    mpos: { x: 0, y: 0, z: 0 },
+  });
+
+  await window.waitForTimeout(300);
+
+  // The running file row should no longer show the pause button.
+  const pauseBtn = window.locator(
+    "[data-testid='file-actions-job.gcode'] button[title='Pause job']",
+  );
+  await expect(pauseBtn).not.toBeVisible({ timeout: 5_000 });
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -173,3 +173,42 @@ export async function screenshot(window: Page, name: string): Promise<Buffer> {
     path: path.join(ROOT, "test-results", `${name}.png`),
   });
 }
+
+/**
+ * Mock an IPC `invoke` handler in the Electron main process so that the next
+ * (and all subsequent) calls to `ipcRenderer.invoke(channel)` return
+ * `returnValue` without reaching the real handler.
+ *
+ * The value must be JSON-serializable.
+ */
+export async function mockIpcInvoke(
+  electronApp: ElectronApplication,
+  channel: string,
+  returnValue: unknown,
+): Promise<void> {
+  await electronApp.evaluate(
+    ({ ipcMain }, { ch, val }) => {
+      ipcMain.removeHandler(ch);
+      ipcMain.handle(ch, async () => val);
+    },
+    { ch: channel, val: returnValue },
+  );
+}
+
+/**
+ * Push an IPC event from the main process to the renderer, simulating a live
+ * data push (e.g. machine status updates, console messages).
+ */
+export async function pushRendererEvent(
+  electronApp: ElectronApplication,
+  channel: string,
+  payload: unknown,
+): Promise<void> {
+  await electronApp.evaluate(
+    ({ BrowserWindow }, { ch, p }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      win?.webContents.send(ch, p);
+    },
+    { ch: channel, p: payload },
+  );
+}

--- a/tests/e2e/launch.spec.ts
+++ b/tests/e2e/launch.spec.ts
@@ -147,13 +147,16 @@ test("SVG canvas element is present", async () => {
 
 test("clicking Jog shows the jog controls panel, clicking again hides it", async () => {
   const jogBtn = window.locator("button:has-text('Jog')");
-
-  // Open
-  await jogBtn.click();
   const jogPanel = window.locator("text=Jog Controls").first();
+
+  // Panel is open by default
   await expect(jogPanel).toBeVisible({ timeout: 3000 });
 
   // Close
   await jogBtn.click();
   await expect(jogPanel).not.toBeVisible({ timeout: 3000 });
+
+  // Re-open
+  await jogBtn.click();
+  await expect(jogPanel).toBeVisible({ timeout: 3000 });
 });


### PR DESCRIPTION
This pull request introduces several improvements focused on graceful resource management, robust inter-process communication, and enhanced user experience in the UI primarily focused on gcode preview behaviour. The most significant additional changes include ensuring the FluidNC WebSocket is closed gracefully to prevent hardware issues, introducing a safe mechanism for sending IPC messages, and enhancing the jog controls and file/job management in the UI.

**Resource Management and Stability:**

* The FluidNC WebSocket is now closed gracefully on app exit, sending a proper close frame instead of a TCP RST, which prevents the ESP32's WS server from becoming wedged and requiring a power cycle. (`src/machine/fluidnc.ts`, `src/main/index.ts`) [[1]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR592-L593) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR65-R72)
* Added cancellation of reconnect timers and improved state tracking in the FluidNC client during disconnects. (`src/machine/fluidnc.ts`)

**Inter-Process Communication Improvements:**

* Introduced a `safeSend` function to prevent sending IPC messages to destroyed renderer windows, avoiding errors during shutdown or window closure. All relevant event and task update emissions now use this guard. (`src/main/index.ts`) [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR82-R126) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL362-R390) [[3]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL389-R409) [[4]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL419-R439) [[5]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL440-R460) [[6]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL620-R651)

**UI/UX Enhancements:**

* Added a draggable, floating jog panel that can be toggled from the toolbar, improving accessibility and customization of jog controls. (`src/renderer/src/App.tsx`) [[1]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL1-R8) [[2]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR21-R63) [[3]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL60-R104) [[4]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL70-R114) [[5]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR130-R152)
* Improved job and toolpath management in the file browser: 
  - Tracks which file is actively running, so pause/resume controls only appear for the correct file.
  - Loads toolpaths before job start (with preview progress feedback and error handling), and prompts the user before replacing an active toolpath. (`src/renderer/src/components/FileBrowserPanel.tsx`) [[1]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR117-R136) [[2]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR166-R197) [[3]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR232-R239) [[4]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR255-R271) [[5]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR285-R372) [[6]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR386-R394)

**Minor Fixes:**

* Fixed a UI bug where machine coordinates would display even if unavailable, by checking for the presence of `wpos`. (`src/renderer/src/components/ConsolePanel.tsx`)