### PR TITLE
Remove redundant text from gcode generation toast

### DIFF
--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -703,9 +703,7 @@ export function Toolbar({
     upsertTask({
       id: taskId,
       type: "gcode-generate",
-      label: prefs.optimise
-        ? "Generating G-code (optimised)"
-        : "Generating G-code",
+      label: "Generating G-code",
       progress: 0,
       status: "running",
     });
@@ -716,9 +714,7 @@ export function Toolbar({
         upsertTask({
           id: taskId,
           type: "gcode-generate",
-          label: prefs.optimise
-            ? "Generating G-code (optimised)"
-            : "Generating G-code",
+          label: "Generating G-code",
           progress: msg.percent,
           status: "running",
         });


### PR DESCRIPTION
Text seems pointless now and is truncated anyway so removing.