### PR TITLE
Render & gcode generation optimization

### DIFF
--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -796,11 +796,11 @@ export function PlotCanvas() {
 
       if (!gcodeToolpath) return;
 
-      // Per-frame draw-call budgets: cuts and rapids have independent caps
-      // so rapid moves can never crowd out the more important cut paths.
-      // 150 k cut + 50 k rapid keeps a single frame well under GPU timeout limits.
-      const MAX_CUT_CALLS = 150_000;
-      const MAX_RAPID_CALLS = 50_000;
+      // Safety draw-call budgets — viewport culling below means these are
+      // only reached if an extraordinary number of paths land inside the
+      // visible area simultaneously (i.e. fully zoomed-out on a dense file).
+      const MAX_CUT_CALLS = 500_000;
+      const MAX_RAPID_CALLS = 150_000;
 
       ctx.save();
       ctx.setTransform(a, 0, 0, d, e, f);
@@ -817,6 +817,17 @@ export function PlotCanvas() {
       const lodMm = LOD_PX / pxPerMm;
       const lodMm2 = lodMm * lodMm;
 
+      // ── Viewport bounds in G-code mm ────────────────────────────────────────
+      // Invert the canvas transform (buffer px → G-code mm) so we can cull
+      // paths that are entirely outside the visible area.  A 20 mm padding
+      // ensures paths whose first point is off-screen but whose stroke enters
+      // the viewport are not incorrectly discarded.
+      const VP_PAD_MM = 20;
+      const vpL = Math.min((0 - e) / a, (physW - e) / a) - VP_PAD_MM;
+      const vpR = Math.max((0 - e) / a, (physW - e) / a) + VP_PAD_MM;
+      const vpT = Math.min((0 - f) / d, (physH - f) / d) - VP_PAD_MM;
+      const vpB = Math.max((0 - f) / d, (physH - f) / d) + VP_PAD_MM;
+
       // ── Cut moves first (pen-down strokes, solid blue) ────────────────────
       // Drawn before rapids so the cut budget is never consumed by rapid moves.
       if (gcodeToolpath.cutPaths.length > 0) {
@@ -828,6 +839,22 @@ export function PlotCanvas() {
         for (const path of gcodeToolpath.cutPaths) {
           if (cutCalls >= MAX_CUT_CALLS) break;
           if (path.length < 4) continue;
+
+          // Viewport cull: compute path bounding box and skip if entirely
+          // outside the visible area.  O(n) per path but cheaper than drawing.
+          let pMinX = path[0],
+            pMaxX = path[0],
+            pMinY = path[1],
+            pMaxY = path[1];
+          for (let i = 2; i < path.length; i += 2) {
+            if (path[i] < pMinX) pMinX = path[i];
+            else if (path[i] > pMaxX) pMaxX = path[i];
+            if (path[i + 1] < pMinY) pMinY = path[i + 1];
+            else if (path[i + 1] > pMaxY) pMaxY = path[i + 1];
+          }
+          if (pMaxX < vpL || pMinX > vpR || pMaxY < vpT || pMinY > vpB)
+            continue;
+
           ctx.moveTo(path[0], path[1]);
           let lastX = path[0],
             lastY = path[1];
@@ -860,6 +887,13 @@ export function PlotCanvas() {
             y0 = rp[i + 1],
             x1 = rp[i + 2],
             y1 = rp[i + 3];
+          // Viewport cull for rapid segments.
+          const rMinX = x0 < x1 ? x0 : x1,
+            rMaxX = x0 > x1 ? x0 : x1;
+          const rMinY = y0 < y1 ? y0 : y1,
+            rMaxY = y0 > y1 ? y0 : y1;
+          if (rMaxX < vpL || rMinX > vpR || rMaxY < vpT || rMinY > vpB)
+            continue;
           const dx = x1 - x0,
             dy = y1 - y0;
           if (dx * dx + dy * dy >= lodMm2) {

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -644,6 +644,16 @@ export function PlotCanvas() {
   // every viewport update).
   const toolpathCanvasRef = useRef<HTMLCanvasElement>(null);
 
+  // Cache of combined Path2D geometry per import, keyed by import ID.
+  // Invalidated when imp.paths reference changes (immer creates a new array on
+  // any mutation). Two entries per import: outline strokes + hatch lines.
+  const importPath2DCacheRef = useRef(
+    new Map<
+      string,
+      { pathsRef: SvgImport["paths"]; outline: Path2D; hatch: Path2D }
+    >(),
+  );
+
   // Lazy Path2D cache for the two live plot-progress overlay strings.
   // Using a ref-held object avoids stale-closure issues while still preventing
   // Path2D reconstruction on every viewport change (only on string change).
@@ -709,6 +719,80 @@ export function PlotCanvas() {
       ctx.fillStyle = "#0d1117";
       ctx.fillRect(bedXMin, bedYMin, bedXMax - bedXMin, bedYMax - bedYMin);
       ctx.restore();
+
+      // ── SVG imports (canvas-rendered to avoid SVG DOM layout cost) ────────────
+      // Paths are rendered here; invisible hit-area rects remain in the SVG
+      // for drag/click interaction.  Combined Path2D per import is built once
+      // and cached; rebuilt only when imp.paths reference changes.
+      {
+        const vpA = vp.zoom * dpr;
+        const vpE = vp.panX * dpr;
+        const vpF = vp.panY * dpr;
+        // Prune cache entries for imports that no longer exist.
+        for (const id of importPath2DCacheRef.current.keys()) {
+          if (!imports.some((imp) => imp.id === id))
+            importPath2DCacheRef.current.delete(id);
+        }
+        for (const imp of imports) {
+          if (!imp.visible) continue;
+          // Build or retrieve combined Path2D objects for this import.
+          let impCache = importPath2DCacheRef.current.get(imp.id);
+          if (!impCache || impCache.pathsRef !== imp.paths) {
+            const outlineD = imp.paths
+              .filter((p) => p.visible && p.outlineVisible !== false)
+              .map((p) => p.d)
+              .join(" ");
+            const hatchD = imp.paths
+              .filter((p) => p.visible && (p.hatchLines?.length ?? 0) > 0)
+              .flatMap((p) => p.hatchLines!)
+              .join(" ");
+            impCache = {
+              pathsRef: imp.paths,
+              outline: new Path2D(outlineD),
+              hatch: new Path2D(hatchD),
+            };
+            importPath2DCacheRef.current.set(imp.id, impCache);
+          }
+
+          const impSX = (imp.scaleX ?? imp.scale) * MM_TO_PX;
+          const impSY = (imp.scaleY ?? imp.scale) * MM_TO_PX;
+          const vbX = imp.viewBoxX ?? 0;
+          const vbY = imp.viewBoxY ?? 0;
+          const left = PAD + imp.x * MM_TO_PX;
+          const impTop = isBottom
+            ? canvasH -
+              PAD -
+              (imp.y + imp.svgHeight * (imp.scaleY ?? imp.scale)) * MM_TO_PX
+            : PAD +
+              (imp.y + imp.svgHeight * (imp.scaleY ?? imp.scale)) * MM_TO_PX;
+          const bboxW = imp.svgWidth * impSX;
+          const bboxH = imp.svgHeight * impSY;
+          const cxSvg = left + bboxW / 2;
+          const cySvg = impTop + bboxH / 2;
+          const deg = imp.rotation ?? 0;
+          // Effective pixels-per-user-unit: used to emulate non-scaling-stroke.
+          const avgImpScale =
+            Math.sqrt(Math.abs(impSX) * Math.abs(impSY)) * vp.zoom;
+          const isImpSelected = imp.id === selectedImportId;
+
+          ctx.save();
+          ctx.setTransform(vpA, 0, 0, vpA, vpE, vpF);
+          ctx.translate(cxSvg, cySvg);
+          if (deg !== 0) ctx.rotate((deg * Math.PI) / 180);
+          ctx.scale(impSX, impSY);
+          ctx.translate(-(vbX + imp.svgWidth / 2), -(vbY + imp.svgHeight / 2));
+          ctx.setLineDash([]);
+          // Outline paths
+          ctx.strokeStyle = isImpSelected ? "#60a0ff" : "#3a6aaa";
+          ctx.lineWidth = 1.5 / avgImpScale;
+          ctx.stroke(impCache.outline);
+          // Hatch fill lines
+          ctx.strokeStyle = isImpSelected ? "#4a88cc" : "#2a5a8a";
+          ctx.lineWidth = 0.8 / avgImpScale;
+          ctx.stroke(impCache.hatch);
+          ctx.restore();
+        }
+      }
 
       if (!gcodeToolpath) return;
 
@@ -855,6 +939,9 @@ export function PlotCanvas() {
     bedYMin,
     bedXMax,
     bedYMax,
+    imports,
+    selectedImportId,
+    canvasH,
   ]);
 
   // ── Cursor ────────────────────────────────────────────────────────────────────
@@ -1647,31 +1734,7 @@ function ImportLayer({
         onMouseDown={(e) => onImportMouseDown(e, imp.id)}
         style={{ cursor: "grab" }}
       >
-        {imp.paths
-          .filter((p) => p.visible)
-          .map((p) => (
-            <g key={p.id}>
-              {p.outlineVisible !== false && (
-                <path
-                  d={p.d}
-                  fill="none"
-                  stroke={selected ? "#60a0ff" : "#3a6aaa"}
-                  strokeWidth={1.5}
-                  vectorEffect="non-scaling-stroke"
-                />
-              )}
-              {p.hatchLines?.map((hl, i) => (
-                <path
-                  key={i}
-                  d={hl}
-                  fill="none"
-                  stroke={selected ? "#4a88cc" : "#2a5a8a"}
-                  strokeWidth={0.8}
-                  vectorEffect="non-scaling-stroke"
-                />
-              ))}
-            </g>
-          ))}
+        {/* Paths rendered on canvas overlay — no SVG <path> elements here */}
         {/* Hit-test rect covering the whole viewBox */}
         <rect
           x={vbX}

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -670,18 +670,20 @@ export function PlotCanvas() {
       if (!ctx) return;
 
       // Resize backing store for current container dimensions + DPR.
+      // Cap at 8192 px to avoid allocating beyond typical GPU texture limits.
       const dpr = window.devicePixelRatio || 1;
-      const physW = Math.round(containerSize.w * dpr);
-      const physH = Math.round(containerSize.h * dpr);
+      const physW = Math.min(Math.round(containerSize.w * dpr), 8192);
+      const physH = Math.min(Math.round(containerSize.h * dpr), 8192);
       if (canvas.width !== physW || canvas.height !== physH) {
         canvas.width = physW;
         canvas.height = physH;
       }
       ctx.clearRect(0, 0, physW, physH);
-      if (!gcodeToolpath) return;
 
       // ── Transform: G-code mm → physical canvas pixels ──────────────────────
-      // Matches the coordinate system of the SVG <g transform> on the toolpath.
+      // Computed before the toolpath guard so the bed background is always
+      // painted. The SVG bed <rect> uses fill="none", allowing the canvas layer
+      // to show through and provide the dark bed background.
       const tx = isCenter
         ? PAD + (bedW / 2) * MM_TO_PX
         : isRight
@@ -701,6 +703,21 @@ export function PlotCanvas() {
       const e = (tx * vp.zoom + vp.panX) * dpr;
       const f = (ty * vp.zoom + vp.panY) * dpr;
 
+      // Always paint the bed background — visible with or without a toolpath.
+      ctx.save();
+      ctx.setTransform(a, 0, 0, d, e, f);
+      ctx.fillStyle = "#0d1117";
+      ctx.fillRect(bedXMin, bedYMin, bedXMax - bedXMin, bedYMax - bedYMin);
+      ctx.restore();
+
+      if (!gcodeToolpath) return;
+
+      // Per-frame draw-call budgets: cuts and rapids have independent caps
+      // so rapid moves can never crowd out the more important cut paths.
+      // 150 k cut + 50 k rapid keeps a single frame well under GPU timeout limits.
+      const MAX_CUT_CALLS = 150_000;
+      const MAX_RAPID_CALLS = 50_000;
+
       ctx.save();
       ctx.setTransform(a, 0, 0, d, e, f);
 
@@ -716,6 +733,36 @@ export function PlotCanvas() {
       const lodMm = LOD_PX / pxPerMm;
       const lodMm2 = lodMm * lodMm;
 
+      // ── Cut moves first (pen-down strokes, solid blue) ────────────────────
+      // Drawn before rapids so the cut budget is never consumed by rapid moves.
+      if (gcodeToolpath.cutPaths.length > 0) {
+        ctx.beginPath();
+        ctx.strokeStyle = toolpathSelected ? "#38bdf8" : "#0ea5e9";
+        ctx.lineWidth = 1.5 / pxPerMm;
+        ctx.setLineDash([]);
+        let cutCalls = 0;
+        for (const path of gcodeToolpath.cutPaths) {
+          if (cutCalls >= MAX_CUT_CALLS) break;
+          if (path.length < 4) continue;
+          ctx.moveTo(path[0], path[1]);
+          let lastX = path[0],
+            lastY = path[1];
+          for (let i = 2; i < path.length && cutCalls < MAX_CUT_CALLS; i += 2) {
+            const nx = path[i],
+              ny = path[i + 1];
+            const dx = nx - lastX,
+              dy = ny - lastY;
+            if (dx * dx + dy * dy >= lodMm2) {
+              ctx.lineTo(nx, ny);
+              lastX = nx;
+              lastY = ny;
+              cutCalls++;
+            }
+          }
+        }
+        ctx.stroke();
+      }
+
       // ── Rapid moves (pen-up travel, grey dashed) ──────────────────────────
       const rp = gcodeToolpath.rapidPaths;
       if (rp.length >= 4) {
@@ -723,7 +770,8 @@ export function PlotCanvas() {
         ctx.strokeStyle = "#4a5568";
         ctx.lineWidth = 0.5 / pxPerMm;
         ctx.setLineDash([2 / pxPerMm, 1 / pxPerMm]);
-        for (let i = 0; i < rp.length; i += 4) {
+        let rapidCalls = 0;
+        for (let i = 0; i < rp.length && rapidCalls < MAX_RAPID_CALLS; i += 4) {
           const x0 = rp[i],
             y0 = rp[i + 1],
             x1 = rp[i + 2],
@@ -733,32 +781,7 @@ export function PlotCanvas() {
           if (dx * dx + dy * dy >= lodMm2) {
             ctx.moveTo(x0, y0);
             ctx.lineTo(x1, y1);
-          }
-        }
-        ctx.stroke();
-      }
-
-      // ── Cut moves (pen-down strokes, solid blue) ──────────────────────────
-      if (gcodeToolpath.cutPaths.length > 0) {
-        ctx.beginPath();
-        ctx.strokeStyle = toolpathSelected ? "#38bdf8" : "#0ea5e9";
-        ctx.lineWidth = 1.5 / pxPerMm;
-        ctx.setLineDash([]);
-        for (const path of gcodeToolpath.cutPaths) {
-          if (path.length < 4) continue;
-          ctx.moveTo(path[0], path[1]);
-          let lastX = path[0],
-            lastY = path[1];
-          for (let i = 2; i < path.length; i += 2) {
-            const nx = path[i],
-              ny = path[i + 1];
-            const dx = nx - lastX,
-              dy = ny - lastY;
-            if (dx * dx + dy * dy >= lodMm2) {
-              ctx.lineTo(nx, ny);
-              lastX = nx;
-              lastY = ny;
-            }
+            rapidCalls++;
           }
         }
         ctx.stroke();
@@ -895,13 +918,14 @@ export function PlotCanvas() {
           selectToolpath(false);
         }}
       >
-        {/* Bed background */}
+        {/* Bed background — filled by the canvas layer behind this SVG.
+             fill="none" here so the canvas #0d1117 rect shows through. */}
         <rect
           x={PAD}
           y={PAD}
           width={bedW * MM_TO_PX}
           height={bedH * MM_TO_PX}
-          fill="#0d1117"
+          fill="none"
           stroke="#0f3460"
           strokeWidth={1}
         />

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -628,6 +628,212 @@ export function PlotCanvas() {
     [fitToView],
   );
 
+  // ── Toolpath canvas overlay ───────────────────────────────────────────────────
+  // G-code toolpath (potentially hundreds of thousands of segments) is rendered
+  // onto a separate <canvas> element instead of as SVG <path> elements.
+  //
+  // Why canvas beats SVG for dense paths:
+  //   • No per-element DOM layout or style-cascade overhead
+  //   • No vectorEffect="non-scaling-stroke" re-computation on every zoom/pan
+  //   • Level-of-detail (LOD): sub-pixel segments are skipped based on current
+  //     zoom level, dramatically reducing GPU work for dense G-code files
+  //   • RAF debouncing: rapid pan/zoom events collapse into one repaint per frame
+  //
+  // Plot-progress overlays are rendered on the same canvas via cached Path2D
+  // objects (rebuilt only when the overlay string actually changes, not on
+  // every viewport update).
+  const toolpathCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Lazy Path2D cache for the two live plot-progress overlay strings.
+  // Using a ref-held object avoids stale-closure issues while still preventing
+  // Path2D reconstruction on every viewport change (only on string change).
+  const ppCutsPath2DRef = useRef<{ text: string; path: Path2D | null }>({
+    text: "",
+    path: null,
+  });
+  const ppRapidsPath2DRef = useRef<{ text: string; path: Path2D | null }>({
+    text: "",
+    path: null,
+  });
+
+  // Minimum segment screen-length (CSS px) below which a segment is skipped.
+  const LOD_PX = 0.4;
+
+  useEffect(() => {
+    let rafId: number | null = null;
+
+    const draw = () => {
+      rafId = null;
+      const canvas = toolpathCanvasRef.current;
+      if (!canvas || containerSize.w === 0 || containerSize.h === 0) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      // Resize backing store for current container dimensions + DPR.
+      const dpr = window.devicePixelRatio || 1;
+      const physW = Math.round(containerSize.w * dpr);
+      const physH = Math.round(containerSize.h * dpr);
+      if (canvas.width !== physW || canvas.height !== physH) {
+        canvas.width = physW;
+        canvas.height = physH;
+      }
+      ctx.clearRect(0, 0, physW, physH);
+      if (!gcodeToolpath) return;
+
+      // ── Transform: G-code mm → physical canvas pixels ──────────────────────
+      // Matches the coordinate system of the SVG <g transform> on the toolpath.
+      const tx = isCenter
+        ? PAD + (bedW / 2) * MM_TO_PX
+        : isRight
+          ? PAD + bedW * MM_TO_PX
+          : PAD;
+      const ty = isCenter
+        ? PAD + (bedH / 2) * MM_TO_PX
+        : isBottom
+          ? PAD + bedH * MM_TO_PX
+          : PAD;
+      const sx = isRight ? -MM_TO_PX : MM_TO_PX;
+      const sy = isCenter || isBottom ? -MM_TO_PX : MM_TO_PX;
+
+      // Canvas CTM (G-code mm → buffer pixels).
+      const a = sx * vp.zoom * dpr;
+      const d = sy * vp.zoom * dpr;
+      const e = (tx * vp.zoom + vp.panX) * dpr;
+      const f = (ty * vp.zoom + vp.panY) * dpr;
+
+      ctx.save();
+      ctx.setTransform(a, 0, 0, d, e, f);
+
+      // Clip to bed bounds (G-code mm coordinates after setTransform).
+      ctx.beginPath();
+      ctx.rect(bedXMin, bedYMin, bedXMax - bedXMin, bedYMax - bedYMin);
+      ctx.clip();
+
+      // CSS pixels per G-code mm — used to scale lineWidth and the LOD threshold.
+      const pxPerMm = Math.abs(sx * vp.zoom);
+
+      // LOD: skip segments whose length in G-code mm is below this threshold.
+      const lodMm = LOD_PX / pxPerMm;
+      const lodMm2 = lodMm * lodMm;
+
+      // ── Rapid moves (pen-up travel, grey dashed) ──────────────────────────
+      const rp = gcodeToolpath.rapidPaths;
+      if (rp.length >= 4) {
+        ctx.beginPath();
+        ctx.strokeStyle = "#4a5568";
+        ctx.lineWidth = 0.5 / pxPerMm;
+        ctx.setLineDash([2 / pxPerMm, 1 / pxPerMm]);
+        for (let i = 0; i < rp.length; i += 4) {
+          const x0 = rp[i],
+            y0 = rp[i + 1],
+            x1 = rp[i + 2],
+            y1 = rp[i + 3];
+          const dx = x1 - x0,
+            dy = y1 - y0;
+          if (dx * dx + dy * dy >= lodMm2) {
+            ctx.moveTo(x0, y0);
+            ctx.lineTo(x1, y1);
+          }
+        }
+        ctx.stroke();
+      }
+
+      // ── Cut moves (pen-down strokes, solid blue) ──────────────────────────
+      if (gcodeToolpath.cutPaths.length > 0) {
+        ctx.beginPath();
+        ctx.strokeStyle = toolpathSelected ? "#38bdf8" : "#0ea5e9";
+        ctx.lineWidth = 1.5 / pxPerMm;
+        ctx.setLineDash([]);
+        for (const path of gcodeToolpath.cutPaths) {
+          if (path.length < 4) continue;
+          ctx.moveTo(path[0], path[1]);
+          let lastX = path[0],
+            lastY = path[1];
+          for (let i = 2; i < path.length; i += 2) {
+            const nx = path[i],
+              ny = path[i + 1];
+            const dx = nx - lastX,
+              dy = ny - lastY;
+            if (dx * dx + dy * dy >= lodMm2) {
+              ctx.lineTo(nx, ny);
+              lastX = nx;
+              lastY = ny;
+            }
+          }
+        }
+        ctx.stroke();
+      }
+
+      // ── Plot-progress overlays via cached Path2D ─────────────────────────
+      // Path2D is only rebuilt when the string content changes, so rapid
+      // pan/zoom while a job is running does not retrigger string parsing.
+      if (plotProgressRapids) {
+        if (ppRapidsPath2DRef.current.text !== plotProgressRapids) {
+          try {
+            ppRapidsPath2DRef.current = {
+              text: plotProgressRapids,
+              path: new Path2D(plotProgressRapids),
+            };
+          } catch {
+            ppRapidsPath2DRef.current = {
+              text: plotProgressRapids,
+              path: null,
+            };
+          }
+        }
+        const p2d = ppRapidsPath2DRef.current.path;
+        if (p2d) {
+          ctx.strokeStyle = "#f97316";
+          ctx.lineWidth = 0.5 / pxPerMm;
+          ctx.setLineDash([2 / pxPerMm, 1 / pxPerMm]);
+          ctx.stroke(p2d);
+        }
+      }
+      if (plotProgressCuts) {
+        if (ppCutsPath2DRef.current.text !== plotProgressCuts) {
+          try {
+            ppCutsPath2DRef.current = {
+              text: plotProgressCuts,
+              path: new Path2D(plotProgressCuts),
+            };
+          } catch {
+            ppCutsPath2DRef.current = { text: plotProgressCuts, path: null };
+          }
+        }
+        const p2d = ppCutsPath2DRef.current.path;
+        if (p2d) {
+          ctx.strokeStyle = "#ef4444";
+          ctx.lineWidth = 2 / pxPerMm;
+          ctx.setLineDash([]);
+          ctx.stroke(p2d);
+        }
+      }
+
+      ctx.restore();
+    };
+
+    rafId = requestAnimationFrame(draw);
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [
+    gcodeToolpath,
+    toolpathSelected,
+    vp,
+    plotProgressCuts,
+    plotProgressRapids,
+    containerSize,
+    bedW,
+    bedH,
+    isCenter,
+    isBottom,
+    isRight,
+    bedXMin,
+    bedYMin,
+    bedXMax,
+    bedYMax,
+  ]);
+
   // ── Cursor ────────────────────────────────────────────────────────────────────
   const cursor = spaceDown
     ? isPanning
@@ -648,6 +854,22 @@ export function PlotCanvas() {
       onMouseDown={onContainerMouseDown}
       onContextMenu={onContextMenu}
     >
+      {/* ── Toolpath canvas — renders G-code paths with per-frame LOD.
+           Positioned below the main SVG so SVG imports appear on top.
+           pointerEvents:none keeps all click/drag handling on the SVG layer. ── */}
+      <canvas
+        ref={toolpathCanvasRef}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          display: "block",
+          width: containerSize.w || canvasW,
+          height: containerSize.h || canvasH,
+          pointerEvents: "none",
+        }}
+      />
+
       {/* ── Canvas SVG — fills the container; viewBox drives pan/zoom so the
            browser renders all paths at native screen resolution instead of
            rasterising a CSS-scaled compositing layer (which causes blurriness). ── */}
@@ -716,30 +938,10 @@ export function PlotCanvas() {
 
         {/* Rulers are rendered as a screen-space overlay — see below */}
 
-        {/* G-code toolpath overlay */}
+        {/* G-code toolpath hit-area (paths rendered on the canvas overlay below). */}
         {gcodeToolpath &&
           (() => {
             const { minX, maxX, minY, maxY } = gcodeToolpath.bounds;
-            const svgLeft = isCenter
-              ? PAD + (bedW / 2 + minX) * MM_TO_PX
-              : isRight
-                ? PAD + (bedW - maxX) * MM_TO_PX
-                : PAD + minX * MM_TO_PX;
-            const svgRight = isCenter
-              ? PAD + (bedW / 2 + maxX) * MM_TO_PX
-              : isRight
-                ? PAD + (bedW - minX) * MM_TO_PX
-                : PAD + maxX * MM_TO_PX;
-            const svgTop = isCenter
-              ? PAD + (bedH / 2 - maxY) * MM_TO_PX
-              : isBottom
-                ? PAD + (bedH - maxY) * MM_TO_PX
-                : PAD + minY * MM_TO_PX;
-            const svgBottom = isCenter
-              ? PAD + (bedH / 2 - minY) * MM_TO_PX
-              : isBottom
-                ? PAD + (bedH - minY) * MM_TO_PX
-                : PAD + maxY * MM_TO_PX;
             return (
               <>
                 <g
@@ -757,76 +959,22 @@ export function PlotCanvas() {
                         : PAD
                   }) scale(${isRight ? -MM_TO_PX : MM_TO_PX}, ${isCenter || isBottom ? -MM_TO_PX : MM_TO_PX})`}
                 >
-                  <clipPath id="bed-clip">
-                    <rect
-                      x={isCenter ? -bedW / 2 : 0}
-                      y={isCenter ? -bedH / 2 : 0}
-                      width={bedW}
-                      height={bedH}
-                    />
-                  </clipPath>
-                  <g clipPath="url(#bed-clip)">
-                    {gcodeToolpath.rapids && (
-                      <path
-                        d={gcodeToolpath.rapids}
-                        stroke="#4a5568"
-                        strokeWidth={0.5}
-                        fill="none"
-                        strokeDasharray="2 1"
-                        vectorEffect="non-scaling-stroke"
-                      />
-                    )}
-                    {gcodeToolpath.cuts && (
-                      <path
-                        d={gcodeToolpath.cuts}
-                        stroke={toolpathSelected ? "#38bdf8" : "#0ea5e9"}
-                        strokeWidth={1.5}
-                        fill="none"
-                        vectorEffect="non-scaling-stroke"
-                      />
-                    )}
-                    {/* ── Live plot-progress overlay ─────────────────────────
-                         Completed rapid moves → orange; completed cut moves → red.
-                         Rendered on top of the base toolpath, segment by segment,
-                         matching the path data exactly so no drift from sampling. */}
-                    {plotProgressRapids && (
-                      <path
-                        d={plotProgressRapids}
-                        stroke="#f97316"
-                        strokeWidth={0.5}
-                        fill="none"
-                        strokeDasharray="2 1"
-                        vectorEffect="non-scaling-stroke"
-                        pointerEvents="none"
-                      />
-                    )}
-                    {plotProgressCuts && (
-                      <path
-                        d={plotProgressCuts}
-                        stroke="#ef4444"
-                        strokeWidth={2}
-                        fill="none"
-                        vectorEffect="non-scaling-stroke"
-                        pointerEvents="none"
-                      />
-                    )}
-                    {/* Invisible hit-area for selecting the toolpath */}
-                    <rect
-                      x={minX}
-                      y={minY}
-                      width={maxX - minX}
-                      height={maxY - minY}
-                      fill="transparent"
-                      style={{ cursor: "pointer" }}
-                      vectorEffect="non-scaling-stroke"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        selectImport(null);
-                        selectToolpath(true);
-                        // selectedJobFile is synced by the toolpathSelected effect below.
-                      }}
-                    />
-                  </g>
+                  {/* Invisible hit-area for selecting the toolpath */}
+                  <rect
+                    x={minX}
+                    y={minY}
+                    width={maxX - minX}
+                    height={maxY - minY}
+                    fill="transparent"
+                    style={{ cursor: "pointer" }}
+                    vectorEffect="non-scaling-stroke"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      selectImport(null);
+                      selectToolpath(true);
+                      // selectedJobFile is synced by the toolpathSelected effect below.
+                    }}
+                  />
                 </g>
 
                 {toolpathSelected && (

--- a/src/renderer/src/utils/gcodeParser.ts
+++ b/src/renderer/src/utils/gcodeParser.ts
@@ -1,11 +1,14 @@
 // ── G-code toolpath parser ────────────────────────────────────────────────────
 //
-// Converts a G-code text file into two SVG path `d` strings:
-//   cuts   — G1/G2/G3 feed moves (pen down / drawing)
-//   rapids — G0 rapid moves (pen up / travel)
+// Converts a G-code text file into compact typed-array geometry:
+//   cutPaths   — array of Float32Array sub-paths for G1/G2/G3 feed moves
+//   rapidPaths — single flat Float32Array of [x0,y0,x1,y1,...] quad pairs for G0 rapids
 //
-// Coordinates are output in millimetres in the G-code work coordinate space
-// so they can be rendered directly on the bed canvas via a matching transform.
+// Coordinates are in millimetres in the G-code work coordinate space.
+// Using typed arrays instead of SVG path strings:
+//   - eliminates multi-megabyte string allocations for large files
+//   - enables O(n) LOD filtering at canvas render time (skip sub-pixel segments)
+//   - reduces memory by ~3× vs equivalent UTF-16 path strings
 //
 // Supported:
 //   G0, G1        — linear rapid / feed
@@ -30,8 +33,14 @@ export interface GcodeSegment {
 }
 
 export interface GcodeToolpath {
-  cuts: string; // SVG path d — feed moves
-  rapids: string; // SVG path d — rapid moves
+  /** Feed-move sub-paths (pen down).  Each Float32Array is one continuous
+   *  stroke: [x0,y0, x1,y1, x2,y2, ...].  A new array begins wherever the
+   *  pen lifted between cuts (i.e. a G0 rapid or initial pen-up gap). */
+  cutPaths: Float32Array[];
+  /** Rapid-move segments (pen up), packed as flat quads:
+   *  [x_from, y_from, x_to, y_to,  x_from, y_from, x_to, y_to, ...].
+   *  Stride = 4 (one segment per group of four values). */
+  rapidPaths: Float32Array;
   bounds: { minX: number; maxX: number; minY: number; maxY: number };
   lineCount: number;
   /** Individual motion segments used for live plot-progress tracking.
@@ -55,8 +64,14 @@ export function parseGcode(gcode: string): GcodeToolpath {
   let inMillimeters = true;
   let motionMode = 0; // 0=G0, 1=G1, 2=G2, 3=G3
 
-  const cutParts: string[] = [];
-  const rapidParts: string[] = [];
+  // Cut sub-paths: each number[] becomes one Float32Array in cutPaths.
+  // currentCutPath is the active (open) sub-path being built.
+  const cutSubPaths: number[][] = [];
+  let currentCutPath: number[] | null = null;
+
+  // Rapid segments: flat [x_from, y_from, x_to, y_to, ...] buffer.
+  const rapidData: number[] = [];
+
   const segments: GcodeSegment[] = [];
 
   let minX = 0,
@@ -148,19 +163,21 @@ export function parseGcode(gcode: string): GcodeToolpath {
     });
 
     if (motionMode === 0) {
-      // Rapid — always start a new sub-path segment
+      // Rapid — record as a flat quad [x_from, y_from, x_to, y_to]
       totalRapidDistance += segDist;
-      rapidParts.push(
-        `M ${x.toFixed(3)} ${y.toFixed(3)} L ${nx.toFixed(3)} ${ny.toFixed(3)}`,
-      );
+      rapidData.push(x, y, nx, ny);
+      // A rapid lifts the pen, so the next cut must start a new sub-path.
+      currentCutPath = null;
       lastWasCut = false;
     } else {
       // Feed (G1) or arc (G2/G3 approximated as straight line)
       totalCutDistance += segDist;
-      if (!lastWasCut) {
-        cutParts.push(`M ${x.toFixed(3)} ${y.toFixed(3)}`);
+      if (!lastWasCut || currentCutPath === null) {
+        // Start a new cut sub-path beginning at the current position.
+        currentCutPath = [x, y];
+        cutSubPaths.push(currentCutPath);
       }
-      cutParts.push(`L ${nx.toFixed(3)} ${ny.toFixed(3)}`);
+      currentCutPath.push(nx, ny);
       lastWasCut = true;
     }
 
@@ -169,8 +186,8 @@ export function parseGcode(gcode: string): GcodeToolpath {
   }
 
   return {
-    cuts: cutParts.join(" "),
-    rapids: rapidParts.join(" "),
+    cutPaths: cutSubPaths.map((pts) => new Float32Array(pts)),
+    rapidPaths: new Float32Array(rapidData),
     bounds: { minX, maxX, minY, maxY },
     lineCount,
     segments,

--- a/src/workers/gcodeEngine.ts
+++ b/src/workers/gcodeEngine.ts
@@ -403,31 +403,93 @@ export function arcToBeziers(
 }
 
 // ── Nearest-neighbour path optimiser ──────────────────────────────────────────
+//
+// Uses a sqrt(n)×sqrt(n) spatial grid so that each lookup costs O(1) amortised
+// rather than O(n), reducing total sort time from O(n²) to O(n√n).
+// For 100 k subpaths this is roughly a 1000× speed improvement over the naive
+// linear scan approach.
 
 export function nearestNeighbourSort(subpaths: Subpath[]): Subpath[] {
   if (subpaths.length === 0) return [];
-  const remaining = subpaths.slice();
-  const sorted: Subpath[] = [];
-  let curX = 0,
-    curY = 0;
+  const n = subpaths.length;
+  if (n === 1) return [subpaths[0]];
 
-  while (remaining.length > 0) {
-    let bestIdx = 0;
+  // ── Build bounding box of all start points ──────────────────────────────
+  let xMin = Infinity, yMin = Infinity, xMax = -Infinity, yMax = -Infinity;
+  for (const sp of subpaths) {
+    const { x, y } = sp[0];
+    if (x < xMin) xMin = x;
+    if (y < yMin) yMin = y;
+    if (x > xMax) xMax = x;
+    if (y > yMax) yMax = y;
+  }
+  xMax += 1e-9; yMax += 1e-9; // guard band so max-coord points land inside a cell
+
+  // ── Build spatial grid (~1 start point per cell on average) ────────────
+  const cols = Math.max(1, Math.ceil(Math.sqrt(n)));
+  const rows = Math.max(1, Math.ceil(Math.sqrt(n)));
+  const cw = (xMax - xMin) / cols;
+  const ch = (yMax - yMin) / rows;
+  const minCell = Math.min(cw, ch);
+
+  // cells[r * cols + c] = list of subpath indices whose start falls in that cell
+  const cells: number[][] = Array.from({ length: rows * cols }, () => []);
+  for (let i = 0; i < n; i++) {
+    const { x, y } = subpaths[i][0];
+    const c = Math.min(cols - 1, Math.floor((x - xMin) / cw));
+    const r = Math.min(rows - 1, Math.floor((y - yMin) / ch));
+    cells[r * cols + c].push(i);
+  }
+
+  // ── Greedy nearest-neighbour traversal ──────────────────────────────────
+  const visited = new Uint8Array(n);
+  const sorted: Subpath[] = new Array(n);
+  let curX = 0, curY = 0;
+
+  for (let s = 0; s < n; s++) {
+    let bestIdx = -1;
     let bestDist = Infinity;
-    for (let i = 0; i < remaining.length; i++) {
-      const s = remaining[i][0];
-      const d = (s.x - curX) ** 2 + (s.y - curY) ** 2;
-      if (d < bestDist) {
-        bestDist = d;
-        bestIdx = i;
+
+    const cc = Math.min(cols - 1, Math.max(0, Math.floor((curX - xMin) / cw)));
+    const cr = Math.min(rows - 1, Math.max(0, Math.floor((curY - yMin) / ch)));
+    const maxRing = Math.max(cols, rows);
+
+    for (let ring = 0; ring <= maxRing; ring++) {
+      // Early-exit: the nearest any point in this ring can be is (ring-1)*minCell.
+      // If the current best is already closer, no ring beyond this can improve it.
+      if (bestIdx !== -1) {
+        const minPossible = Math.max(0, ring - 1) * minCell;
+        if (minPossible * minPossible > bestDist) break;
+      }
+
+      const rLo = Math.max(0, cr - ring), rHi = Math.min(rows - 1, cr + ring);
+      const cLo = Math.max(0, cc - ring), cHi = Math.min(cols - 1, cc + ring);
+
+      for (let gr = rLo; gr <= rHi; gr++) {
+        for (let gc = cLo; gc <= cHi; gc++) {
+          // Only examine perimeter cells of the ring, not the interior
+          if (ring > 0 && gr > rLo && gr < rHi && gc > cLo && gc < cHi) continue;
+          for (const idx of cells[gr * cols + gc]) {
+            if (visited[idx]) continue;
+            const { x, y } = subpaths[idx][0];
+            const d = (x - curX) ** 2 + (y - curY) ** 2;
+            if (d < bestDist) { bestDist = d; bestIdx = idx; }
+          }
+        }
       }
     }
-    const chosen = remaining.splice(bestIdx, 1)[0];
-    sorted.push(chosen);
-    const last = chosen[chosen.length - 1];
-    curX = last.x;
-    curY = last.y;
+
+    if (bestIdx === -1) {
+      // Fallback: linear scan for any unvisited entry (should never be reached)
+      for (let i = 0; i < n; i++) if (!visited[i]) { bestIdx = i; break; }
+    }
+
+    visited[bestIdx] = 1;
+    sorted[s] = subpaths[bestIdx];
+    const last = subpaths[bestIdx][subpaths[bestIdx].length - 1];
+    curX = last.x; curY = last.y;
   }
+
   return sorted;
 }
 

--- a/src/workers/gcodeEngine.ts
+++ b/src/workers/gcodeEngine.ts
@@ -415,7 +415,10 @@ export function nearestNeighbourSort(subpaths: Subpath[]): Subpath[] {
   if (n === 1) return [subpaths[0]];
 
   // ── Build bounding box of all start points ──────────────────────────────
-  let xMin = Infinity, yMin = Infinity, xMax = -Infinity, yMax = -Infinity;
+  let xMin = Infinity,
+    yMin = Infinity,
+    xMax = -Infinity,
+    yMax = -Infinity;
   for (const sp of subpaths) {
     const { x, y } = sp[0];
     if (x < xMin) xMin = x;
@@ -423,7 +426,8 @@ export function nearestNeighbourSort(subpaths: Subpath[]): Subpath[] {
     if (x > xMax) xMax = x;
     if (y > yMax) yMax = y;
   }
-  xMax += 1e-9; yMax += 1e-9; // guard band so max-coord points land inside a cell
+  xMax += 1e-9;
+  yMax += 1e-9; // guard band so max-coord points land inside a cell
 
   // ── Build spatial grid (~1 start point per cell on average) ────────────
   const cols = Math.max(1, Math.ceil(Math.sqrt(n)));
@@ -444,7 +448,8 @@ export function nearestNeighbourSort(subpaths: Subpath[]): Subpath[] {
   // ── Greedy nearest-neighbour traversal ──────────────────────────────────
   const visited = new Uint8Array(n);
   const sorted: Subpath[] = new Array(n);
-  let curX = 0, curY = 0;
+  let curX = 0,
+    curY = 0;
 
   for (let s = 0; s < n; s++) {
     let bestIdx = -1;
@@ -462,18 +467,24 @@ export function nearestNeighbourSort(subpaths: Subpath[]): Subpath[] {
         if (minPossible * minPossible > bestDist) break;
       }
 
-      const rLo = Math.max(0, cr - ring), rHi = Math.min(rows - 1, cr + ring);
-      const cLo = Math.max(0, cc - ring), cHi = Math.min(cols - 1, cc + ring);
+      const rLo = Math.max(0, cr - ring),
+        rHi = Math.min(rows - 1, cr + ring);
+      const cLo = Math.max(0, cc - ring),
+        cHi = Math.min(cols - 1, cc + ring);
 
       for (let gr = rLo; gr <= rHi; gr++) {
         for (let gc = cLo; gc <= cHi; gc++) {
           // Only examine perimeter cells of the ring, not the interior
-          if (ring > 0 && gr > rLo && gr < rHi && gc > cLo && gc < cHi) continue;
+          if (ring > 0 && gr > rLo && gr < rHi && gc > cLo && gc < cHi)
+            continue;
           for (const idx of cells[gr * cols + gc]) {
             if (visited[idx]) continue;
             const { x, y } = subpaths[idx][0];
             const d = (x - curX) ** 2 + (y - curY) ** 2;
-            if (d < bestDist) { bestDist = d; bestIdx = idx; }
+            if (d < bestDist) {
+              bestDist = d;
+              bestIdx = idx;
+            }
           }
         }
       }
@@ -481,13 +492,18 @@ export function nearestNeighbourSort(subpaths: Subpath[]): Subpath[] {
 
     if (bestIdx === -1) {
       // Fallback: linear scan for any unvisited entry (should never be reached)
-      for (let i = 0; i < n; i++) if (!visited[i]) { bestIdx = i; break; }
+      for (let i = 0; i < n; i++)
+        if (!visited[i]) {
+          bestIdx = i;
+          break;
+        }
     }
 
     visited[bestIdx] = 1;
     sorted[s] = subpaths[bestIdx];
     const last = subpaths[bestIdx][subpaths[bestIdx].length - 1];
-    curX = last.x; curY = last.y;
+    curX = last.x;
+    curY = last.y;
   }
 
   return sorted;

--- a/src/workers/svgWorker.ts
+++ b/src/workers/svgWorker.ts
@@ -96,8 +96,25 @@ async function generate(msg: GenerateMessage): Promise<void> {
 
   const visibleObjects = objects.filter((o) => o.visible);
 
+  // Time-based yield helper — only surrenders to the event loop after a full
+  // frame's worth of work (~16 ms), instead of yielding on every iteration.
+  // This keeps the worker responsive to cancel messages while eliminating the
+  // massive overhead of hundreds-of-thousands of individual setTimeout callbacks.
+  const makeYielder = () => {
+    let last = Date.now();
+    return async () => {
+      const now = Date.now();
+      if (now - last >= 16) {
+        last = now;
+        await sleep(0);
+      }
+    };
+  };
+
   // ── Phase 1: collect all subpaths from all visible objects ────────────────
   const allSubpaths: Subpath[] = [];
+  const yieldPh1 = makeYielder();
+  let lastPct1 = -1;
   for (let i = 0; i < visibleObjects.length; i++) {
     if (cancelled.has(taskId)) {
       cancelled.delete(taskId);
@@ -108,12 +125,12 @@ async function generate(msg: GenerateMessage): Promise<void> {
     for (const sp of clipSubpathsToBed(raw, config)) {
       if (sp.length >= 2) allSubpaths.push(sp);
     }
-    self.postMessage({
-      type: "progress",
-      taskId,
-      percent: Math.round(((i + 1) / visibleObjects.length) * 40),
-    });
-    await sleep(0);
+    const pct = Math.round(((i + 1) / visibleObjects.length) * 40);
+    if (pct !== lastPct1) {
+      lastPct1 = pct;
+      self.postMessage({ type: "progress", taskId, percent: pct });
+    }
+    await yieldPh1();
   }
 
   // ── Phase 2: optional nearest-neighbour reorder ────────────────────────────
@@ -134,6 +151,8 @@ async function generate(msg: GenerateMessage): Promise<void> {
     `; -- ${modeLabel} path (${orderedSubpaths.length} subpaths) -----------`,
   );
 
+  const yieldPh4 = makeYielder();
+  let lastPct4 = -1;
   for (let i = 0; i < orderedSubpaths.length; i++) {
     if (cancelled.has(taskId)) {
       cancelled.delete(taskId);
@@ -150,12 +169,12 @@ async function generate(msg: GenerateMessage): Promise<void> {
     }
     lines.push(config.penUpCommand + " ; Pen up");
     lines.push("");
-    self.postMessage({
-      type: "progress",
-      taskId,
-      percent: 40 + Math.round(((i + 1) / orderedSubpaths.length) * 60),
-    });
-    await sleep(0);
+    const pct = 40 + Math.round(((i + 1) / orderedSubpaths.length) * 60);
+    if (pct !== lastPct4) {
+      lastPct4 = pct;
+      self.postMessage({ type: "progress", taskId, percent: pct });
+    }
+    await yieldPh4();
   }
 
   lines.push("; ── End of job ──────────────────────────────────────────────");

--- a/src/workers/svgWorker.ts
+++ b/src/workers/svgWorker.ts
@@ -88,9 +88,13 @@ async function generate(msg: GenerateMessage): Promise<void> {
 
   // Inject custom start G-code (if any)
   if (customStartGcode) {
-    lines.push("; -- Custom start G-code ----------------------------------------");
+    lines.push(
+      "; -- Custom start G-code ----------------------------------------",
+    );
     lines.push(customStartGcode);
-    lines.push("; ---------------------------------------------------------------");
+    lines.push(
+      "; ---------------------------------------------------------------",
+    );
     lines.push("");
   }
 
@@ -185,9 +189,13 @@ async function generate(msg: GenerateMessage): Promise<void> {
     lines.push("G0 X0 Y0 ; Return to origin");
   }
   if (customEndGcode) {
-    lines.push("; -- Custom end G-code ------------------------------------------");
+    lines.push(
+      "; -- Custom end G-code ------------------------------------------",
+    );
     lines.push(customEndGcode);
-    lines.push("; ---------------------------------------------------------------");
+    lines.push(
+      "; ---------------------------------------------------------------",
+    );
   }
   self.postMessage({ type: "complete", taskId, gcode: lines.join("\n") });
 }

--- a/tests/component/PlotCanvas.test.tsx
+++ b/tests/component/PlotCanvas.test.tsx
@@ -99,7 +99,7 @@ describe("PlotCanvas", () => {
 
   // ── SVG import rendering ───────────────────────────────────────────
 
-  it("renders SVG import paths on canvas", () => {
+  it("renders SVG import hit-area rect on canvas", () => {
     const path = createSvgPath({ d: "M0,0 L100,100", visible: true });
     const imp = createSvgImport({
       name: "test-import",
@@ -108,9 +108,10 @@ describe("PlotCanvas", () => {
     });
     useCanvasStore.setState({ imports: [imp] });
     const { container } = render(<PlotCanvas />);
-    // The import paths should be rendered as SVG path elements
-    const svgPaths = container.querySelectorAll("path");
-    expect(svgPaths.length).toBeGreaterThan(0);
+    // Import paths are rendered on the canvas overlay (not as SVG <path> elements).
+    // A transparent hit-area <rect> is still placed in the SVG for drag/click.
+    const hitRect = container.querySelector("rect[fill='transparent']");
+    expect(hitRect).toBeTruthy();
   });
 
   it("does not render hidden imports", () => {

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -137,8 +137,8 @@ export function createGcodeToolpath(
   overrides?: Partial<GcodeToolpath>,
 ): GcodeToolpath {
   return {
-    cuts: "M 0.000 0.000 L 100.000 100.000",
-    rapids: "M 0.000 0.000 L 50.000 50.000",
+    cutPaths: [new Float32Array([0, 0, 100, 100])],
+    rapidPaths: new Float32Array([0, 0, 50, 50]),
     bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100 },
     lineCount: 10,
     fileSizeBytes: 128,

--- a/tests/unit/gcodeParser.test.ts
+++ b/tests/unit/gcodeParser.test.ts
@@ -1,139 +1,170 @@
-import { describe, it, expect } from "vitest";
+﻿import { describe, it, expect } from "vitest";
 import {
   parseGcode,
   type GcodeToolpath,
 } from "../../src/renderer/src/utils/gcodeParser";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /** Convenience: parse and return the result for assertions. */
 const parse = (gcode: string): GcodeToolpath => parseGcode(gcode);
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+const TOL = 0.001; // matches original .toFixed(3) precision
+const approx = (a: number, b: number) => Math.abs(a - b) <= TOL;
+
+function cutsEmpty(r: GcodeToolpath): boolean {
+  return r.cutPaths.length === 0 || r.cutPaths.every((p) => p.length === 0);
+}
+function rapidsEmpty(r: GcodeToolpath): boolean {
+  return r.rapidPaths.length === 0;
+}
+/** Returns true if any cut sub-path contains a point close to (x, y). */
+function cutsContainPoint(r: GcodeToolpath, x: number, y: number): boolean {
+  return r.cutPaths.some((path) => {
+    for (let i = 0; i < path.length; i += 2) {
+      if (approx(path[i], x) && approx(path[i + 1], y)) return true;
+    }
+    return false;
+  });
+}
+/** Returns true if any rapid segment has a from- or to-point close to (x, y). */
+function rapidsContainPoint(r: GcodeToolpath, x: number, y: number): boolean {
+  const rp = r.rapidPaths;
+  for (let i = 0; i < rp.length; i += 2) {
+    if (approx(rp[i], x) && approx(rp[i + 1], y)) return true;
+  }
+  return false;
+}
+/** Number of distinct cut sub-paths (pen-down strokes). */
+function cutSubpathCount(r: GcodeToolpath): number {
+  return r.cutPaths.length;
+}
+/** Number of rapid (pen-up) segments. */
+function rapidSegmentCount(r: GcodeToolpath): number {
+  return r.rapidPaths.length / 4;
+}
+
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 describe("parseGcode", () => {
-  // ── Empty / trivial input ─────────────────────────────────────────────────
+  // â”€â”€ Empty / trivial input â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("returns empty paths for an empty string", () => {
     const r = parse("");
-    expect(r.cuts).toBe("");
-    expect(r.rapids).toBe("");
-    // split("") produces [""] → parser counts 1 line
+    expect(cutsEmpty(r)).toBe(true);
+    expect(rapidsEmpty(r)).toBe(true);
+    // split("") produces [""] â†’ parser counts 1 line
     expect(r.lineCount).toBe(1);
   });
 
   it("returns empty paths for pure comment lines", () => {
     const r = parse("; this is a comment\n(another comment)\n");
-    expect(r.cuts).toBe("");
-    expect(r.rapids).toBe("");
+    expect(cutsEmpty(r)).toBe(true);
+    expect(rapidsEmpty(r)).toBe(true);
     // trailing \n produces an extra empty element from split
     expect(r.lineCount).toBe(3);
   });
 
-  // ── Rapid moves (G0) ─────────────────────────────────────────────────────
+  // â”€â”€ Rapid moves (G0) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("parses a single G0 rapid move", () => {
     const r = parse("G0 X10 Y20\n");
-    expect(r.rapids).toContain("M 0.000 0.000");
-    expect(r.rapids).toContain("L 10.000 20.000");
-    expect(r.cuts).toBe("");
+    expect(rapidsContainPoint(r, 0, 0)).toBe(true);
+    expect(rapidsContainPoint(r, 10, 20)).toBe(true);
+    expect(cutsEmpty(r)).toBe(true);
   });
 
-  it("generates separate M-L segments for multiple rapids", () => {
+  it("generates separate segments for multiple rapids", () => {
     const r = parse("G0 X10 Y10\nG0 X20 Y20\n");
-    // Each rapid starts a new M...L segment
-    const mCount = (r.rapids.match(/M /g) || []).length;
-    expect(mCount).toBe(2);
+    expect(rapidSegmentCount(r)).toBe(2);
   });
 
-  // ── Feed moves (G1) ──────────────────────────────────────────────────────
+  // â”€â”€ Feed moves (G1) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("parses a single G1 linear feed move", () => {
     const r = parse("G1 X5 Y5\n");
-    expect(r.cuts).toContain("M 0.000 0.000");
-    expect(r.cuts).toContain("L 5.000 5.000");
-    expect(r.rapids).toBe("");
+    expect(cutsContainPoint(r, 0, 0)).toBe(true);
+    expect(cutsContainPoint(r, 5, 5)).toBe(true);
+    expect(rapidsEmpty(r)).toBe(true);
   });
 
   it("continues the same cut sub-path for consecutive G1 moves", () => {
     const r = parse("G1 X5 Y5\nG1 X10 Y10\n");
-    const mCount = (r.cuts.match(/M /g) || []).length;
-    expect(mCount).toBe(1); // one continuous cut sub-path
+    expect(cutSubpathCount(r)).toBe(1); // one continuous cut sub-path
   });
 
   it("starts a new cut sub-path after a rapid intervenes", () => {
     const r = parse("G1 X5 Y5\nG0 X20 Y20\nG1 X25 Y25\n");
-    const mCount = (r.cuts.match(/M /g) || []).length;
-    expect(mCount).toBe(2); // two separate cut sub-paths
+    expect(cutSubpathCount(r)).toBe(2); // two separate cut sub-paths
   });
 
-  // ── Arc commands (G2/G3) — approximated as lines ──────────────────────────
+  // â”€â”€ Arc commands (G2/G3) â€” approximated as lines â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("treats G2 clockwise arc as a feed move", () => {
     const r = parse("G1 X5 Y0\nG2 X10 Y5 I5 J0\n");
-    // G2 treated as feed — should be in cuts, not rapids
-    expect(r.cuts).toContain("L 10.000 5.000");
-    expect(r.rapids).toBe("");
+    // G2 treated as feed â€” should be in cuts, not rapids
+    expect(cutsContainPoint(r, 10, 5)).toBe(true);
+    expect(rapidsEmpty(r)).toBe(true);
   });
 
   it("treats G3 counter-clockwise arc as a feed move", () => {
     const r = parse("G1 X5 Y0\nG3 X10 Y5 I5 J0\n");
-    expect(r.cuts).toContain("L 10.000 5.000");
+    expect(cutsContainPoint(r, 10, 5)).toBe(true);
   });
 
-  // ── Modal state ───────────────────────────────────────────────────────────
+  // â”€â”€ Modal state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("keeps modal motion mode across lines (G1 sticky)", () => {
     const r = parse("G1\nX5 Y5\nX10 Y10\n");
     // After G1, subsequent X/Y coords should produce cuts
-    expect(r.cuts).toContain("L 10.000 10.000");
+    expect(cutsContainPoint(r, 10, 10)).toBe(true);
   });
 
-  // ── Units: G20 (inch) & G21 (mm) ─────────────────────────────────────────
+  // â”€â”€ Units: G20 (inch) & G21 (mm) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("defaults to millimetres (G21)", () => {
     const r = parse("G1 X1 Y1\n");
-    expect(r.cuts).toContain("L 1.000 1.000");
+    expect(cutsContainPoint(r, 1, 1)).toBe(true);
   });
 
   it("scales inch coordinates by 25.4 when G20 is active", () => {
     const r = parse("G20\nG1 X1 Y1\n");
-    expect(r.cuts).toContain("L 25.400 25.400");
+    expect(cutsContainPoint(r, 25.4, 25.4)).toBe(true);
   });
 
   it("switches back to mm with G21 after G20", () => {
     const r = parse("G20\nG1 X1 Y1\nG21\nG1 X50 Y50\n");
-    expect(r.cuts).toContain("L 25.400 25.400");
-    expect(r.cuts).toContain("L 50.000 50.000");
+    expect(cutsContainPoint(r, 25.4, 25.4)).toBe(true);
+    expect(cutsContainPoint(r, 50, 50)).toBe(true);
   });
 
-  // ── Positioning: G90 (absolute) & G91 (relative) ─────────────────────────
+  // â”€â”€ Positioning: G90 (absolute) & G91 (relative) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("defaults to absolute positioning (G90)", () => {
     const r = parse("G1 X10 Y10\nG1 X20 Y20\n");
-    expect(r.cuts).toContain("L 20.000 20.000");
+    expect(cutsContainPoint(r, 20, 20)).toBe(true);
   });
 
   it("handles relative positioning G91", () => {
     const r = parse("G91\nG1 X10 Y10\nG1 X5 Y5\n");
     // First move: 0+10=10, 0+10=10
     // Second move: 10+5=15, 10+5=15
-    expect(r.cuts).toContain("L 15.000 15.000");
+    expect(cutsContainPoint(r, 15, 15)).toBe(true);
   });
 
-  // ── Comments ──────────────────────────────────────────────────────────────
+  // â”€â”€ Comments â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("strips semicolon comments", () => {
     const r = parse("G1 X10 Y10 ; move to start\n");
-    expect(r.cuts).toContain("L 10.000 10.000");
+    expect(cutsContainPoint(r, 10, 10)).toBe(true);
   });
 
   it("strips parenthesis comments", () => {
     const r = parse("G1 X10 (inline) Y10\n");
-    expect(r.cuts).toContain("L 10.000 10.000");
+    expect(cutsContainPoint(r, 10, 10)).toBe(true);
   });
 
-  // ── Bounds tracking ───────────────────────────────────────────────────────
+  // â”€â”€ Bounds tracking â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("tracks bounding box correctly", () => {
     const r = parse("G0 X10 Y20\nG1 X30 Y5\n");
@@ -151,7 +182,7 @@ describe("parseGcode", () => {
     expect(r.bounds).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
   });
 
-  // ── Line count ────────────────────────────────────────────────────────────
+  // â”€â”€ Line count â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("counts all lines including blank ones", () => {
     // trailing \n splits into 4 elements: ["G0 X0 Y0","","G1 X10 Y10",""]
@@ -159,42 +190,42 @@ describe("parseGcode", () => {
     expect(r.lineCount).toBe(4);
   });
 
-  // ── Partial coordinates ───────────────────────────────────────────────────
+  // â”€â”€ Partial coordinates â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("inherits previous coordinate when only X or Y is specified", () => {
     const r = parse("G1 X10 Y20\nG1 X30\n");
     // Second line: X=30, Y inherits 20
-    expect(r.cuts).toContain("L 30.000 20.000");
+    expect(cutsContainPoint(r, 30, 20)).toBe(true);
   });
 
-  // ── Mode switch mid-file ──────────────────────────────────────────────
+  // â”€â”€ Mode switch mid-file â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("handles mixed absolute/relative mode switch mid-file", () => {
     const r = parse("G90\nG1 X10 Y10\nG91\nG1 X5 Y5\nG90\nG1 X50 Y50\n");
-    // G90: X10 Y10 → absolute (10,10)
-    // G91: X5 Y5  → relative from (10,10) → (15,15)
-    // G90: X50 Y50 → absolute (50,50)
-    expect(r.cuts).toContain("L 10.000 10.000");
-    expect(r.cuts).toContain("L 15.000 15.000");
-    expect(r.cuts).toContain("L 50.000 50.000");
+    // G90: X10 Y10 â†’ absolute (10,10)
+    // G91: X5 Y5  â†’ relative from (10,10) â†’ (15,15)
+    // G90: X50 Y50 â†’ absolute (50,50)
+    expect(cutsContainPoint(r, 10, 10)).toBe(true);
+    expect(cutsContainPoint(r, 15, 15)).toBe(true);
+    expect(cutsContainPoint(r, 50, 50)).toBe(true);
   });
 
-  // ── Line number prefix ────────────────────────────────────────────────
+  // â”€â”€ Line number prefix â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("ignores N-word line number prefix", () => {
     const r = parse("N100 G1 X10 Y20\nN200 G0 X30 Y40\n");
-    expect(r.cuts).toContain("L 10.000 20.000");
-    expect(r.rapids).toContain("L 30.000 40.000");
+    expect(cutsContainPoint(r, 10, 20)).toBe(true);
+    expect(rapidsContainPoint(r, 30, 40)).toBe(true);
   });
 
-  // ── Block delete ──────────────────────────────────────────────────────
+  // â”€â”€ Block delete â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("strips block-delete prefix '/' and still parses the line", () => {
     const r = parse("/ G1 X5 Y5\n");
-    expect(r.cuts).toContain("L 5.000 5.000");
+    expect(cutsContainPoint(r, 5, 5)).toBe(true);
   });
 
-  // ── Large file ────────────────────────────────────────────────────────
+  // â”€â”€ Large file â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("handles a large file with 1000+ lines", () => {
     const lines: string[] = ["G1"];
@@ -203,10 +234,10 @@ describe("parseGcode", () => {
     }
     const r = parse(lines.join("\n"));
     expect(r.lineCount).toBeGreaterThanOrEqual(1002);
-    expect(r.cuts).toContain("L 1000.000 1000.000");
+    expect(cutsContainPoint(r, 1000, 1000)).toBe(true);
   });
 
-  // ── fileSizeBytes ─────────────────────────────────────────────────────────
+  // â”€â”€ fileSizeBytes â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("reports fileSizeBytes equal to gcode string length", () => {
     const gcode = "G1 X10 Y10\n";
@@ -219,10 +250,10 @@ describe("parseGcode", () => {
     expect(r.fileSizeBytes).toBe(0);
   });
 
-  // ── totalCutDistance / totalRapidDistance ─────────────────────────────────
+  // â”€â”€ totalCutDistance / totalRapidDistance â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("accumulates totalCutDistance for G1 moves", () => {
-    // 3-4-5 right triangle: move from (0,0) to (3,4) → distance = 5
+    // 3-4-5 right triangle: move from (0,0) to (3,4) â†’ distance = 5
     const r = parse("G1 X3 Y4\n");
     expect(r.totalCutDistance).toBeCloseTo(5, 3);
     expect(r.totalRapidDistance).toBe(0);
@@ -248,7 +279,7 @@ describe("parseGcode", () => {
     expect(r.totalCutDistance).toBeCloseTo(25.4, 3);
   });
 
-  // ── feedrate ──────────────────────────────────────────────────────────────
+  // â”€â”€ feedrate â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
   it("returns feedrate 0 when no F word is present", () => {
     const r = parse("G1 X10 Y10\n");


### PR DESCRIPTION
This pull request introduces significant performance and memory optimizations to G-code parsing and generation, as well as improvements to progress reporting and test coverage. The most notable changes include switching from SVG path strings to typed arrays for representing toolpaths, implementing a highly efficient nearest-neighbour path optimizer, and improving the responsiveness and efficiency of the SVG-to-G-code worker.

**Performance and Memory Optimizations**

* The `parseGcode` function in `gcodeParser.ts` now outputs toolpaths as typed arrays (`Float32Array`) instead of SVG path strings, reducing memory usage and enabling more efficient rendering and filtering. The `GcodeToolpath` interface and the underlying parsing logic were updated accordingly. [[1]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8L3-R11) [[2]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8L33-R43) [[3]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8L58-R74) [[4]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8L151-R180) [[5]](diffhunk://#diff-a561a6b59df88cf57c0e148e39c2472f233184e775a757c72c6a7ce2c60a0bc8L172-R190) [[6]](diffhunk://#diff-7c0d34ff665e5e4ab9be4b79cf4c1000a9f52309a9ce386b7c1c295d121b4c3cL140-R141)

**Algorithm Improvements**

* The nearest-neighbour path optimizer in `gcodeEngine.ts` was rewritten to use a spatial grid, reducing path sorting complexity from O(n²) to O(n√n) and providing a ~1000× speedup for large jobs.

**Worker Responsiveness and Progress Reporting**

* The SVG-to-G-code worker (`svgWorker.ts`) now uses a time-based yielding strategy, yielding only after a frame's worth of work (~16ms), which improves responsiveness to cancel messages and eliminates the overhead of frequent setTimeouts. Progress reporting is now throttled to avoid excessive messages. [[1]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5L91-R121) [[2]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5L111-R137) [[3]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R158-R159) [[4]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5L153-R181)
* Minor formatting improvements for custom start/end G-code comments for consistency.

**Test Updates**

* The `PlotCanvas` test was updated to reflect that SVG imports are now rendered as hit-area rectangles for interaction, not as SVG path elements. [[1]](diffhunk://#diff-2349326bb72ff2ef6985eb89625a88c90b2847406d0deba138e3349208e88663L102-R102) [[2]](diffhunk://#diff-2349326bb72ff2ef6985eb89625a88c90b2847406d0deba138e3349208e88663L111-R114)
* The G-code toolpath factory was updated to use the new typed array format.