### PR TITLE
Copy paste layers

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -125,7 +125,7 @@ function buildApplicationMenu(): void {
           click: (_item, win) => {
             // Let native cut handle any text-input focus, and also notify the
             // renderer so it can perform a canvas-layer cut if one is selected.
-            win?.webContents.cut();
+            if (win instanceof BrowserWindow) win.webContents.cut();
             safeSend("menu:editCut");
           },
         },
@@ -135,7 +135,7 @@ function buildApplicationMenu(): void {
           accelerator: "CmdOrCtrl+C",
           enabled: false,
           click: (_item, win) => {
-            win?.webContents.copy();
+            if (win instanceof BrowserWindow) win.webContents.copy();
             safeSend("menu:editCopy");
           },
         },
@@ -145,7 +145,7 @@ function buildApplicationMenu(): void {
           accelerator: "CmdOrCtrl+V",
           click: (_item, win) => {
             // Native paste for text fields; canvas clipboard paste handled in renderer.
-            win?.webContents.paste();
+            if (win instanceof BrowserWindow) win.webContents.paste();
             safeSend("menu:editPaste");
           },
         },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -117,10 +117,49 @@ function buildApplicationMenu(): void {
         { role: "undo" as const },
         { role: "redo" as const },
         { type: "separator" as const },
-        { role: "cut" as const },
-        { role: "copy" as const },
-        { role: "paste" as const },
-        { role: "selectAll" as const },
+        {
+          id: "editCut",
+          label: "Cut",
+          accelerator: "CmdOrCtrl+X",
+          enabled: false,
+          click: (_item, win) => {
+            // Let native cut handle any text-input focus, and also notify the
+            // renderer so it can perform a canvas-layer cut if one is selected.
+            win?.webContents.cut();
+            safeSend("menu:editCut");
+          },
+        },
+        {
+          id: "editCopy",
+          label: "Copy",
+          accelerator: "CmdOrCtrl+C",
+          enabled: false,
+          click: (_item, win) => {
+            win?.webContents.copy();
+            safeSend("menu:editCopy");
+          },
+        },
+        {
+          id: "editPaste",
+          label: "Paste",
+          accelerator: "CmdOrCtrl+V",
+          click: (_item, win) => {
+            // Native paste for text fields; canvas clipboard paste handled in renderer.
+            win?.webContents.paste();
+            safeSend("menu:editPaste");
+          },
+        },
+        {
+          id: "editSelectAll",
+          label: "Select All",
+          accelerator: "CmdOrCtrl+A",
+          click: () => {
+            // Do NOT call webContents.selectAll() here — that selects all page
+            // text.  The renderer decides whether to canvas-select or let the
+            // native text-selection behaviour take over.
+            safeSend("menu:editSelectAll");
+          },
+        },
       ],
     },
 
@@ -168,6 +207,15 @@ ipcMain.on("menu:setLayoutMenuState", (_e, hasImports: boolean) => {
   const close = menu?.getMenuItemById("closeLayout");
   if (save) save.enabled = hasImports;
   if (close) close.enabled = hasImports;
+});
+
+// Enable/disable Cut and Copy menu items based on whether a canvas import is selected.
+ipcMain.on("menu:setEditMenuState", (_e, hasSelection: boolean) => {
+  const menu = Menu.getApplicationMenu();
+  const cut = menu?.getMenuItemById("editCut");
+  const copy = menu?.getMenuItemById("editCopy");
+  if (cut) cut.enabled = hasSelection;
+  if (copy) copy.enabled = hasSelection;
 });
 
 app.whenReady().then(() => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -186,6 +186,33 @@ const appApi: TerraForgeAPI["app"] = {
   },
 };
 
+// ─── Edit API ─────────────────────────────────────────────────────────────────
+
+const editApi: TerraForgeAPI["edit"] = {
+  onMenuCopy: (cb) => {
+    const listener = () => cb();
+    ipcRenderer.on("menu:editCopy", listener);
+    return () => ipcRenderer.off("menu:editCopy", listener);
+  },
+  onMenuCut: (cb) => {
+    const listener = () => cb();
+    ipcRenderer.on("menu:editCut", listener);
+    return () => ipcRenderer.off("menu:editCut", listener);
+  },
+  onMenuPaste: (cb) => {
+    const listener = () => cb();
+    ipcRenderer.on("menu:editPaste", listener);
+    return () => ipcRenderer.off("menu:editPaste", listener);
+  },
+  onMenuSelectAll: (cb) => {
+    const listener = () => cb();
+    ipcRenderer.on("menu:editSelectAll", listener);
+    return () => ipcRenderer.off("menu:editSelectAll", listener);
+  },
+  setHasSelection: (hasSelection) =>
+    ipcRenderer.send("menu:setEditMenuState", hasSelection),
+};
+
 // ─── Expose to renderer ───────────────────────────────────────────────────────
 
 const api: TerraForgeAPI = {
@@ -196,5 +223,6 @@ const api: TerraForgeAPI = {
   jobs,
   config,
   app: appApi,
+  edit: editApi,
 };
 contextBridge.exposeInMainWorld("terraForge", api);

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -49,8 +49,10 @@ export function PlotCanvas() {
 
   const imports = useCanvasStore((s) => s.imports);
   const selectedImportId = useCanvasStore((s) => s.selectedImportId);
+  const allImportsSelected = useCanvasStore((s) => s.allImportsSelected);
   const selectImport = useCanvasStore((s) => s.selectImport);
   const removeImport = useCanvasStore((s) => s.removeImport);
+  const clearImports = useCanvasStore((s) => s.clearImports);
   const updateImport = useCanvasStore((s) => s.updateImport);
   const gcodeToolpath = useCanvasStore((s) => s.gcodeToolpath);
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
@@ -275,7 +277,9 @@ export function PlotCanvas() {
 
       // Delete / Backspace → remove selected item
       if (e.key === "Delete" || e.key === "Backspace") {
-        if (selectedImportId) {
+        if (allImportsSelected) {
+          clearImports();
+        } else if (selectedImportId) {
           removeImport(selectedImportId);
         } else if (toolpathSelected && !isJobActive) {
           setGcodeToolpath(null);
@@ -323,9 +327,11 @@ export function PlotCanvas() {
     };
   }, [
     selectedImportId,
+    allImportsSelected,
     toolpathSelected,
     isJobActive,
     removeImport,
+    clearImports,
     selectImport,
     selectToolpath,
     setGcodeToolpath,
@@ -773,7 +779,8 @@ export function PlotCanvas() {
           // Effective pixels-per-user-unit: used to emulate non-scaling-stroke.
           const avgImpScale =
             Math.sqrt(Math.abs(impSX) * Math.abs(impSY)) * vp.zoom;
-          const isImpSelected = imp.id === selectedImportId;
+          const isImpSelected =
+            allImportsSelected || imp.id === selectedImportId;
 
           ctx.save();
           ctx.setTransform(vpA, 0, 0, vpA, vpE, vpF);
@@ -975,6 +982,7 @@ export function PlotCanvas() {
     bedYMax,
     imports,
     selectedImportId,
+    allImportsSelected,
     canvasH,
   ]);
 
@@ -1136,7 +1144,7 @@ export function PlotCanvas() {
             <ImportLayer
               key={imp.id}
               imp={imp}
-              selected={selectedImportId === imp.id}
+              selected={allImportsSelected || selectedImportId === imp.id}
               onImportMouseDown={onImportMouseDown}
               getBedY={getBedY}
             />
@@ -1144,12 +1152,10 @@ export function PlotCanvas() {
       </svg>
 
       {/* ── Handle overlay — bounding box + handles in pure screen-pixel space */}
-      {selectedImportId &&
-        containerSize.w > 0 &&
-        (() => {
-          const imp = imports.find((i) => i.id === selectedImportId);
-          return imp ? (
+      {allImportsSelected && containerSize.w > 0
+        ? imports.map((imp) => (
             <HandleOverlay
+              key={imp.id}
               imp={imp}
               zoom={vp.zoom}
               panX={vp.panX}
@@ -1161,8 +1167,26 @@ export function PlotCanvas() {
               onRotateHandleMouseDown={onRotateHandleMouseDown}
               onDelete={() => removeImport(imp.id)}
             />
-          ) : null;
-        })()}
+          ))
+        : selectedImportId &&
+          containerSize.w > 0 &&
+          (() => {
+            const imp = imports.find((i) => i.id === selectedImportId);
+            return imp ? (
+              <HandleOverlay
+                imp={imp}
+                zoom={vp.zoom}
+                panX={vp.panX}
+                panY={vp.panY}
+                containerW={containerSize.w}
+                containerH={containerSize.h}
+                getBedY={getBedY}
+                onHandleMouseDown={onHandleMouseDown}
+                onRotateHandleMouseDown={onRotateHandleMouseDown}
+                onDelete={() => removeImport(imp.id)}
+              />
+            ) : null;
+          })()}
 
       {/* ── Toolpath selection overlay — screen-pixel space ─────────────── */}
       {gcodeToolpath &&

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -231,6 +231,8 @@ export function PlotCanvas() {
     startMouseY: number;
     startObjX: number;
     startObjY: number;
+    /** Set when dragging all selected imports as a group. */
+    group?: { id: string; startX: number; startY: number }[];
   } | null>(null);
 
   // ── Scale-handle state ────────────────────────────────────────────────────────
@@ -393,8 +395,26 @@ export function PlotCanvas() {
     (e: React.MouseEvent, id: string) => {
       if (spaceRef.current) return; // space held → pan mode, not drag
       e.stopPropagation();
+      const state = useCanvasStore.getState();
+      // In group mode clicking an import continues the group drag without
+      // breaking out to single selection.
+      if (state.allImportsSelected) {
+        setDragging({
+          id,
+          startMouseX: e.clientX,
+          startMouseY: e.clientY,
+          startObjX: 0,
+          startObjY: 0,
+          group: state.imports.map((imp) => ({
+            id: imp.id,
+            startX: imp.x,
+            startY: imp.y,
+          })),
+        });
+        return;
+      }
       selectImport(id);
-      const imp = useCanvasStore.getState().imports.find((i) => i.id === id);
+      const imp = state.imports.find((i) => i.id === id);
       if (!imp) return;
       setDragging({
         id,
@@ -459,6 +479,28 @@ export function PlotCanvas() {
     [],
   );
 
+  /** Starts a group drag — fired from the GroupHandleOverlay hit area. */
+  const onGroupMouseDown = useCallback(
+    (e: React.MouseEvent<SVGRectElement>) => {
+      if (spaceRef.current) return;
+      e.stopPropagation();
+      const currentImports = useCanvasStore.getState().imports;
+      setDragging({
+        id: "__group__",
+        startMouseX: e.clientX,
+        startMouseY: e.clientY,
+        startObjX: 0,
+        startObjY: 0,
+        group: currentImports.map((imp) => ({
+          id: imp.id,
+          startX: imp.x,
+          startY: imp.y,
+        })),
+      });
+    },
+    [],
+  );
+
   // ── Unified window mousemove / mouseup ────────────────────────────────────────
   const onMouseMove = useCallback(
     (e: MouseEvent) => {
@@ -480,10 +522,16 @@ export function PlotCanvas() {
         const zoom = vpRef.current.zoom;
         const dx = (e.clientX - dragging.startMouseX) / (MM_TO_PX * zoom);
         const dy = -(e.clientY - dragging.startMouseY) / (MM_TO_PX * zoom);
-        updateImport(dragging.id, {
-          x: dragging.startObjX + dx,
-          y: dragging.startObjY + dy,
-        });
+        if (dragging.group) {
+          for (const item of dragging.group) {
+            updateImport(item.id, { x: item.startX + dx, y: item.startY + dy });
+          }
+        } else {
+          updateImport(dragging.id, {
+            x: dragging.startObjX + dx,
+            y: dragging.startObjY + dy,
+          });
+        }
       }
 
       // Scale-handle drag
@@ -1152,10 +1200,25 @@ export function PlotCanvas() {
       </svg>
 
       {/* ── Handle overlay — bounding box + handles in pure screen-pixel space */}
-      {allImportsSelected && containerSize.w > 0
-        ? imports.map((imp) => (
+      {allImportsSelected && containerSize.w > 0 ? (
+        <GroupHandleOverlay
+          imports={imports.filter((i) => i.visible)}
+          zoom={vp.zoom}
+          panX={vp.panX}
+          panY={vp.panY}
+          containerW={containerSize.w}
+          containerH={containerSize.h}
+          getBedY={getBedY}
+          onGroupMouseDown={onGroupMouseDown}
+          onDelete={clearImports}
+        />
+      ) : (
+        selectedImportId &&
+        containerSize.w > 0 &&
+        (() => {
+          const imp = imports.find((i) => i.id === selectedImportId);
+          return imp ? (
             <HandleOverlay
-              key={imp.id}
               imp={imp}
               zoom={vp.zoom}
               panX={vp.panX}
@@ -1167,26 +1230,9 @@ export function PlotCanvas() {
               onRotateHandleMouseDown={onRotateHandleMouseDown}
               onDelete={() => removeImport(imp.id)}
             />
-          ))
-        : selectedImportId &&
-          containerSize.w > 0 &&
-          (() => {
-            const imp = imports.find((i) => i.id === selectedImportId);
-            return imp ? (
-              <HandleOverlay
-                imp={imp}
-                zoom={vp.zoom}
-                panX={vp.panX}
-                panY={vp.panY}
-                containerW={containerSize.w}
-                containerH={containerSize.h}
-                getBedY={getBedY}
-                onHandleMouseDown={onHandleMouseDown}
-                onRotateHandleMouseDown={onRotateHandleMouseDown}
-                onDelete={() => removeImport(imp.id)}
-              />
-            ) : null;
-          })()}
+          ) : null;
+        })()
+      )}
 
       {/* ── Toolpath selection overlay — screen-pixel space ─────────────── */}
       {gcodeToolpath &&
@@ -1803,6 +1849,159 @@ function ImportLayer({
         />
       </g>
     </g>
+  );
+}
+
+// ─── Group handle overlay ─ single AABB around all selected imports ──────────
+interface GroupHandleOverlayProps {
+  imports: SvgImport[];
+  zoom: number;
+  panX: number;
+  panY: number;
+  containerW: number;
+  containerH: number;
+  getBedY: (mm: number) => number;
+  onGroupMouseDown: (e: React.MouseEvent<SVGRectElement>) => void;
+  onDelete: () => void;
+}
+
+function GroupHandleOverlay({
+  imports,
+  zoom,
+  panX,
+  panY,
+  containerW,
+  containerH,
+  getBedY,
+  onGroupMouseDown,
+  onDelete,
+}: GroupHandleOverlayProps) {
+  if (imports.length === 0) return null;
+
+  // World (SVG canvas) → screen (CSS pixel) transform
+  const w2s = (x: number, y: number): [number, number] => [
+    x * zoom + panX,
+    y * zoom + panY,
+  ];
+
+  // Compute axis-aligned bounding box across ALL rotated import corners
+  let minSx = Infinity,
+    maxSx = -Infinity;
+  let minSy = Infinity,
+    maxSy = -Infinity;
+
+  for (const imp of imports) {
+    const sX = (imp.scaleX ?? imp.scale) * MM_TO_PX;
+    const sY = (imp.scaleY ?? imp.scale) * MM_TO_PX;
+    const left = PAD + imp.x * MM_TO_PX;
+    const top = getBedY(imp.y + imp.svgHeight * (imp.scaleY ?? imp.scale));
+    const bboxW = imp.svgWidth * sX;
+    const bboxH = imp.svgHeight * sY;
+    const cxSvg = left + bboxW / 2;
+    const cySvg = top + bboxH / 2;
+    const hw = bboxW / 2;
+    const hh = bboxH / 2;
+    const rad = ((imp.rotation ?? 0) * Math.PI) / 180;
+    const cosA = Math.cos(rad);
+    const sinA = Math.sin(rad);
+
+    for (const [ox, oy] of [
+      [-hw, -hh],
+      [hw, -hh],
+      [hw, hh],
+      [-hw, hh],
+    ] as [number, number][]) {
+      const [sx, sy] = w2s(
+        cxSvg + ox * cosA - oy * sinA,
+        cySvg + ox * sinA + oy * cosA,
+      );
+      if (sx < minSx) minSx = sx;
+      if (sx > maxSx) maxSx = sx;
+      if (sy < minSy) minSy = sy;
+      if (sy > maxSy) maxSy = sy;
+    }
+  }
+
+  const BBOX_PAD = 6; // extra padding around AABB in screen px
+  minSx -= BBOX_PAD;
+  minSy -= BBOX_PAD;
+  maxSx += BBOX_PAD;
+  maxSy += BBOX_PAD;
+
+  // Place the delete button at the top-right corner
+  const delSx = maxSx + DEL_OFFSET_PX * 0.7;
+  const delSy = minSy - DEL_OFFSET_PX * 0.7;
+
+  return (
+    <svg
+      style={{
+        position: "absolute",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+        zIndex: 5,
+      }}
+      width={containerW}
+      height={containerH}
+      viewBox={`0 0 ${containerW} ${containerH}`}
+    >
+      {/* Dashed bounding box outline */}
+      <rect
+        x={minSx}
+        y={minSy}
+        width={maxSx - minSx}
+        height={maxSy - minSy}
+        fill="none"
+        stroke="#e94560"
+        strokeWidth={1}
+        strokeDasharray="4 2"
+        pointerEvents="none"
+      />
+      {/* Transparent drag hit area — same bounds as the outline */}
+      <rect
+        x={minSx}
+        y={minSy}
+        width={maxSx - minSx}
+        height={maxSy - minSy}
+        fill="transparent"
+        style={{ cursor: "grab", pointerEvents: "all" }}
+        onMouseDown={onGroupMouseDown}
+      />
+      {/* Delete button */}
+      <g
+        data-testid="group-handle-delete"
+        transform={`translate(${delSx},${delSy})`}
+        style={{ cursor: "pointer", pointerEvents: "all" }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+      >
+        <svg
+          x={-DEL_HALF_PX}
+          y={-DEL_HALF_PX}
+          width={DEL_HALF_PX * 2}
+          height={DEL_HALF_PX * 2}
+          viewBox="0 0 24 24"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect
+            width="18"
+            height="18"
+            x="3"
+            y="3"
+            rx="2"
+            ry="2"
+            fill="#e94560"
+            stroke="none"
+          />
+          <path d="m15 9-6 6" stroke="white" strokeWidth={2.5} />
+          <path d="m9 9 6 6" stroke="white" strokeWidth={2.5} />
+        </svg>
+      </g>
+    </svg>
   );
 }
 

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -257,6 +257,67 @@ export function PlotCanvas() {
     startRotation: number; // imp.rotation at mousedown (degrees)
   } | null>(null);
 
+  // ── Group scale-handle state ──────────────────────────────────────────────────
+  const [groupScaling, setGroupScaling] = useState<{
+    handle: HandlePos;
+    startMouseX: number;
+    startMouseY: number;
+    gCx: number;
+    gCy: number; // group AABB centre in SVG world px
+    gHW: number;
+    gHH: number; // group AABB half-extents in SVG world px
+    items: {
+      id: string;
+      startScaleX: number;
+      startScaleY: number;
+      cxSvg: number; // import centre in SVG world px at gesture start
+      cySvg: number;
+    }[];
+  } | null>(null);
+
+  // ── Group rotate-handle state ─────────────────────────────────────────────────
+  const [groupRotating, setGroupRotating] = useState<{
+    gCx: number;
+    gCy: number; // group AABB centre in SVG world px
+    gHW: number; // group AABB half-width in SVG world px (with padding)
+    gHH: number; // group AABB half-height in SVG world px (with padding)
+    startAngle: number;
+    baseOBBAngle: number; // accumulated OBB angle from previous gestures (degrees)
+    items: {
+      id: string;
+      cxSvg: number;
+      cySvg: number;
+      startX: number;
+      startY: number;
+      startRotation: number;
+    }[];
+  } | null>(null);
+
+  // Live OBB angle (degrees) updated on every mousemove during a rotation gesture.
+  // Equals baseOBBAngle + current-gesture delta.
+  const [groupOBBAngle, setGroupOBBAngle] = useState(0);
+
+  // OBB geometry persisted after a rotation gesture so the box keeps its
+  // orientation when the mouse is released.
+  const [persistentGroupOBB, setPersistentGroupOBB] = useState<{
+    gCx: number;
+    gCy: number;
+    gHW: number;
+    gHH: number;
+    angle: number;
+  } | null>(null);
+  const persistentGroupOBBRef = useRef(persistentGroupOBB);
+  persistentGroupOBBRef.current = persistentGroupOBB;
+
+  // Clear the persistent OBB whenever the group selection is dropped so a
+  // new Ctrl+A always starts with a fresh axis-aligned bounding box.
+  useEffect(() => {
+    if (!allImportsSelected) {
+      setPersistentGroupOBB(null);
+      setGroupOBBAngle(0);
+    }
+  }, [allImportsSelected]);
+
   // ── Toolpath selection ────────────────────────────────────────────────────────
   // toolpathSelected and selectToolpath live in canvasStore so PropertiesPanel
   // can react to canvas selection changes (and vice versa).
@@ -479,6 +540,125 @@ export function PlotCanvas() {
     [],
   );
 
+  // Mutable refs so group gesture callbacks can read current layout values
+  // without needing to be re-created on every render.
+  const isBottomRef = useRef(isBottom);
+  isBottomRef.current = isBottom;
+  const canvasHRef = useRef(canvasH);
+  canvasHRef.current = canvasH;
+  const getBedYRef = useRef(getBedY);
+  getBedYRef.current = getBedY;
+
+  // ── Group handle callbacks ────────────────────────────────────────────────────
+  const onGroupHandleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGCircleElement>, handle: HandlePos) => {
+      e.stopPropagation();
+      const { imports: imps } = useCanvasStore.getState();
+      const gBedY = getBedYRef.current;
+      let minWx = Infinity,
+        maxWx = -Infinity,
+        minWy = Infinity,
+        maxWy = -Infinity;
+      const items: {
+        id: string;
+        startScaleX: number;
+        startScaleY: number;
+        cxSvg: number;
+        cySvg: number;
+      }[] = [];
+      for (const imp of imps) {
+        const sX = (imp.scaleX ?? imp.scale) * MM_TO_PX;
+        const sY = (imp.scaleY ?? imp.scale) * MM_TO_PX;
+        const left = PAD + imp.x * MM_TO_PX;
+        const top = gBedY(imp.y + imp.svgHeight * (imp.scaleY ?? imp.scale));
+        const hw = (imp.svgWidth * sX) / 2;
+        const hh = (imp.svgHeight * sY) / 2;
+        const cxSvg = left + hw;
+        const cySvg = top + hh;
+        const rad = ((imp.rotation ?? 0) * Math.PI) / 180;
+        const cosA = Math.cos(rad);
+        const sinA = Math.sin(rad);
+        for (const [ox, oy] of [
+          [-hw, -hh],
+          [hw, -hh],
+          [hw, hh],
+          [-hw, hh],
+        ] as [number, number][]) {
+          const wx = cxSvg + ox * cosA - oy * sinA;
+          const wy = cySvg + ox * sinA + oy * cosA;
+          if (wx < minWx) minWx = wx;
+          if (wx > maxWx) maxWx = wx;
+          if (wy < minWy) minWy = wy;
+          if (wy > maxWy) maxWy = wy;
+        }
+        items.push({
+          id: imp.id,
+          startScaleX: imp.scaleX ?? imp.scale,
+          startScaleY: imp.scaleY ?? imp.scale,
+          cxSvg,
+          cySvg,
+        });
+      }
+      setPersistentGroupOBB(null); // geometry changes — discard stale OBB
+      setGroupScaling({
+        handle,
+        startMouseX: e.clientX,
+        startMouseY: e.clientY,
+        gCx: (minWx + maxWx) / 2,
+        gCy: (minWy + maxWy) / 2,
+        gHW: (maxWx - minWx) / 2,
+        gHH: (maxWy - minWy) / 2,
+        items,
+      });
+    },
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const onGroupRotateHandleMouseDown = useCallback(
+    (
+      e: React.MouseEvent<SVGCircleElement>,
+      gCx: number,
+      gCy: number,
+      gHW: number,
+      gHH: number,
+    ) => {
+      e.stopPropagation();
+      const { imports: imps } = useCanvasStore.getState();
+      const gBedY = getBedYRef.current;
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const vp = vpRef.current;
+      const mx = (e.clientX - rect.left - vp.panX) / vp.zoom;
+      const my = (e.clientY - rect.top - vp.panY) / vp.zoom;
+      const baseOBBAngle = persistentGroupOBBRef.current?.angle ?? 0;
+      setGroupOBBAngle(baseOBBAngle);
+      setGroupRotating({
+        gCx,
+        gCy,
+        gHW,
+        gHH,
+        baseOBBAngle,
+        startAngle: Math.atan2(my - gCy, mx - gCx),
+        items: imps.map((imp) => {
+          const sX = (imp.scaleX ?? imp.scale) * MM_TO_PX;
+          const sY = (imp.scaleY ?? imp.scale) * MM_TO_PX;
+          const left = PAD + imp.x * MM_TO_PX;
+          const top = gBedY(imp.y + imp.svgHeight * (imp.scaleY ?? imp.scale));
+          return {
+            id: imp.id,
+            cxSvg: left + (imp.svgWidth * sX) / 2,
+            cySvg: top + (imp.svgHeight * sY) / 2,
+            startX: imp.x,
+            startY: imp.y,
+            startRotation: imp.rotation ?? 0,
+          };
+        }),
+      });
+    },
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
   /** Starts a group drag — fired from the GroupHandleOverlay hit area. */
   const onGroupMouseDown = useCallback(
     (e: React.MouseEvent<SVGRectElement>) => {
@@ -609,24 +789,157 @@ export function PlotCanvas() {
         const delta = (angle - rotating.startAngle) * (180 / Math.PI);
         updateImport(rotating.id, { rotation: rotating.startRotation + delta });
       }
+
+      // Group scale-handle drag
+      if (groupScaling) {
+        const zoom = vpRef.current.zoom;
+        const dx = (e.clientX - groupScaling.startMouseX) / zoom;
+        const dy = (e.clientY - groupScaling.startMouseY) / zoom;
+        const h = groupScaling.handle;
+        const { gCx, gCy, gHW, gHH } = groupScaling;
+        // Scale factor in the primary axis for this handle
+        let delta = 0;
+        if (h === "tl" || h === "bl") delta = -dx;
+        else if (h === "tr" || h === "br") delta = dx;
+        else if (h === "t") delta = -dy;
+        else if (h === "b") delta = dy;
+        else if (h === "r") delta = dx;
+        else if (h === "l") delta = -dx;
+        const dimPx = h === "t" || h === "b" ? 2 * gHH : 2 * gHW;
+        const k = Math.max(0.001, 1 + delta / dimPx);
+        // For edge handles scale only one axis; corners = uniform.
+        const kX = h === "t" || h === "b" ? 1 : k;
+        const kY = h === "l" || h === "r" ? 1 : k;
+        // Anchor: opposite corner/edge in SVG world coords
+        const ax =
+          h === "tl" || h === "bl"
+            ? gCx + gHW
+            : h === "tr" || h === "br"
+              ? gCx - gHW
+              : gCx;
+        const ay =
+          h === "tl" || h === "tr"
+            ? gCy + gHH
+            : h === "bl" || h === "br"
+              ? gCy - gHH
+              : gCy;
+        const ib = isBottomRef.current;
+        const cH = canvasHRef.current;
+        for (const item of groupScaling.items) {
+          const imp = useCanvasStore
+            .getState()
+            .imports.find((i) => i.id === item.id);
+          if (!imp) continue;
+          const newSX = item.startScaleX * kX;
+          const newSY = item.startScaleY * kY;
+          const newCxSvg = ax + (item.cxSvg - ax) * kX;
+          const newCySvg = ay + (item.cySvg - ay) * kY;
+          const newX = (newCxSvg - PAD) / MM_TO_PX - (imp.svgWidth * newSX) / 2;
+          const newY = ib
+            ? (cH - PAD - newCySvg) / MM_TO_PX - (imp.svgHeight * newSY) / 2
+            : (newCySvg - PAD) / MM_TO_PX - (imp.svgHeight * newSY) / 2;
+          updateImport(item.id, {
+            x: newX,
+            y: newY,
+            scaleX: newSX,
+            scaleY: newSY,
+          });
+        }
+      }
+
+      // Group rotate-handle drag
+      if (groupRotating) {
+        const container = containerRef.current;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        const vp = vpRef.current;
+        const mx = (e.clientX - rect.left - vp.panX) / vp.zoom;
+        const my = (e.clientY - rect.top - vp.panY) / vp.zoom;
+        const angle = Math.atan2(
+          my - groupRotating.gCy,
+          mx - groupRotating.gCx,
+        );
+        const delta = (angle - groupRotating.startAngle) * (180 / Math.PI);
+        setGroupOBBAngle(groupRotating.baseOBBAngle + delta);
+        const rad = (delta * Math.PI) / 180;
+        const cosD = Math.cos(rad);
+        const sinD = Math.sin(rad);
+        const ib = isBottomRef.current;
+        const cH = canvasHRef.current;
+        for (const item of groupRotating.items) {
+          const imp = useCanvasStore
+            .getState()
+            .imports.find((i) => i.id === item.id);
+          if (!imp) continue;
+          const dx2 = item.cxSvg - groupRotating.gCx;
+          const dy2 = item.cySvg - groupRotating.gCy;
+          const newCxSvg = groupRotating.gCx + dx2 * cosD - dy2 * sinD;
+          const newCySvg = groupRotating.gCy + dx2 * sinD + dy2 * cosD;
+          const sX = imp.scaleX ?? imp.scale;
+          const sY = imp.scaleY ?? imp.scale;
+          const newX = (newCxSvg - PAD) / MM_TO_PX - (imp.svgWidth * sX) / 2;
+          const newY = ib
+            ? (cH - PAD - newCySvg) / MM_TO_PX - (imp.svgHeight * sY) / 2
+            : (newCySvg - PAD) / MM_TO_PX - (imp.svgHeight * sY) / 2;
+          updateImport(item.id, {
+            x: newX,
+            y: newY,
+            rotation: item.startRotation + delta,
+          });
+        }
+      }
     },
-    [dragging, scaling, rotating, updateImport, setVp, setFitted],
+    [
+      dragging,
+      scaling,
+      rotating,
+      groupScaling,
+      groupRotating,
+      updateImport,
+      setVp,
+      setFitted,
+    ],
   );
 
   const onMouseUp = useCallback(() => {
     // If any gesture was active, mark it so the SVG onClick can ignore the
     // synthetic click that the browser fires after mouseup.
-    if (dragging || scaling || rotating || panStartRef.current) {
+    if (
+      dragging ||
+      scaling ||
+      rotating ||
+      groupScaling ||
+      groupRotating ||
+      panStartRef.current
+    ) {
       justDraggedRef.current = true;
     }
     setDragging(null);
     setScaling(null);
     setRotating(null);
+    // Persist OBB orientation after a completed rotation gesture so the box
+    // doesn't snap back to axis-aligned when the mouse is released.
+    if (groupRotating) {
+      setPersistentGroupOBB({
+        gCx: groupRotating.gCx,
+        gCy: groupRotating.gCy,
+        gHW: groupRotating.gHW,
+        gHH: groupRotating.gHH,
+        angle: groupOBBAngle,
+      });
+    }
+    // Discard stale OBB when drag or scale has changed the group's geometry.
+    if (dragging?.group || groupScaling) {
+      setPersistentGroupOBB(null);
+    }
+    setGroupScaling(null);
+    setGroupRotating(null);
+    setGroupOBBAngle(0);
     if (panStartRef.current) {
       panStartRef.current = null;
       setIsPanning(false);
     }
-  }, [dragging, scaling, rotating]);
+  }, [dragging, scaling, rotating, groupScaling, groupRotating, groupOBBAngle]);
 
   useEffect(() => {
     window.addEventListener("mousemove", onMouseMove);
@@ -1210,7 +1523,20 @@ export function PlotCanvas() {
           containerH={containerSize.h}
           getBedY={getBedY}
           onGroupMouseDown={onGroupMouseDown}
+          onGroupHandleMouseDown={onGroupHandleMouseDown}
+          onGroupRotateHandleMouseDown={onGroupRotateHandleMouseDown}
           onDelete={clearImports}
+          activeOBB={
+            groupRotating
+              ? {
+                  gCx: groupRotating.gCx,
+                  gCy: groupRotating.gCy,
+                  gHW: groupRotating.gHW,
+                  gHH: groupRotating.gHH,
+                  angle: groupOBBAngle,
+                }
+              : (persistentGroupOBB ?? undefined)
+          }
         />
       ) : (
         selectedImportId &&
@@ -1862,7 +2188,26 @@ interface GroupHandleOverlayProps {
   containerH: number;
   getBedY: (mm: number) => number;
   onGroupMouseDown: (e: React.MouseEvent<SVGRectElement>) => void;
+  onGroupHandleMouseDown: (
+    e: React.MouseEvent<SVGCircleElement>,
+    handle: HandlePos,
+  ) => void;
+  onGroupRotateHandleMouseDown: (
+    e: React.MouseEvent<SVGCircleElement>,
+    gCx: number,
+    gCy: number,
+    gHW: number,
+    gHH: number,
+  ) => void;
   onDelete: () => void;
+  /** When a rotation gesture is active, render an OBB instead of AABB. */
+  activeOBB?: {
+    gCx: number;
+    gCy: number;
+    gHW: number;
+    gHH: number;
+    angle: number;
+  };
 }
 
 function GroupHandleOverlay({
@@ -1874,7 +2219,10 @@ function GroupHandleOverlay({
   containerH,
   getBedY,
   onGroupMouseDown,
+  onGroupHandleMouseDown,
+  onGroupRotateHandleMouseDown,
   onDelete,
+  activeOBB,
 }: GroupHandleOverlayProps) {
   if (imports.length === 0) return null;
 
@@ -1884,11 +2232,167 @@ function GroupHandleOverlay({
     y * zoom + panY,
   ];
 
-  // Compute axis-aligned bounding box across ALL rotated import corners
-  let minSx = Infinity,
-    maxSx = -Infinity;
-  let minSy = Infinity,
-    maxSy = -Infinity;
+  // Shared cursor map used by both OBB and AABB paths
+  type HEntry = [HandlePos, number, number];
+  const cursorMap: Record<HandlePos, string> = {
+    tl: "nwse-resize",
+    t: "ns-resize",
+    tr: "nesw-resize",
+    r: "ew-resize",
+    br: "nwse-resize",
+    b: "ns-resize",
+    bl: "nesw-resize",
+    l: "ew-resize",
+  };
+
+  // Shared delete-button SVG markup
+  const deleteIcon = (
+    <svg
+      x={-DEL_HALF_PX}
+      y={-DEL_HALF_PX}
+      width={DEL_HALF_PX * 2}
+      height={DEL_HALF_PX * 2}
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect
+        width="18"
+        height="18"
+        x="3"
+        y="3"
+        rx="2"
+        ry="2"
+        fill="#e94560"
+        stroke="none"
+      />
+      <path d="m15 9-6 6" stroke="white" strokeWidth={2.5} />
+      <path d="m9 9 6 6" stroke="white" strokeWidth={2.5} />
+    </svg>
+  );
+
+  // ── OBB path: active during a rotation gesture ───────────────────────────
+  // Instead of a recomputed axis-aligned box, we rotate the initial AABB
+  // (captured at gesture start) by the current angle delta using an SVG
+  // transform, so the box visually rotates with the group.
+  if (activeOBB) {
+    const { gCx: oCx, gCy: oCy, gHW: oHW, gHH: oHH, angle } = activeOBB;
+    const [pivotSx, pivotSy] = w2s(oCx, oCy);
+    const hw = oHW * zoom;
+    const hh = oHH * zoom;
+    const rotHy = pivotSy - hh - ROTATE_STEM_PX;
+    const delX = pivotSx + hw + DEL_OFFSET_PX * 0.7;
+    const delY = pivotSy - hh - DEL_OFFSET_PX * 0.7;
+    const obbHandles: HEntry[] = [
+      ["tl", pivotSx - hw, pivotSy - hh],
+      ["t", pivotSx, pivotSy - hh],
+      ["tr", pivotSx + hw, pivotSy - hh],
+      ["r", pivotSx + hw, pivotSy],
+      ["br", pivotSx + hw, pivotSy + hh],
+      ["b", pivotSx, pivotSy + hh],
+      ["bl", pivotSx - hw, pivotSy + hh],
+      ["l", pivotSx - hw, pivotSy],
+    ];
+    return (
+      <svg
+        style={{
+          position: "absolute",
+          inset: 0,
+          overflow: "hidden",
+          pointerEvents: "none",
+          zIndex: 5,
+        }}
+        width={containerW}
+        height={containerH}
+        viewBox={`0 0 ${containerW} ${containerH}`}
+      >
+        {/* Entire OBB is rendered inside a rotated <g> so the box and all
+            handles visually rotate with the group. */}
+        <g transform={`rotate(${angle}, ${pivotSx}, ${pivotSy})`}>
+          {/* Dashed OBB outline */}
+          <rect
+            x={pivotSx - hw}
+            y={pivotSy - hh}
+            width={hw * 2}
+            height={hh * 2}
+            fill="none"
+            stroke="#e94560"
+            strokeWidth={1}
+            strokeDasharray="4 2"
+            pointerEvents="none"
+          />
+          {/* Drag hit area */}
+          <rect
+            x={pivotSx - hw}
+            y={pivotSy - hh}
+            width={hw * 2}
+            height={hh * 2}
+            fill="transparent"
+            style={{ cursor: "grab", pointerEvents: "all" }}
+            onMouseDown={onGroupMouseDown}
+          />
+          {/* Rotation stem */}
+          <line
+            x1={pivotSx}
+            y1={pivotSy - hh}
+            x2={pivotSx}
+            y2={rotHy}
+            stroke="#e94560"
+            strokeWidth={1}
+            pointerEvents="none"
+          />
+          {/* Rotation handle */}
+          <circle
+            cx={pivotSx}
+            cy={rotHy}
+            r={HANDLE_SCREEN_R}
+            fill="#e94560"
+            stroke="white"
+            strokeWidth={1.5}
+            style={{ cursor: ROTATE_CURSOR, pointerEvents: "all" }}
+            onMouseDown={(e) =>
+              onGroupRotateHandleMouseDown(e, oCx, oCy, oHW, oHH)
+            }
+          />
+          {/* 8 scale handles */}
+          {obbHandles.map(([id, sx, sy]) => (
+            <circle
+              key={id}
+              cx={sx}
+              cy={sy}
+              r={HANDLE_SCREEN_R}
+              fill="white"
+              stroke="#e94560"
+              strokeWidth={1.5}
+              style={{ cursor: cursorMap[id], pointerEvents: "all" }}
+              onMouseDown={(e) => onGroupHandleMouseDown(e, id)}
+            />
+          ))}
+          {/* Delete button */}
+          <g
+            data-testid="group-handle-delete"
+            transform={`translate(${delX}, ${delY})`}
+            style={{ cursor: "pointer", pointerEvents: "all" }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            {deleteIcon}
+          </g>
+        </g>
+      </svg>
+    );
+  }
+
+  // ── AABB path: default (no active rotation gesture) ─────────────────────────
+  // Compute axis-aligned bounding box in SVG *world* coords first,
+  // so geometry callbacks can reference the same coordinate system.
+  let minWx = Infinity,
+    maxWx = -Infinity;
+  let minWy = Infinity,
+    maxWy = -Infinity;
 
   for (const imp of imports) {
     const sX = (imp.scaleX ?? imp.scale) * MM_TO_PX;
@@ -1904,33 +2408,60 @@ function GroupHandleOverlay({
     const rad = ((imp.rotation ?? 0) * Math.PI) / 180;
     const cosA = Math.cos(rad);
     const sinA = Math.sin(rad);
-
     for (const [ox, oy] of [
       [-hw, -hh],
       [hw, -hh],
       [hw, hh],
       [-hw, hh],
     ] as [number, number][]) {
-      const [sx, sy] = w2s(
-        cxSvg + ox * cosA - oy * sinA,
-        cySvg + ox * sinA + oy * cosA,
-      );
-      if (sx < minSx) minSx = sx;
-      if (sx > maxSx) maxSx = sx;
-      if (sy < minSy) minSy = sy;
-      if (sy > maxSy) maxSy = sy;
+      const wx = cxSvg + ox * cosA - oy * sinA;
+      const wy = cySvg + ox * sinA + oy * cosA;
+      if (wx < minWx) minWx = wx;
+      if (wx > maxWx) maxWx = wx;
+      if (wy < minWy) minWy = wy;
+      if (wy > maxWy) maxWy = wy;
     }
   }
 
-  const BBOX_PAD = 6; // extra padding around AABB in screen px
-  minSx -= BBOX_PAD;
-  minSy -= BBOX_PAD;
-  maxSx += BBOX_PAD;
-  maxSy += BBOX_PAD;
+  const BBOX_PAD_W = 6 / zoom; // extra padding in world px (zoom-invariant screen px)
+  minWx -= BBOX_PAD_W;
+  maxWx += BBOX_PAD_W;
+  minWy -= BBOX_PAD_W;
+  maxWy += BBOX_PAD_W;
 
-  // Place the delete button at the top-right corner
-  const delSx = maxSx + DEL_OFFSET_PX * 0.7;
-  const delSy = minSy - DEL_OFFSET_PX * 0.7;
+  const gCx = (minWx + maxWx) / 2;
+  const gCy = (minWy + maxWy) / 2;
+  const gHW = (maxWx - minWx) / 2;
+  const gHH = (maxWy - minWy) / 2;
+
+  // Convert AABB corners/edges to screen coords
+  const [tlSx, tlSy] = w2s(minWx, minWy);
+  const [trSx, trSy] = w2s(maxWx, minWy);
+  const [brSx, brSy] = w2s(maxWx, maxWy);
+  const [blSx, blSy] = w2s(minWx, maxWy);
+  const [tcSx, tcSy] = w2s(gCx, minWy);
+  const [bcSx, bcSy] = w2s(gCx, maxWy);
+  const [lcSx, lcSy] = w2s(minWx, gCy);
+  const [rcSx, rcSy] = w2s(maxWx, gCy);
+
+  const handles: HEntry[] = [
+    ["tl", tlSx, tlSy],
+    ["t", tcSx, tcSy],
+    ["tr", trSx, trSy],
+    ["r", rcSx, rcSy],
+    ["br", brSx, brSy],
+    ["b", bcSx, bcSy],
+    ["bl", blSx, blSy],
+    ["l", lcSx, lcSy],
+  ];
+
+  // Rotation handle: ROTATE_STEM_PX screen px above top-centre
+  const rotHx = tcSx;
+  const rotHy = tcSy - ROTATE_STEM_PX;
+
+  // Delete button: diagonal from top-right corner
+  const delSx = trSx + DEL_OFFSET_PX * 0.7;
+  const delSy = trSy - DEL_OFFSET_PX * 0.7;
 
   return (
     <svg
@@ -1947,26 +2478,61 @@ function GroupHandleOverlay({
     >
       {/* Dashed bounding box outline */}
       <rect
-        x={minSx}
-        y={minSy}
-        width={maxSx - minSx}
-        height={maxSy - minSy}
+        x={tlSx}
+        y={tlSy}
+        width={trSx - tlSx}
+        height={blSy - tlSy}
         fill="none"
         stroke="#e94560"
         strokeWidth={1}
         strokeDasharray="4 2"
         pointerEvents="none"
       />
-      {/* Transparent drag hit area — same bounds as the outline */}
+      {/* Transparent drag hit area (covers interior excluding handles) */}
       <rect
-        x={minSx}
-        y={minSy}
-        width={maxSx - minSx}
-        height={maxSy - minSy}
+        x={tlSx}
+        y={tlSy}
+        width={trSx - tlSx}
+        height={blSy - tlSy}
         fill="transparent"
         style={{ cursor: "grab", pointerEvents: "all" }}
         onMouseDown={onGroupMouseDown}
       />
+      {/* Rotation stem */}
+      <line
+        x1={tcSx}
+        y1={tcSy}
+        x2={rotHx}
+        y2={rotHy}
+        stroke="#e94560"
+        strokeWidth={1}
+        pointerEvents="none"
+      />
+      {/* Rotation handle */}
+      <circle
+        cx={rotHx}
+        cy={rotHy}
+        r={HANDLE_SCREEN_R}
+        fill="#e94560"
+        stroke="white"
+        strokeWidth={1.5}
+        style={{ cursor: ROTATE_CURSOR, pointerEvents: "all" }}
+        onMouseDown={(e) => onGroupRotateHandleMouseDown(e, gCx, gCy, gHW, gHH)}
+      />
+      {/* 8 scale handles */}
+      {handles.map(([id, sx, sy]) => (
+        <circle
+          key={id}
+          cx={sx}
+          cy={sy}
+          r={HANDLE_SCREEN_R}
+          fill="white"
+          stroke="#e94560"
+          strokeWidth={1.5}
+          style={{ cursor: cursorMap[id], pointerEvents: "all" }}
+          onMouseDown={(e) => onGroupHandleMouseDown(e, id)}
+        />
+      ))}
       {/* Delete button */}
       <g
         data-testid="group-handle-delete"

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -285,12 +285,18 @@ export function Toolbar({
   const setConnected = useMachineStore((s) => s.setConnected);
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
   const imports = useCanvasStore((s) => s.imports);
+  const selectedImportId = useCanvasStore((s) => s.selectedImportId);
   const addImport = useCanvasStore((s) => s.addImport);
   const clearImports = useCanvasStore((s) => s.clearImports);
   const loadLayout = useCanvasStore((s) => s.loadLayout);
   const setGcodeToolpath = useCanvasStore((s) => s.setGcodeToolpath);
   const setGcodeSource = useCanvasStore((s) => s.setGcodeSource);
   const selectToolpath = useCanvasStore((s) => s.selectToolpath);
+  const copyImport = useCanvasStore((s) => s.copyImport);
+  const cutImport = useCanvasStore((s) => s.cutImport);
+  const pasteImport = useCanvasStore((s) => s.pasteImport);
+  const selectAllImports = useCanvasStore((s) => s.selectAllImports);
+  const clipboardImport = useCanvasStore((s) => s.clipboardImport);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const registerCancelCallback = useTaskStore((s) => s.registerCancelCallback);
   const unregisterCancelCallback = useTaskStore(
@@ -792,6 +798,54 @@ export function Toolbar({
   loadLayoutRef.current = handleLoadLayout;
   closeLayoutRef.current = handleCloseLayout;
 
+  // ── Edit clipboard — keep refs current for use in stable IPC/keyboard listeners ─
+  const selectedImportIdRef = useRef(selectedImportId);
+  const clipboardImportRef = useRef(clipboardImport);
+  selectedImportIdRef.current = selectedImportId;
+  clipboardImportRef.current = clipboardImport;
+  const copyImportRef = useRef(copyImport);
+  const cutImportRef = useRef(cutImport);
+  const pasteImportRef = useRef(pasteImport);
+  const selectAllImportsRef = useRef(selectAllImports);
+  copyImportRef.current = copyImport;
+  cutImportRef.current = cutImport;
+  pasteImportRef.current = pasteImport;
+  selectAllImportsRef.current = selectAllImports;
+
+  /** Returns true if the event originates from a text editing element. */
+  function isTextInputFocused(): boolean {
+    const el = document.activeElement;
+    if (!el) return false;
+    const tag = el.tagName.toLowerCase();
+    return (
+      tag === "input" ||
+      tag === "textarea" ||
+      (el as HTMLElement).isContentEditable
+    );
+  }
+
+  /** Handle a copy request from menu or keyboard — canvas items only. */
+  function handleEditCopy() {
+    const id = selectedImportIdRef.current;
+    if (id) copyImportRef.current(id);
+  }
+
+  /** Handle a cut request from menu or keyboard — canvas items only. */
+  function handleEditCut() {
+    const id = selectedImportIdRef.current;
+    if (id) cutImportRef.current(id);
+  }
+
+  /** Handle a paste request from menu or keyboard. */
+  function handleEditPaste() {
+    if (clipboardImportRef.current) pasteImportRef.current();
+  }
+
+  /** Handle select-all from menu or keyboard — canvas items only. */
+  function handleEditSelectAll() {
+    selectAllImportsRef.current();
+  }
+
   // Subscribe to native File-menu → layout action events.
   useEffect(() => {
     const unsubImport = window.terraForge.fs.onMenuImport(() => handleImport());
@@ -807,12 +861,60 @@ export function Toolbar({
     const unsubAbout = window.terraForge.app.onMenuAbout(() =>
       setShowAbout(true),
     );
+
+    // ── Edit menu events (fired alongside native webContents ops) ────────────
+    const unsubCopy = window.terraForge.edit.onMenuCopy(() => {
+      if (!isTextInputFocused()) handleEditCopy();
+    });
+    const unsubCut = window.terraForge.edit.onMenuCut(() => {
+      if (!isTextInputFocused()) handleEditCut();
+    });
+    const unsubPaste = window.terraForge.edit.onMenuPaste(() => {
+      if (!isTextInputFocused()) handleEditPaste();
+    });
+    const unsubSelectAll = window.terraForge.edit.onMenuSelectAll(() => {
+      // Only canvas-select when focus isn't in a text field AND there is no
+      // active text selection (e.g. user highlighted text in the console).
+      if (!isTextInputFocused() && !window.getSelection()?.toString())
+        handleEditSelectAll();
+    });
+
+    // ── Keyboard shortcuts — intercept only when no text field is focused ────
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      if (isTextInputFocused()) return;
+      switch (e.key.toLowerCase()) {
+        case "c":
+          handleEditCopy();
+          break;
+        case "x":
+          handleEditCut();
+          break;
+        case "v":
+          handleEditPaste();
+          break;
+        case "a":
+          // If text is already selected somewhere, let the browser expand it
+          // natively rather than hijacking the shortcut for canvas selection.
+          if (window.getSelection()?.toString()) break;
+          handleEditSelectAll();
+          e.preventDefault(); // prevent browser select-all of page text
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+
     return () => {
       unsubImport();
       unsubOpen();
       unsubSave();
       unsubClose();
       unsubAbout();
+      unsubCopy();
+      unsubCut();
+      unsubPaste();
+      unsubSelectAll();
+      window.removeEventListener("keydown", onKeyDown);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -820,6 +922,11 @@ export function Toolbar({
   useEffect(() => {
     window.terraForge.fs.setLayoutMenuState(imports.length > 0);
   }, [imports.length]);
+
+  // Keep Edit → Cut / Copy menu items enabled only when a canvas import is selected.
+  useEffect(() => {
+    window.terraForge.edit.setHasSelection(selectedImportId !== null);
+  }, [selectedImportId]);
 
   const handleGenerateGcode = async (prefs: GcodePrefs) => {
     const cfg = activeConfig();

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -297,6 +297,7 @@ export function Toolbar({
   const pasteImport = useCanvasStore((s) => s.pasteImport);
   const selectAllImports = useCanvasStore((s) => s.selectAllImports);
   const clipboardImport = useCanvasStore((s) => s.clipboardImport);
+  const allImportsSelected = useCanvasStore((s) => s.allImportsSelected);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const registerCancelCallback = useTaskStore((s) => s.registerCancelCallback);
   const unregisterCancelCallback = useTaskStore(
@@ -801,16 +802,20 @@ export function Toolbar({
   // ── Edit clipboard — keep refs current for use in stable IPC/keyboard listeners ─
   const selectedImportIdRef = useRef(selectedImportId);
   const clipboardImportRef = useRef(clipboardImport);
+  const allImportsSelectedRef = useRef(allImportsSelected);
   selectedImportIdRef.current = selectedImportId;
   clipboardImportRef.current = clipboardImport;
+  allImportsSelectedRef.current = allImportsSelected;
   const copyImportRef = useRef(copyImport);
   const cutImportRef = useRef(cutImport);
   const pasteImportRef = useRef(pasteImport);
   const selectAllImportsRef = useRef(selectAllImports);
+  const clearImportsRef = useRef(clearImports);
   copyImportRef.current = copyImport;
   cutImportRef.current = cutImport;
   pasteImportRef.current = pasteImport;
   selectAllImportsRef.current = selectAllImports;
+  clearImportsRef.current = clearImports;
 
   /** Returns true if the event originates from a text editing element. */
   function isTextInputFocused(): boolean {
@@ -832,6 +837,10 @@ export function Toolbar({
 
   /** Handle a cut request from menu or keyboard — canvas items only. */
   function handleEditCut() {
+    if (allImportsSelectedRef.current) {
+      clearImportsRef.current();
+      return;
+    }
     const id = selectedImportIdRef.current;
     if (id) cutImportRef.current(id);
   }

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -873,10 +873,7 @@ export function Toolbar({
       if (!isTextInputFocused()) handleEditPaste();
     });
     const unsubSelectAll = window.terraForge.edit.onMenuSelectAll(() => {
-      // Only canvas-select when focus isn't in a text field AND there is no
-      // active text selection (e.g. user highlighted text in the console).
-      if (!isTextInputFocused() && !window.getSelection()?.toString())
-        handleEditSelectAll();
+      if (!isTextInputFocused()) handleEditSelectAll();
     });
 
     // ── Keyboard shortcuts — intercept only when no text field is focused ────
@@ -894,9 +891,6 @@ export function Toolbar({
           handleEditPaste();
           break;
         case "a":
-          // If text is already selected somewhere, let the browser expand it
-          // natively rather than hijacking the shortcut for canvas selection.
-          if (window.getSelection()?.toString()) break;
           handleEditSelectAll();
           e.preventDefault(); // prevent browser select-all of page text
           break;

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -413,12 +413,22 @@ export const useCanvasStore = create<CanvasState>()(
     selectAllImports: () =>
       set((state) => {
         if (state.imports.length === 0) return;
-        // If nothing is selected, select the first import
         if (!state.selectedImportId) {
+          // Nothing selected → select the first import.
           state.selectedImportId = state.imports[0].id;
-          state.selectedPathId = null;
-          state.toolpathSelected = false;
+        } else {
+          // Something already selected → advance to the next import so the user
+          // gets visible feedback and can cycle through all layers with Ctrl+A.
+          // Wraps back to the first import after the last one.
+          const idx = state.imports.findIndex(
+            (i) => i.id === state.selectedImportId,
+          );
+          const nextIdx =
+            idx === -1 || idx >= state.imports.length - 1 ? 0 : idx + 1;
+          state.selectedImportId = state.imports[nextIdx].id;
         }
+        state.selectedPathId = null;
+        state.toolpathSelected = false;
       }),
   })),
 );

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { v4 as uuid } from "uuid";
 import {
   type SvgImport,
   type SvgPath,
@@ -10,10 +11,32 @@ import {
 import type { GcodeToolpath } from "../utils/gcodeParser";
 import { generateHatchPaths } from "../utils/hatchFill";
 
+// ─── Clipboard helpers ────────────────────────────────────────────────────────
+
+/**
+ * Generate a unique copy name for a pasted import, following the pattern:
+ * "<base> copy" → "<base> copy (2)" → "<base> copy (3)" etc.
+ * Strips any existing copy suffix from sourceName before computing the base,
+ * so copying "foo copy" produces "foo copy (2)" rather than "foo copy copy".
+ */
+export function generateCopyName(
+  sourceName: string,
+  existingNames: string[],
+): string {
+  const base = sourceName.replace(/ copy \(\d+\)$/, "").replace(/ copy$/, "");
+  const copyBase = `${base} copy`;
+  if (!existingNames.includes(copyBase)) return copyBase;
+  let n = 2;
+  while (existingNames.includes(`${copyBase} (${n})`)) n++;
+  return `${copyBase} (${n})`;
+}
+
 interface CanvasState {
   imports: SvgImport[];
   selectedImportId: string | null;
   selectedPathId: string | null;
+  /** In-memory clipboard for cut/copy/paste of canvas imports. */
+  clipboardImport: SvgImport | null;
   gcodeToolpath: GcodeToolpath | null;
   /** Persists the file info for the currently loaded G-code toolpath so it
    *  can be restored into selectedJobFile when the user re-selects the toolpath
@@ -69,6 +92,16 @@ interface CanvasState {
     angleDeg: number,
     enabled: boolean,
   ) => void;
+
+  // ─── Clipboard ──────────────────────────────────────────────────────────────
+  /** Copy the selected import to the in-memory clipboard without removing it. */
+  copyImport: (id: string) => void;
+  /** Copy to clipboard and remove the import from the canvas. */
+  cutImport: (id: string) => void;
+  /** Paste the clipboard import as a new copy with an offset position and generated name. */
+  pasteImport: () => void;
+  /** Select the first import if none is currently selected. No-op when empty. */
+  selectAllImports: () => void;
 }
 
 export const useCanvasStore = create<CanvasState>()(
@@ -76,6 +109,7 @@ export const useCanvasStore = create<CanvasState>()(
     imports: [],
     selectedImportId: null,
     selectedPathId: null,
+    clipboardImport: null,
     gcodeToolpath: null,
     gcodeSource: null,
     toolpathSelected: false,
@@ -324,6 +358,66 @@ export const useCanvasStore = create<CanvasState>()(
 
           const lines = generateHatchPaths(p.d, spacingUnits, safeAngle);
           p.hatchLines = lines.length ? lines : undefined;
+        }
+      }),
+
+    // ─── Clipboard actions ──────────────────────────────────────────────────
+
+    copyImport: (id) => {
+      const imp = get().imports.find((i) => i.id === id);
+      if (!imp) return;
+      const snap = structuredClone(imp);
+      set((state) => {
+        state.clipboardImport = snap;
+      });
+    },
+
+    cutImport: (id) => {
+      const imp = get().imports.find((i) => i.id === id);
+      if (!imp) return;
+      const snap = structuredClone(imp);
+      set((state) => {
+        state.clipboardImport = snap;
+        state.imports = state.imports.filter((i) => i.id !== id);
+        if (state.selectedImportId === id) {
+          state.selectedImportId = null;
+          state.selectedPathId = null;
+        }
+      });
+    },
+
+    pasteImport: () => {
+      const clipboard = get().clipboardImport;
+      if (!clipboard) return;
+      const existingNames = get().imports.map((i) => i.name);
+      const newName = generateCopyName(clipboard.name, existingNames);
+      const newId = uuid();
+      const pasted: SvgImport = {
+        ...structuredClone(clipboard),
+        id: newId,
+        name: newName,
+        // Assign fresh IDs to all paths so they don't alias the originals
+        paths: clipboard.paths.map((p) => ({ ...p, id: uuid() })),
+        // Offset slightly so the copy doesn't sit exactly on top of the original
+        x: clipboard.x + 5,
+        y: clipboard.y + 5,
+      };
+      set((state) => {
+        state.imports.push(pasted);
+        state.selectedImportId = newId;
+        state.selectedPathId = null;
+        if (state.toolpathSelected) state.toolpathSelected = false;
+      });
+    },
+
+    selectAllImports: () =>
+      set((state) => {
+        if (state.imports.length === 0) return;
+        // If nothing is selected, select the first import
+        if (!state.selectedImportId) {
+          state.selectedImportId = state.imports[0].id;
+          state.selectedPathId = null;
+          state.toolpathSelected = false;
         }
       }),
   })),

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -35,6 +35,9 @@ interface CanvasState {
   imports: SvgImport[];
   selectedImportId: string | null;
   selectedPathId: string | null;
+  /** True when the user has "selected all" canvas imports (Ctrl+A). Cleared when
+   *  a single import is clicked, imports are cleared, or the toolpath is selected. */
+  allImportsSelected: boolean;
   /** In-memory clipboard for cut/copy/paste of canvas imports. */
   clipboardImport: SvgImport | null;
   gcodeToolpath: GcodeToolpath | null;
@@ -100,7 +103,8 @@ interface CanvasState {
   cutImport: (id: string) => void;
   /** Paste the clipboard import as a new copy with an offset position and generated name. */
   pasteImport: () => void;
-  /** Select the first import if none is currently selected. No-op when empty. */
+  /** Select all canvas imports.  If already all-selected, cycles to the first single
+   *  import so repeated Ctrl+A is still useful. */
   selectAllImports: () => void;
 }
 
@@ -109,6 +113,7 @@ export const useCanvasStore = create<CanvasState>()(
     imports: [],
     selectedImportId: null,
     selectedPathId: null,
+    allImportsSelected: false,
     clipboardImport: null,
     gcodeToolpath: null,
     gcodeSource: null,
@@ -138,6 +143,16 @@ export const useCanvasStore = create<CanvasState>()(
         if (state.selectedImportId === id) {
           state.selectedImportId = null;
           state.selectedPathId = null;
+        }
+        // If we were in "all selected" mode, re-evaluate — if only one remains select
+        // it individually; if none remain clear everything.
+        if (state.allImportsSelected) {
+          state.allImportsSelected = false;
+          if (state.imports.length === 1) {
+            state.selectedImportId = state.imports[0].id;
+          } else if (state.imports.length === 0) {
+            state.selectedImportId = null;
+          }
         }
       }),
 
@@ -196,6 +211,7 @@ export const useCanvasStore = create<CanvasState>()(
       set((state) => {
         state.selectedImportId = id;
         state.selectedPathId = null;
+        state.allImportsSelected = false;
         // Selecting an SVG import clears toolpath selection (and vice-versa).
         if (id !== null) state.toolpathSelected = false;
       }),
@@ -207,6 +223,7 @@ export const useCanvasStore = create<CanvasState>()(
         if (selected) {
           state.selectedImportId = null;
           state.selectedPathId = null;
+          state.allImportsSelected = false;
         }
       }),
 
@@ -215,6 +232,7 @@ export const useCanvasStore = create<CanvasState>()(
         state.imports = [];
         state.selectedImportId = null;
         state.selectedPathId = null;
+        state.allImportsSelected = false;
       }),
 
     loadLayout: (newImports) =>
@@ -227,6 +245,7 @@ export const useCanvasStore = create<CanvasState>()(
         }));
         state.selectedImportId = null;
         state.selectedPathId = null;
+        state.allImportsSelected = false;
       }),
 
     selectedImport: () => {
@@ -413,19 +432,18 @@ export const useCanvasStore = create<CanvasState>()(
     selectAllImports: () =>
       set((state) => {
         if (state.imports.length === 0) return;
-        if (!state.selectedImportId) {
-          // Nothing selected → select the first import.
+        if (state.imports.length === 1) {
+          // Only one import — just select it directly.
           state.selectedImportId = state.imports[0].id;
+          state.allImportsSelected = false;
+        } else if (!state.allImportsSelected) {
+          // Zero or one import selected → enter "all selected" mode.
+          state.allImportsSelected = true;
+          state.selectedImportId = null;
         } else {
-          // Something already selected → advance to the next import so the user
-          // gets visible feedback and can cycle through all layers with Ctrl+A.
-          // Wraps back to the first import after the last one.
-          const idx = state.imports.findIndex(
-            (i) => i.id === state.selectedImportId,
-          );
-          const nextIdx =
-            idx === -1 || idx >= state.imports.length - 1 ? 0 : idx + 1;
-          state.selectedImportId = state.imports[nextIdx].id;
+          // Already all-selected → cycle to the first import individually.
+          state.allImportsSelected = false;
+          state.selectedImportId = state.imports[0].id;
         }
         state.selectedPathId = null;
         state.toolpathSelected = false;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -335,6 +335,22 @@ export interface AppApi {
   onMenuAbout: (cb: () => void) => () => void;
 }
 
+export interface EditApi {
+  /** Subscribe to Edit → Copy menu item (fired alongside native webContents.copy). Returns unsub fn. */
+  onMenuCopy: (cb: () => void) => () => void;
+  /** Subscribe to Edit → Cut menu item. Returns unsub fn. */
+  onMenuCut: (cb: () => void) => () => void;
+  /** Subscribe to Edit → Paste menu item. Returns unsub fn. */
+  onMenuPaste: (cb: () => void) => () => void;
+  /** Subscribe to Edit → Select All menu item. Returns unsub fn. */
+  onMenuSelectAll: (cb: () => void) => () => void;
+  /**
+   * Notify the main process whether Copy/Cut should be enabled in the Edit menu.
+   * Call with true when an import is selected, false when nothing is selected.
+   */
+  setHasSelection: (hasSelection: boolean) => void;
+}
+
 export interface TerraForgeAPI {
   fluidnc: FluidNCApi;
   serial: SerialApi;
@@ -343,6 +359,7 @@ export interface TerraForgeAPI {
   jobs: JobsApi;
   config: ConfigApi;
   app: AppApi;
+  edit: EditApi;
 }
 
 // ─── Jog ─────────────────────────────────────────────────────────────────────

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -195,6 +195,13 @@ if (typeof window !== "undefined") {
       openExternal: vi.fn().mockResolvedValue(undefined),
       onMenuAbout: vi.fn().mockReturnValue(() => {}),
     },
+    edit: {
+      onMenuCopy: vi.fn().mockReturnValue(() => {}),
+      onMenuCut: vi.fn().mockReturnValue(() => {}),
+      onMenuPaste: vi.fn().mockReturnValue(() => {}),
+      onMenuSelectAll: vi.fn().mockReturnValue(() => {}),
+      setHasSelection: vi.fn(),
+    },
   };
   (window as any).terraForge = mockApi;
 }

--- a/tests/unit/stores/canvasStore.test.ts
+++ b/tests/unit/stores/canvasStore.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
     imports: [],
     selectedImportId: null,
     selectedPathId: null,
+    allImportsSelected: false,
     clipboardImport: null,
     gcodeToolpath: null,
     gcodeSource: null,
@@ -696,32 +697,43 @@ describe("canvasStore", () => {
       expect(useCanvasStore.getState().imports).toHaveLength(0);
     });
 
-    it("selectAllImports selects first import when nothing is selected", () => {
+    it("selectAllImports enters all-selected mode when multiple imports exist and none selected", () => {
       const imp1 = createSvgImport();
       const imp2 = createSvgImport();
       useCanvasStore.getState().addImport(imp1);
       useCanvasStore.getState().addImport(imp2);
       useCanvasStore.getState().selectAllImports();
-      expect(useCanvasStore.getState().selectedImportId).toBe(imp1.id);
+      expect(useCanvasStore.getState().allImportsSelected).toBe(true);
+      expect(useCanvasStore.getState().selectedImportId).toBeNull();
     });
 
-    it("selectAllImports cycles to the next import when one is already active", () => {
+    it("selectAllImports enters all-selected mode when one import is already selected", () => {
       const imp1 = createSvgImport();
       const imp2 = createSvgImport();
       useCanvasStore.getState().addImport(imp1);
       useCanvasStore.getState().addImport(imp2);
       useCanvasStore.getState().selectImport(imp1.id);
       useCanvasStore.getState().selectAllImports();
-      expect(useCanvasStore.getState().selectedImportId).toBe(imp2.id);
+      expect(useCanvasStore.getState().allImportsSelected).toBe(true);
+      expect(useCanvasStore.getState().selectedImportId).toBeNull();
     });
 
-    it("selectAllImports wraps from last import back to first", () => {
+    it("selectAllImports cycles to first import individually when already all-selected", () => {
       const imp1 = createSvgImport();
       const imp2 = createSvgImport();
       useCanvasStore.getState().addImport(imp1);
       useCanvasStore.getState().addImport(imp2);
-      useCanvasStore.getState().selectImport(imp2.id);
+      useCanvasStore.getState().selectAllImports(); // enter all-selected
+      useCanvasStore.getState().selectAllImports(); // cycle to first
+      expect(useCanvasStore.getState().allImportsSelected).toBe(false);
+      expect(useCanvasStore.getState().selectedImportId).toBe(imp1.id);
+    });
+
+    it("selectAllImports selects single import directly when only one exists", () => {
+      const imp1 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1);
       useCanvasStore.getState().selectAllImports();
+      expect(useCanvasStore.getState().allImportsSelected).toBe(false);
       expect(useCanvasStore.getState().selectedImportId).toBe(imp1.id);
     });
 

--- a/tests/unit/stores/canvasStore.test.ts
+++ b/tests/unit/stores/canvasStore.test.ts
@@ -705,14 +705,24 @@ describe("canvasStore", () => {
       expect(useCanvasStore.getState().selectedImportId).toBe(imp1.id);
     });
 
-    it("selectAllImports keeps current selection when one is already active", () => {
+    it("selectAllImports cycles to the next import when one is already active", () => {
+      const imp1 = createSvgImport();
+      const imp2 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1);
+      useCanvasStore.getState().addImport(imp2);
+      useCanvasStore.getState().selectImport(imp1.id);
+      useCanvasStore.getState().selectAllImports();
+      expect(useCanvasStore.getState().selectedImportId).toBe(imp2.id);
+    });
+
+    it("selectAllImports wraps from last import back to first", () => {
       const imp1 = createSvgImport();
       const imp2 = createSvgImport();
       useCanvasStore.getState().addImport(imp1);
       useCanvasStore.getState().addImport(imp2);
       useCanvasStore.getState().selectImport(imp2.id);
       useCanvasStore.getState().selectAllImports();
-      expect(useCanvasStore.getState().selectedImportId).toBe(imp2.id);
+      expect(useCanvasStore.getState().selectedImportId).toBe(imp1.id);
     });
 
     it("selectAllImports is a no-op when no imports exist", () => {

--- a/tests/unit/stores/canvasStore.test.ts
+++ b/tests/unit/stores/canvasStore.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useCanvasStore } from "../../../src/renderer/src/store/canvasStore";
+import {
+  useCanvasStore,
+  generateCopyName,
+} from "../../../src/renderer/src/store/canvasStore";
 import { createSvgImport, createSvgPath } from "../../helpers/factories";
 
 // Reset Zustand state between tests
@@ -8,6 +11,7 @@ beforeEach(() => {
     imports: [],
     selectedImportId: null,
     selectedPathId: null,
+    clipboardImport: null,
     gcodeToolpath: null,
     gcodeSource: null,
   });
@@ -546,5 +550,174 @@ describe("canvasStore", () => {
     expect(
       useCanvasStore.getState().imports[0].paths[0].hatchLines,
     ).toBeUndefined();
+  });
+
+  // ── generateCopyName (pure helper) ────────────────────────────────────────
+
+  describe("generateCopyName", () => {
+    it("appends ' copy' when no copy exists", () => {
+      expect(generateCopyName("my layer", [])).toBe("my layer copy");
+    });
+
+    it("appends ' copy (2)' when '<base> copy' already exists", () => {
+      expect(generateCopyName("my layer", ["my layer copy"])).toBe(
+        "my layer copy (2)",
+      );
+    });
+
+    it("increments n until a unique name is found", () => {
+      expect(
+        generateCopyName("my layer", ["my layer copy", "my layer copy (2)"]),
+      ).toBe("my layer copy (3)");
+    });
+
+    it("strips existing ' copy' suffix before computing base", () => {
+      // Copying "foo copy" should produce "foo copy (2)" not "foo copy copy"
+      expect(generateCopyName("foo copy", ["foo copy"])).toBe("foo copy (2)");
+    });
+
+    it("strips existing ' copy (n)' suffix before computing base", () => {
+      expect(generateCopyName("foo copy (3)", ["foo copy"])).toBe(
+        "foo copy (2)",
+      );
+    });
+  });
+
+  // ── copyImport / cutImport / pasteImport / selectAllImports ──────────────
+
+  describe("clipboard actions", () => {
+    beforeEach(() => {
+      useCanvasStore.setState({
+        imports: [],
+        selectedImportId: null,
+        selectedPathId: null,
+        clipboardImport: null,
+      });
+    });
+
+    it("copyImport stores a snapshot in clipboardImport", () => {
+      const imp = createSvgImport({ name: "layer1" });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      expect(useCanvasStore.getState().clipboardImport?.id).toBe(imp.id);
+      expect(useCanvasStore.getState().clipboardImport?.name).toBe("layer1");
+    });
+
+    it("copyImport does not remove the import from the canvas", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+    });
+
+    it("copyImport is a no-op for unknown id", () => {
+      useCanvasStore.getState().copyImport("nonexistent");
+      expect(useCanvasStore.getState().clipboardImport).toBeNull();
+    });
+
+    it("cutImport stores snapshot and removes from canvas", () => {
+      const imp = createSvgImport({ name: "to-cut" });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().selectImport(imp.id);
+      useCanvasStore.getState().cutImport(imp.id);
+      expect(useCanvasStore.getState().clipboardImport?.name).toBe("to-cut");
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+    });
+
+    it("cutImport clears selection when the cut import was selected", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().selectImport(imp.id);
+      useCanvasStore.getState().cutImport(imp.id);
+      expect(useCanvasStore.getState().selectedImportId).toBeNull();
+    });
+
+    it("pasteImport adds a copy with ' copy' suffix", () => {
+      const imp = createSvgImport({ name: "layer1", x: 0, y: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      useCanvasStore.getState().pasteImport();
+      const { imports } = useCanvasStore.getState();
+      expect(imports).toHaveLength(2);
+      expect(imports[1].name).toBe("layer1 copy");
+    });
+
+    it("pasteImport offsets position by 5mm", () => {
+      const imp = createSvgImport({ x: 10, y: 20 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      useCanvasStore.getState().pasteImport();
+      const pasted = useCanvasStore.getState().imports[1];
+      expect(pasted.x).toBe(15);
+      expect(pasted.y).toBe(25);
+    });
+
+    it("pasteImport assigns a new unique id", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      useCanvasStore.getState().pasteImport();
+      const { imports } = useCanvasStore.getState();
+      expect(imports[1].id).not.toBe(imports[0].id);
+    });
+
+    it("pasteImport assigns new ids to all paths", () => {
+      const path = createSvgPath();
+      const imp = createSvgImport({ paths: [path] });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      useCanvasStore.getState().pasteImport();
+      const { imports } = useCanvasStore.getState();
+      expect(imports[1].paths[0].id).not.toBe(imports[0].paths[0].id);
+    });
+
+    it("pasteImport selects the pasted import", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      useCanvasStore.getState().pasteImport();
+      const { selectedImportId, imports } = useCanvasStore.getState();
+      expect(selectedImportId).toBe(imports[1].id);
+    });
+
+    it("pasteImport generates incrementing copy names on multiple pastes", () => {
+      const imp = createSvgImport({ name: "logo" });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().copyImport(imp.id);
+      useCanvasStore.getState().pasteImport();
+      useCanvasStore.getState().pasteImport();
+      const names = useCanvasStore.getState().imports.map((i) => i.name);
+      expect(names).toContain("logo copy");
+      expect(names).toContain("logo copy (2)");
+    });
+
+    it("pasteImport is a no-op when clipboard is empty", () => {
+      useCanvasStore.getState().pasteImport();
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+    });
+
+    it("selectAllImports selects first import when nothing is selected", () => {
+      const imp1 = createSvgImport();
+      const imp2 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1);
+      useCanvasStore.getState().addImport(imp2);
+      useCanvasStore.getState().selectAllImports();
+      expect(useCanvasStore.getState().selectedImportId).toBe(imp1.id);
+    });
+
+    it("selectAllImports keeps current selection when one is already active", () => {
+      const imp1 = createSvgImport();
+      const imp2 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1);
+      useCanvasStore.getState().addImport(imp2);
+      useCanvasStore.getState().selectImport(imp2.id);
+      useCanvasStore.getState().selectAllImports();
+      expect(useCanvasStore.getState().selectedImportId).toBe(imp2.id);
+    });
+
+    it("selectAllImports is a no-op when no imports exist", () => {
+      useCanvasStore.getState().selectAllImports();
+      expect(useCanvasStore.getState().selectedImportId).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
This pull request adds full clipboard support (cut, copy, paste, select all) for canvas imports in the application, integrating both keyboard shortcuts and menu actions with the renderer and main process. It introduces an in-memory clipboard, ensures menu state reflects selection, and provides robust handling for copy naming and multi-selection. The changes are grouped below by theme.

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/5183fd28-cc92-4126-ae81-26394d320eed" />

**Edit Menu Integration & IPC:**

* Replaced native Edit menu items with custom handlers for Cut, Copy, Paste, and Select All, each sending IPC messages to the renderer and triggering native clipboard actions as appropriate. Menu items for Cut/Copy are enabled only when a canvas import is selected. (`src/main/index.ts`) [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL120-R162) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR212-R220)
* Added a new `edit` API to the preload script and type definitions, exposing event subscriptions for Edit menu actions and a setter to update selection state for menu enablement. (`src/preload/index.ts`, `src/types/index.ts`) [[1]](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0R189-R215) [[2]](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0R226) [[3]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R338-R353) [[4]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R362)

**Renderer Clipboard & Selection Logic:**

* Implemented clipboard actions in the canvas store: copy, cut, paste, and select all for SVG imports. Copy and paste generate unique names and IDs for imports, and paste offsets the import position. Added `allImportsSelected` and `clipboardImport` state. (`src/renderer/src/store/canvasStore.ts`) [[1]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R3) [[2]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R14-R42) [[3]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R98-R117) [[4]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R147-R156) [[5]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R214) [[6]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R226) [[7]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R235) [[8]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R248) [[9]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R382-R450)
* Added a helper to generate unique copy names for pasted imports, avoiding duplicate "copy" suffixes. (`src/renderer/src/store/canvasStore.ts`, `tests/unit/stores/canvasStore.test.ts`) [[1]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R14-R42) [[2]](diffhunk://#diff-792b5e6cd696de59ac634e0ec490e96dcd2fafd9f8bdf2bc9a2ef62d63fbb76bL2-R5)

**Toolbar & Keyboard Shortcuts:**

* Subscribed to Edit menu events and keyboard shortcuts in the toolbar, dispatching clipboard actions only when a text input is not focused. Keeps menu item state in sync with selection. (`src/renderer/src/components/Toolbar.tsx`) [[1]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R288-R300) [[2]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R802-R857) [[3]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R873-R920) [[4]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R929-R933)

**Testing Support:**

* Updated test setup to mock the new `edit` API for renderer tests. (`tests/setup.ts`)