### PR TITLE
Undo

### DIFF
--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -457,6 +457,7 @@ export function PlotCanvas() {
       if (spaceRef.current) return; // space held → pan mode, not drag
       e.stopPropagation();
       const state = useCanvasStore.getState();
+      state.snapshotForGesture();
       // In group mode clicking an import continues the group drag without
       // breaking out to single selection.
       if (state.allImportsSelected) {
@@ -491,6 +492,7 @@ export function PlotCanvas() {
   const onHandleMouseDown = useCallback(
     (e: React.MouseEvent<SVGCircleElement>, id: string, handle: HandlePos) => {
       e.stopPropagation();
+      useCanvasStore.getState().snapshotForGesture();
       const imp = useCanvasStore.getState().imports.find((i) => i.id === id);
       if (!imp) return;
       const sX = imp.scaleX ?? imp.scale;
@@ -521,6 +523,7 @@ export function PlotCanvas() {
       cySvg: number,
     ) => {
       e.stopPropagation();
+      useCanvasStore.getState().snapshotForGesture();
       const imp = useCanvasStore.getState().imports.find((i) => i.id === id);
       if (!imp) return;
       const container = containerRef.current;
@@ -553,6 +556,7 @@ export function PlotCanvas() {
   const onGroupHandleMouseDown = useCallback(
     (e: React.MouseEvent<SVGCircleElement>, handle: HandlePos) => {
       e.stopPropagation();
+      useCanvasStore.getState().snapshotForGesture();
       const { imports: imps } = useCanvasStore.getState();
       const gBedY = getBedYRef.current;
       let minWx = Infinity,
@@ -623,6 +627,7 @@ export function PlotCanvas() {
       gHH: number,
     ) => {
       e.stopPropagation();
+      useCanvasStore.getState().snapshotForGesture();
       const { imports: imps } = useCanvasStore.getState();
       const gBedY = getBedYRef.current;
       const container = containerRef.current;
@@ -664,6 +669,7 @@ export function PlotCanvas() {
     (e: React.MouseEvent<SVGRectElement>) => {
       if (spaceRef.current) return;
       e.stopPropagation();
+      useCanvasStore.getState().snapshotForGesture();
       const currentImports = useCanvasStore.getState().imports;
       setDragging({
         id: "__group__",
@@ -902,6 +908,8 @@ export function PlotCanvas() {
   );
 
   const onMouseUp = useCallback(() => {
+    // Commit gesture snapshot to undo stack (only if imports actually changed).
+    useCanvasStore.getState().commitGesture();
     // If any gesture was active, mark it so the SVG onClick can ignore the
     // synthetic click that the browser fires after mouseup.
     if (

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -298,6 +298,8 @@ export function Toolbar({
   const selectAllImports = useCanvasStore((s) => s.selectAllImports);
   const clipboardImport = useCanvasStore((s) => s.clipboardImport);
   const allImportsSelected = useCanvasStore((s) => s.allImportsSelected);
+  const undo = useCanvasStore((s) => s.undo);
+  const redo = useCanvasStore((s) => s.redo);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const registerCancelCallback = useTaskStore((s) => s.registerCancelCallback);
   const unregisterCancelCallback = useTaskStore(
@@ -816,6 +818,10 @@ export function Toolbar({
   pasteImportRef.current = pasteImport;
   selectAllImportsRef.current = selectAllImports;
   clearImportsRef.current = clearImports;
+  const undoRef = useRef(undo);
+  undoRef.current = undo;
+  const redoRef = useRef(redo);
+  redoRef.current = redo;
 
   /** Returns true if the event originates from a text editing element. */
   function isTextInputFocused(): boolean {
@@ -902,6 +908,18 @@ export function Toolbar({
         case "a":
           handleEditSelectAll();
           e.preventDefault(); // prevent browser select-all of page text
+          break;
+        case "z":
+          e.preventDefault();
+          if (e.shiftKey) {
+            redoRef.current();
+          } else {
+            undoRef.current();
+          }
+          break;
+        case "y":
+          e.preventDefault();
+          redoRef.current();
           break;
       }
     };

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -40,6 +40,12 @@ interface CanvasState {
   allImportsSelected: boolean;
   /** In-memory clipboard for cut/copy/paste of canvas imports. */
   clipboardImport: SvgImport | null;
+  /** Undo stack — snapshots of the imports array before each discrete edit. Capped at 50. */
+  undoStack: SvgImport[][];
+  undo: () => void;
+  /** Redo stack — snapshots pushed by undo(). Cleared whenever a new edit is made. Capped at 50. */
+  redoStack: SvgImport[][];
+  redo: () => void;
   gcodeToolpath: GcodeToolpath | null;
   /** Persists the file info for the currently loaded G-code toolpath so it
    *  can be restored into selectedJobFile when the user re-selects the toolpath
@@ -109,344 +115,405 @@ interface CanvasState {
 }
 
 export const useCanvasStore = create<CanvasState>()(
-  immer((set, get) => ({
-    imports: [],
-    selectedImportId: null,
-    selectedPathId: null,
-    allImportsSelected: false,
-    clipboardImport: null,
-    gcodeToolpath: null,
-    gcodeSource: null,
-    toolpathSelected: false,
-    showCentreMarker: true,
-    plotProgressCuts: "",
-    plotProgressRapids: "",
-    gcodePreviewLoading: false,
-    setGcodePreviewLoading: (loading) =>
+  immer((set, get) => {
+    const pushUndo = () => {
+      const snap = structuredClone(get().imports);
       set((state) => {
-        state.gcodePreviewLoading = loading;
-      }),
+        state.undoStack.push(snap);
+        if (state.undoStack.length > 50)
+          state.undoStack.splice(0, state.undoStack.length - 50);
+        // Any new edit invalidates the redo history.
+        state.redoStack = [];
+      });
+    };
 
-    addImport: (imp) =>
-      set((state) => {
-        state.imports.push({
-          hatchEnabled: false,
-          hatchSpacingMM: DEFAULT_HATCH_SPACING_MM,
-          hatchAngleDeg: DEFAULT_HATCH_ANGLE_DEG,
-          ...imp,
+    return {
+      imports: [],
+      undoStack: [],
+      redoStack: [],
+      selectedImportId: null,
+      selectedPathId: null,
+      allImportsSelected: false,
+      clipboardImport: null,
+      gcodeToolpath: null,
+      gcodeSource: null,
+      toolpathSelected: false,
+      showCentreMarker: true,
+      plotProgressCuts: "",
+      plotProgressRapids: "",
+      gcodePreviewLoading: false,
+      setGcodePreviewLoading: (loading) =>
+        set((state) => {
+          state.gcodePreviewLoading = loading;
+        }),
+
+      addImport: (imp) => {
+        pushUndo();
+        set((state) => {
+          state.imports.push({
+            hatchEnabled: false,
+            hatchSpacingMM: DEFAULT_HATCH_SPACING_MM,
+            hatchAngleDeg: DEFAULT_HATCH_ANGLE_DEG,
+            ...imp,
+          });
         });
-      }),
+      },
 
-    removeImport: (id) =>
-      set((state) => {
-        state.imports = state.imports.filter((i) => i.id !== id);
-        if (state.selectedImportId === id) {
+      removeImport: (id) => {
+        if (!get().imports.some((i) => i.id === id)) return;
+        pushUndo();
+        set((state) => {
+          state.imports = state.imports.filter((i) => i.id !== id);
+          if (state.selectedImportId === id) {
+            state.selectedImportId = null;
+            state.selectedPathId = null;
+          }
+          // If we were in "all selected" mode, re-evaluate — if only one remains select
+          // it individually; if none remain clear everything.
+          if (state.allImportsSelected) {
+            state.allImportsSelected = false;
+            if (state.imports.length === 1) {
+              state.selectedImportId = state.imports[0].id;
+            } else if (state.imports.length === 0) {
+              state.selectedImportId = null;
+            }
+          }
+        });
+      },
+
+      updateImport: (id, patch) =>
+        set((state) => {
+          const imp = state.imports.find((i) => i.id === id);
+          if (!imp) return;
+          Object.assign(imp, patch);
+          // If scale/scaleX/scaleY changed while hatch is enabled, regenerate hatch lines
+          // so the physical spacing (in mm) stays correct after resize.
+          if (
+            imp.hatchEnabled &&
+            ("scale" in patch || "scaleX" in patch || "scaleY" in patch)
+          ) {
+            const effectiveScale = Math.sqrt(
+              (imp.scaleX ?? imp.scale) * (imp.scaleY ?? imp.scale),
+            );
+            const spacingMM = imp.hatchSpacingMM ?? DEFAULT_HATCH_SPACING_MM;
+            const angleDeg = imp.hatchAngleDeg ?? DEFAULT_HATCH_ANGLE_DEG;
+            if (
+              effectiveScale > 0 &&
+              Number.isFinite(effectiveScale) &&
+              spacingMM > 0 &&
+              Number.isFinite(angleDeg)
+            ) {
+              const spacingUnits = spacingMM / effectiveScale;
+              for (const p of imp.paths) {
+                if (!p.hasFill) {
+                  p.hatchLines = undefined;
+                  continue;
+                }
+                const lines = generateHatchPaths(p.d, spacingUnits, angleDeg);
+                p.hatchLines = lines.length ? lines : undefined;
+              }
+            }
+          }
+        }),
+
+      updatePath: (importId, pathId, patch) =>
+        set((state) => {
+          const imp = state.imports.find((i) => i.id === importId);
+          if (!imp) return;
+          const path = imp.paths.find((p) => p.id === pathId);
+          if (path) Object.assign(path, patch);
+        }),
+
+      removePath: (importId, pathId) =>
+        set((state) => {
+          const imp = state.imports.find((i) => i.id === importId);
+          if (!imp) return;
+          imp.paths = imp.paths.filter((p) => p.id !== pathId);
+          if (state.selectedPathId === pathId) state.selectedPathId = null;
+        }),
+
+      selectImport: (id) =>
+        set((state) => {
+          state.selectedImportId = id;
+          state.selectedPathId = null;
+          state.allImportsSelected = false;
+          // Selecting an SVG import clears toolpath selection (and vice-versa).
+          if (id !== null) state.toolpathSelected = false;
+        }),
+
+      selectToolpath: (selected) =>
+        set((state) => {
+          state.toolpathSelected = selected;
+          // Selecting the toolpath clears any SVG import selection.
+          if (selected) {
+            state.selectedImportId = null;
+            state.selectedPathId = null;
+            state.allImportsSelected = false;
+          }
+        }),
+
+      clearImports: () => {
+        if (get().imports.length === 0) return;
+        pushUndo();
+        set((state) => {
+          state.imports = [];
           state.selectedImportId = null;
           state.selectedPathId = null;
-        }
-        // If we were in "all selected" mode, re-evaluate — if only one remains select
-        // it individually; if none remain clear everything.
-        if (state.allImportsSelected) {
           state.allImportsSelected = false;
-          if (state.imports.length === 1) {
-            state.selectedImportId = state.imports[0].id;
-          } else if (state.imports.length === 0) {
-            state.selectedImportId = null;
-          }
-        }
-      }),
+        });
+      },
 
-    updateImport: (id, patch) =>
-      set((state) => {
-        const imp = state.imports.find((i) => i.id === id);
-        if (!imp) return;
-        Object.assign(imp, patch);
-        // If scale/scaleX/scaleY changed while hatch is enabled, regenerate hatch lines
-        // so the physical spacing (in mm) stays correct after resize.
-        if (
-          imp.hatchEnabled &&
-          ("scale" in patch || "scaleX" in patch || "scaleY" in patch)
-        ) {
+      loadLayout: (newImports) => {
+        pushUndo();
+        set((state) => {
+          state.imports = newImports.map((imp) => ({
+            hatchEnabled: false,
+            hatchSpacingMM: DEFAULT_HATCH_SPACING_MM,
+            hatchAngleDeg: DEFAULT_HATCH_ANGLE_DEG,
+            ...imp,
+          }));
+          state.selectedImportId = null;
+          state.selectedPathId = null;
+          state.allImportsSelected = false;
+        });
+      },
+
+      selectedImport: () => {
+        const { imports, selectedImportId } = get();
+        return imports.find((i) => i.id === selectedImportId);
+      },
+
+      setGcodeToolpath: (tp) =>
+        set((state) => {
+          state.gcodeToolpath = tp as GcodeToolpath;
+          // Auto-clear the stored local-file source when the toolpath is removed.
+          if (tp === null) {
+            state.gcodeSource = null;
+            state.toolpathSelected = false;
+            state.plotProgressCuts = "";
+            state.plotProgressRapids = "";
+          }
+        }),
+
+      setGcodeSource: (src) =>
+        set((state) => {
+          state.gcodeSource = src;
+        }),
+
+      toggleCentreMarker: () =>
+        set((state) => {
+          state.showCentreMarker = !state.showCentreMarker;
+        }),
+
+      toVectorObjects: (): VectorObject[] =>
+        get()
+          .imports.filter((imp) => imp.visible)
+          .flatMap((imp) =>
+            imp.paths
+              .filter((p) => p.visible)
+              .flatMap((p): VectorObject[] => {
+                const base: VectorObject = {
+                  id: p.id,
+                  svgSource: p.svgSource,
+                  path: p.d,
+                  x: imp.x,
+                  y: imp.y,
+                  scale: imp.scale,
+                  scaleX: imp.scaleX,
+                  scaleY: imp.scaleY,
+                  rotation: imp.rotation,
+                  visible: true,
+                  originalWidth: imp.svgWidth,
+                  originalHeight: imp.svgHeight,
+                  layer: p.layer,
+                };
+                const outlineVOs: VectorObject[] =
+                  p.outlineVisible !== false ? [base] : [];
+                const hatchVOs: VectorObject[] = (p.hatchLines ?? []).map(
+                  (hl, i): VectorObject => ({
+                    ...base,
+                    id: `${p.id}-h${i}`,
+                    svgSource: "",
+                    path: hl,
+                  }),
+                );
+                return [...outlineVOs, ...hatchVOs];
+              }),
+          ),
+
+      setPlotProgress: (cuts, rapids) =>
+        set((state) => {
+          state.plotProgressCuts = cuts;
+          state.plotProgressRapids = rapids;
+        }),
+
+      clearPlotProgress: () =>
+        set((state) => {
+          state.plotProgressCuts = "";
+          state.plotProgressRapids = "";
+        }),
+
+      applyHatch: (importId, spacingMM, angleDeg, enabled) =>
+        set((state) => {
+          const imp = state.imports.find((i) => i.id === importId);
+          if (!imp) return;
+
+          // Sanitize incoming values before persisting to avoid storing NaN/Infinity
+          // (which can arrive transiently from <input type="number"> while editing).
+          const safeSpacing =
+            Number.isFinite(spacingMM) && spacingMM > 0
+              ? spacingMM
+              : imp.hatchSpacingMM;
+          const safeAngle = Number.isFinite(angleDeg)
+            ? angleDeg
+            : imp.hatchAngleDeg;
+
+          // Persist user configuration
+          imp.hatchEnabled = enabled;
+          imp.hatchSpacingMM = safeSpacing;
+          imp.hatchAngleDeg = safeAngle;
+
+          // When non-uniform scaling is active (scaleX/scaleY set independently),
+          // use the geometric mean of the two axis scales so mm spacing is consistent
+          // regardless of which axis the user adjusted.
           const effectiveScale = Math.sqrt(
             (imp.scaleX ?? imp.scale) * (imp.scaleY ?? imp.scale),
           );
-          const spacingMM = imp.hatchSpacingMM ?? DEFAULT_HATCH_SPACING_MM;
-          const angleDeg = imp.hatchAngleDeg ?? DEFAULT_HATCH_ANGLE_DEG;
-          if (
+
+          // Defense in depth: only generate hatch lines when configuration is valid.
+          const spacingIsValid =
+            Number.isFinite(safeSpacing) &&
+            safeSpacing > 0 &&
+            Number.isFinite(safeAngle) &&
             effectiveScale > 0 &&
             Number.isFinite(effectiveScale) &&
-            spacingMM > 0 &&
-            Number.isFinite(angleDeg)
-          ) {
-            const spacingUnits = spacingMM / effectiveScale;
+            enabled;
+
+          if (!spacingIsValid) {
+            // Invalid spacing/scale or hatching disabled: clear any existing hatch lines.
             for (const p of imp.paths) {
-              if (!p.hasFill) {
-                p.hatchLines = undefined;
-                continue;
-              }
-              const lines = generateHatchPaths(p.d, spacingUnits, angleDeg);
-              p.hatchLines = lines.length ? lines : undefined;
+              p.hatchLines = undefined;
             }
+            return;
           }
-        }
-      }),
 
-    updatePath: (importId, pathId, patch) =>
-      set((state) => {
-        const imp = state.imports.find((i) => i.id === importId);
-        if (!imp) return;
-        const path = imp.paths.find((p) => p.id === pathId);
-        if (path) Object.assign(path, patch);
-      }),
+          const spacingUnits = safeSpacing / effectiveScale;
 
-    removePath: (importId, pathId) =>
-      set((state) => {
-        const imp = state.imports.find((i) => i.id === importId);
-        if (!imp) return;
-        imp.paths = imp.paths.filter((p) => p.id !== pathId);
-        if (state.selectedPathId === pathId) state.selectedPathId = null;
-      }),
-
-    selectImport: (id) =>
-      set((state) => {
-        state.selectedImportId = id;
-        state.selectedPathId = null;
-        state.allImportsSelected = false;
-        // Selecting an SVG import clears toolpath selection (and vice-versa).
-        if (id !== null) state.toolpathSelected = false;
-      }),
-
-    selectToolpath: (selected) =>
-      set((state) => {
-        state.toolpathSelected = selected;
-        // Selecting the toolpath clears any SVG import selection.
-        if (selected) {
-          state.selectedImportId = null;
-          state.selectedPathId = null;
-          state.allImportsSelected = false;
-        }
-      }),
-
-    clearImports: () =>
-      set((state) => {
-        state.imports = [];
-        state.selectedImportId = null;
-        state.selectedPathId = null;
-        state.allImportsSelected = false;
-      }),
-
-    loadLayout: (newImports) =>
-      set((state) => {
-        state.imports = newImports.map((imp) => ({
-          hatchEnabled: false,
-          hatchSpacingMM: DEFAULT_HATCH_SPACING_MM,
-          hatchAngleDeg: DEFAULT_HATCH_ANGLE_DEG,
-          ...imp,
-        }));
-        state.selectedImportId = null;
-        state.selectedPathId = null;
-        state.allImportsSelected = false;
-      }),
-
-    selectedImport: () => {
-      const { imports, selectedImportId } = get();
-      return imports.find((i) => i.id === selectedImportId);
-    },
-
-    setGcodeToolpath: (tp) =>
-      set((state) => {
-        state.gcodeToolpath = tp as GcodeToolpath;
-        // Auto-clear the stored local-file source when the toolpath is removed.
-        if (tp === null) {
-          state.gcodeSource = null;
-          state.toolpathSelected = false;
-          state.plotProgressCuts = "";
-          state.plotProgressRapids = "";
-        }
-      }),
-
-    setGcodeSource: (src) =>
-      set((state) => {
-        state.gcodeSource = src;
-      }),
-
-    toggleCentreMarker: () =>
-      set((state) => {
-        state.showCentreMarker = !state.showCentreMarker;
-      }),
-
-    toVectorObjects: (): VectorObject[] =>
-      get()
-        .imports.filter((imp) => imp.visible)
-        .flatMap((imp) =>
-          imp.paths
-            .filter((p) => p.visible)
-            .flatMap((p): VectorObject[] => {
-              const base: VectorObject = {
-                id: p.id,
-                svgSource: p.svgSource,
-                path: p.d,
-                x: imp.x,
-                y: imp.y,
-                scale: imp.scale,
-                scaleX: imp.scaleX,
-                scaleY: imp.scaleY,
-                rotation: imp.rotation,
-                visible: true,
-                originalWidth: imp.svgWidth,
-                originalHeight: imp.svgHeight,
-                layer: p.layer,
-              };
-              const outlineVOs: VectorObject[] =
-                p.outlineVisible !== false ? [base] : [];
-              const hatchVOs: VectorObject[] = (p.hatchLines ?? []).map(
-                (hl, i): VectorObject => ({
-                  ...base,
-                  id: `${p.id}-h${i}`,
-                  svgSource: "",
-                  path: hl,
-                }),
-              );
-              return [...outlineVOs, ...hatchVOs];
-            }),
-        ),
-
-    setPlotProgress: (cuts, rapids) =>
-      set((state) => {
-        state.plotProgressCuts = cuts;
-        state.plotProgressRapids = rapids;
-      }),
-
-    clearPlotProgress: () =>
-      set((state) => {
-        state.plotProgressCuts = "";
-        state.plotProgressRapids = "";
-      }),
-
-    applyHatch: (importId, spacingMM, angleDeg, enabled) =>
-      set((state) => {
-        const imp = state.imports.find((i) => i.id === importId);
-        if (!imp) return;
-
-        // Sanitize incoming values before persisting to avoid storing NaN/Infinity
-        // (which can arrive transiently from <input type="number"> while editing).
-        const safeSpacing =
-          Number.isFinite(spacingMM) && spacingMM > 0
-            ? spacingMM
-            : imp.hatchSpacingMM;
-        const safeAngle = Number.isFinite(angleDeg)
-          ? angleDeg
-          : imp.hatchAngleDeg;
-
-        // Persist user configuration
-        imp.hatchEnabled = enabled;
-        imp.hatchSpacingMM = safeSpacing;
-        imp.hatchAngleDeg = safeAngle;
-
-        // When non-uniform scaling is active (scaleX/scaleY set independently),
-        // use the geometric mean of the two axis scales so mm spacing is consistent
-        // regardless of which axis the user adjusted.
-        const effectiveScale = Math.sqrt(
-          (imp.scaleX ?? imp.scale) * (imp.scaleY ?? imp.scale),
-        );
-
-        // Defense in depth: only generate hatch lines when configuration is valid.
-        const spacingIsValid =
-          Number.isFinite(safeSpacing) &&
-          safeSpacing > 0 &&
-          Number.isFinite(safeAngle) &&
-          effectiveScale > 0 &&
-          Number.isFinite(effectiveScale) &&
-          enabled;
-
-        if (!spacingIsValid) {
-          // Invalid spacing/scale or hatching disabled: clear any existing hatch lines.
           for (const p of imp.paths) {
-            p.hatchLines = undefined;
+            if (!p.hasFill) {
+              p.hatchLines = undefined;
+              continue;
+            }
+
+            const lines = generateHatchPaths(p.d, spacingUnits, safeAngle);
+            p.hatchLines = lines.length ? lines : undefined;
           }
-          return;
-        }
+        }),
 
-        const spacingUnits = safeSpacing / effectiveScale;
+      // ─── Clipboard actions ──────────────────────────────────────────────────
 
-        for (const p of imp.paths) {
-          if (!p.hasFill) {
-            p.hatchLines = undefined;
-            continue;
+      copyImport: (id) => {
+        const imp = get().imports.find((i) => i.id === id);
+        if (!imp) return;
+        const snap = structuredClone(imp);
+        set((state) => {
+          state.clipboardImport = snap;
+        });
+      },
+
+      cutImport: (id) => {
+        const imp = get().imports.find((i) => i.id === id);
+        if (!imp) return;
+        pushUndo();
+        const snap = structuredClone(imp);
+        set((state) => {
+          state.clipboardImport = snap;
+          state.imports = state.imports.filter((i) => i.id !== id);
+          if (state.selectedImportId === id) {
+            state.selectedImportId = null;
+            state.selectedPathId = null;
           }
+        });
+      },
 
-          const lines = generateHatchPaths(p.d, spacingUnits, safeAngle);
-          p.hatchLines = lines.length ? lines : undefined;
-        }
-      }),
+      pasteImport: () => {
+        const clipboard = get().clipboardImport;
+        if (!clipboard) return;
+        pushUndo();
+        const existingNames = get().imports.map((i) => i.name);
+        const newName = generateCopyName(clipboard.name, existingNames);
+        const newId = uuid();
+        const pasted: SvgImport = {
+          ...structuredClone(clipboard),
+          id: newId,
+          name: newName,
+          // Assign fresh IDs to all paths so they don't alias the originals
+          paths: clipboard.paths.map((p) => ({ ...p, id: uuid() })),
+          // Offset slightly so the copy doesn't sit exactly on top of the original
+          x: clipboard.x + 5,
+          y: clipboard.y + 5,
+        };
+        set((state) => {
+          state.imports.push(pasted);
+          state.selectedImportId = newId;
+          state.selectedPathId = null;
+          if (state.toolpathSelected) state.toolpathSelected = false;
+        });
+      },
 
-    // ─── Clipboard actions ──────────────────────────────────────────────────
+      selectAllImports: () =>
+        set((state) => {
+          if (state.imports.length === 0) return;
+          if (state.imports.length === 1) {
+            // Only one import — just select it directly.
+            state.selectedImportId = state.imports[0].id;
+            state.allImportsSelected = false;
+          } else if (!state.allImportsSelected) {
+            // Zero or one import selected → enter "all selected" mode.
+            state.allImportsSelected = true;
+            state.selectedImportId = null;
+          } else {
+            // Already all-selected → cycle to the first import individually.
+            state.allImportsSelected = false;
+            state.selectedImportId = state.imports[0].id;
+          }
+          state.selectedPathId = null;
+          state.toolpathSelected = false;
+        }),
 
-    copyImport: (id) => {
-      const imp = get().imports.find((i) => i.id === id);
-      if (!imp) return;
-      const snap = structuredClone(imp);
-      set((state) => {
-        state.clipboardImport = snap;
-      });
-    },
-
-    cutImport: (id) => {
-      const imp = get().imports.find((i) => i.id === id);
-      if (!imp) return;
-      const snap = structuredClone(imp);
-      set((state) => {
-        state.clipboardImport = snap;
-        state.imports = state.imports.filter((i) => i.id !== id);
-        if (state.selectedImportId === id) {
+      undo: () => {
+        const stack = get().undoStack;
+        if (stack.length === 0) return;
+        const prev = stack[stack.length - 1];
+        const currentSnap = structuredClone(get().imports);
+        set((state) => {
+          state.imports = structuredClone(prev);
+          state.undoStack.pop();
+          state.redoStack.push(currentSnap);
+          if (state.redoStack.length > 50)
+            state.redoStack.splice(0, state.redoStack.length - 50);
           state.selectedImportId = null;
           state.selectedPathId = null;
-        }
-      });
-    },
-
-    pasteImport: () => {
-      const clipboard = get().clipboardImport;
-      if (!clipboard) return;
-      const existingNames = get().imports.map((i) => i.name);
-      const newName = generateCopyName(clipboard.name, existingNames);
-      const newId = uuid();
-      const pasted: SvgImport = {
-        ...structuredClone(clipboard),
-        id: newId,
-        name: newName,
-        // Assign fresh IDs to all paths so they don't alias the originals
-        paths: clipboard.paths.map((p) => ({ ...p, id: uuid() })),
-        // Offset slightly so the copy doesn't sit exactly on top of the original
-        x: clipboard.x + 5,
-        y: clipboard.y + 5,
-      };
-      set((state) => {
-        state.imports.push(pasted);
-        state.selectedImportId = newId;
-        state.selectedPathId = null;
-        if (state.toolpathSelected) state.toolpathSelected = false;
-      });
-    },
-
-    selectAllImports: () =>
-      set((state) => {
-        if (state.imports.length === 0) return;
-        if (state.imports.length === 1) {
-          // Only one import — just select it directly.
-          state.selectedImportId = state.imports[0].id;
           state.allImportsSelected = false;
-        } else if (!state.allImportsSelected) {
-          // Zero or one import selected → enter "all selected" mode.
-          state.allImportsSelected = true;
+        });
+      },
+
+      redo: () => {
+        const stack = get().redoStack;
+        if (stack.length === 0) return;
+        const next = stack[stack.length - 1];
+        const currentSnap = structuredClone(get().imports);
+        set((state) => {
+          state.imports = structuredClone(next);
+          state.redoStack.pop();
+          state.undoStack.push(currentSnap);
+          if (state.undoStack.length > 50)
+            state.undoStack.splice(0, state.undoStack.length - 50);
           state.selectedImportId = null;
-        } else {
-          // Already all-selected → cycle to the first import individually.
+          state.selectedPathId = null;
           state.allImportsSelected = false;
-          state.selectedImportId = state.imports[0].id;
-        }
-        state.selectedPathId = null;
-        state.toolpathSelected = false;
-      }),
-  })),
+        });
+      },
+    };
+  }),
 );

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -112,7 +112,26 @@ interface CanvasState {
   /** Select all canvas imports.  If already all-selected, cycles to the first single
    *  import so repeated Ctrl+A is still useful. */
   selectAllImports: () => void;
+  /** Snapshot the current imports before a gesture (drag/scale/rotate) begins.
+   *  Clears the redo stack — starting a new gesture invalidates redo history. */
+  snapshotForGesture: () => void;
+  /** Commit the gesture snapshot to the undo stack only if imports actually changed.
+   *  Discards the snapshot if nothing was modified (e.g. click without drag). */
+  commitGesture: () => void;
 }
+
+// ─── Gesture-undo stash ──────────────────────────────────────────────────────
+// Holds a snapshot captured at gesture-start (drag/scale/rotate mousedown).
+// Committed to undoStack on mouseup only if imports actually changed.
+let _gestureSnapshot: SvgImport[] | null = null;
+
+const gestureFingerprint = (imps: SvgImport[]) =>
+  imps
+    .map(
+      (i) =>
+        `${i.id}:${i.x},${i.y},${i.scale},${i.scaleX ?? ""},${i.scaleY ?? ""},${i.rotation ?? 0}`,
+    )
+    .join("|");
 
 export const useCanvasStore = create<CanvasState>()(
   immer((set, get) => {
@@ -480,6 +499,28 @@ export const useCanvasStore = create<CanvasState>()(
           state.selectedPathId = null;
           state.toolpathSelected = false;
         }),
+
+      snapshotForGesture: () => {
+        _gestureSnapshot = structuredClone(get().imports);
+        // Starting a new gesture invalidates the redo history.
+        set((state) => {
+          state.redoStack = [];
+        });
+      },
+
+      commitGesture: () => {
+        const before = _gestureSnapshot;
+        _gestureSnapshot = null;
+        if (!before) return;
+        const current = get().imports;
+        // Only push if something gesture-mutable actually changed.
+        if (gestureFingerprint(before) === gestureFingerprint(current)) return;
+        set((state) => {
+          state.undoStack.push(before);
+          if (state.undoStack.length > 50)
+            state.undoStack.splice(0, state.undoStack.length - 50);
+        });
+      },
 
       undo: () => {
         const stack = get().undoStack;

--- a/tests/unit/stores/canvasStore.test.ts
+++ b/tests/unit/stores/canvasStore.test.ts
@@ -915,4 +915,91 @@ describe("canvasStore", () => {
       expect(useCanvasStore.getState().allImportsSelected).toBe(false);
     });
   });
+
+  // ── snapshotForGesture / commitGesture ────────────────────────────────────
+
+  describe("snapshotForGesture / commitGesture", () => {
+    it("commitGesture is a no-op when no snapshot was taken", () => {
+      const imp = createSvgImport({ x: 0, y: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().commitGesture();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(0);
+    });
+
+    it("commits snapshot to undoStack when imports changed", () => {
+      const imp = createSvgImport({ x: 0, y: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().snapshotForGesture();
+      // Simulate gesture changing position
+      useCanvasStore.getState().updateImport(imp.id, { x: 50, y: 50 });
+      useCanvasStore.getState().commitGesture();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(1);
+    });
+
+    it("discards snapshot (no undoStack push) when imports did not change", () => {
+      const imp = createSvgImport({ x: 0, y: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().snapshotForGesture();
+      // No mutation — simulates click without drag
+      useCanvasStore.getState().commitGesture();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(0);
+    });
+
+    it("undo after committed gesture restores original position", () => {
+      const imp = createSvgImport({ x: 0, y: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().snapshotForGesture();
+      useCanvasStore.getState().updateImport(imp.id, { x: 99, y: 99 });
+      useCanvasStore.getState().commitGesture();
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports[0].x).toBe(0);
+      expect(useCanvasStore.getState().imports[0].y).toBe(0);
+    });
+
+    it("redo after undo restores the gesture result", () => {
+      const imp = createSvgImport({ x: 0, y: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().snapshotForGesture();
+      useCanvasStore.getState().updateImport(imp.id, { x: 99, y: 99 });
+      useCanvasStore.getState().commitGesture();
+      useCanvasStore.getState().undo();
+      useCanvasStore.getState().redo();
+      expect(useCanvasStore.getState().imports[0].x).toBe(99);
+      expect(useCanvasStore.getState().imports[0].y).toBe(99);
+    });
+
+    it("snapshotForGesture clears the redo stack", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().undo(); // populate redoStack
+      expect(useCanvasStore.getState().redoStack).toHaveLength(1);
+      useCanvasStore.getState().snapshotForGesture();
+      expect(useCanvasStore.getState().redoStack).toHaveLength(0);
+    });
+
+    it("commitGesture detects scale changes", () => {
+      const imp = createSvgImport({ scale: 1 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().snapshotForGesture();
+      useCanvasStore.getState().updateImport(imp.id, { scale: 2 });
+      useCanvasStore.getState().commitGesture();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(1);
+    });
+
+    it("commitGesture detects rotation changes", () => {
+      const imp = createSvgImport({ rotation: 0 });
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().snapshotForGesture();
+      useCanvasStore.getState().updateImport(imp.id, { rotation: 45 });
+      useCanvasStore.getState().commitGesture();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(1);
+    });
+  });
 });

--- a/tests/unit/stores/canvasStore.test.ts
+++ b/tests/unit/stores/canvasStore.test.ts
@@ -15,6 +15,8 @@ beforeEach(() => {
     clipboardImport: null,
     gcodeToolpath: null,
     gcodeSource: null,
+    undoStack: [],
+    redoStack: [],
   });
 });
 
@@ -740,6 +742,177 @@ describe("canvasStore", () => {
     it("selectAllImports is a no-op when no imports exist", () => {
       useCanvasStore.getState().selectAllImports();
       expect(useCanvasStore.getState().selectedImportId).toBeNull();
+    });
+  });
+
+  // ── undo ──────────────────────────────────────────────────────────────
+
+  describe("undo", () => {
+    it("is a no-op when the undo stack is empty", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      // Drain the stack
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+    });
+
+    it("undoes addImport", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+    });
+
+    it("undoes removeImport", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] }); // reset so only removeImport push counts
+      useCanvasStore.getState().removeImport(imp.id);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+      expect(useCanvasStore.getState().imports[0].id).toBe(imp.id);
+    });
+
+    it("undoes cutImport", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().cutImport(imp.id);
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+      expect(useCanvasStore.getState().imports[0].id).toBe(imp.id);
+    });
+
+    it("undoes pasteImport", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.setState({ undoStack: [], clipboardImport: imp });
+      useCanvasStore.getState().pasteImport();
+      expect(useCanvasStore.getState().imports).toHaveLength(2);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+    });
+
+    it("undoes clearImports", () => {
+      const imp1 = createSvgImport();
+      const imp2 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1);
+      useCanvasStore.getState().addImport(imp2);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().clearImports();
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(2);
+    });
+
+    it("resets selection state on undo", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().selectImport(imp.id);
+      useCanvasStore.setState({ undoStack: [] });
+      useCanvasStore.getState().removeImport(imp.id);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().selectedImportId).toBeNull();
+      expect(useCanvasStore.getState().allImportsSelected).toBe(false);
+    });
+
+    it("supports multiple consecutive undos", () => {
+      const imp1 = createSvgImport();
+      const imp2 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1); // stack: [[]]
+      useCanvasStore.getState().addImport(imp2); // stack: [[], [imp1]]
+      expect(useCanvasStore.getState().imports).toHaveLength(2);
+      useCanvasStore.getState().undo(); // restore [imp1]
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+      useCanvasStore.getState().undo(); // restore []
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+    });
+
+    it("caps the undo stack at 50 entries", () => {
+      const base = createSvgImport();
+      useCanvasStore.getState().addImport(base);
+      useCanvasStore.setState({ undoStack: [] });
+      // Push 60 removals, each producing a stack push
+      for (let i = 0; i < 60; i++) {
+        const imp = createSvgImport();
+        useCanvasStore.getState().addImport(imp);
+      }
+      expect(useCanvasStore.getState().undoStack.length).toBeLessThanOrEqual(
+        50,
+      );
+    });
+
+    it("removeImport is a no-op (no undo push) if id not found", () => {
+      useCanvasStore.getState().removeImport("nonexistent");
+      expect(useCanvasStore.getState().undoStack).toHaveLength(0);
+    });
+
+    it("clearImports is a no-op (no undo push) when already empty", () => {
+      useCanvasStore.getState().clearImports();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(0);
+    });
+  });
+
+  // ── redo ──────────────────────────────────────────────────────────────
+
+  describe("redo", () => {
+    it("is a no-op when the redo stack is empty", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().redo(); // nothing to redo
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+    });
+
+    it("redoes after undo", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+      useCanvasStore.getState().redo();
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+      expect(useCanvasStore.getState().imports[0].id).toBe(imp.id);
+    });
+
+    it("supports undo/redo cycling", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().undo();
+      useCanvasStore.getState().redo();
+      useCanvasStore.getState().undo();
+      expect(useCanvasStore.getState().imports).toHaveLength(0);
+      useCanvasStore.getState().redo();
+      expect(useCanvasStore.getState().imports).toHaveLength(1);
+    });
+
+    it("redo pushes current state onto undoStack", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().undo();
+      useCanvasStore.setState({ undoStack: [] }); // clear to isolate
+      useCanvasStore.getState().redo();
+      expect(useCanvasStore.getState().undoStack).toHaveLength(1);
+    });
+
+    it("new edit clears the redo stack", () => {
+      const imp1 = createSvgImport();
+      const imp2 = createSvgImport();
+      useCanvasStore.getState().addImport(imp1);
+      useCanvasStore.getState().undo(); // redoStack now has [imp1]
+      expect(useCanvasStore.getState().redoStack).toHaveLength(1);
+      useCanvasStore.getState().addImport(imp2); // new edit
+      expect(useCanvasStore.getState().redoStack).toHaveLength(0);
+    });
+
+    it("resets selection state on redo", () => {
+      const imp = createSvgImport();
+      useCanvasStore.getState().addImport(imp);
+      useCanvasStore.getState().selectImport(imp.id);
+      useCanvasStore.getState().undo();
+      useCanvasStore.getState().redo();
+      expect(useCanvasStore.getState().selectedImportId).toBeNull();
+      expect(useCanvasStore.getState().allImportsSelected).toBe(false);
     });
   });
 });


### PR DESCRIPTION
This pull request introduces a comprehensive undo/redo system for canvas import operations and gesture-based edits in the application. It ensures that user actions like adding, removing, dragging, scaling, or rotating imports can be reverted or reapplied, significantly improving usability and error recovery. The implementation includes gesture-aware snapshotting to prevent unnecessary undo stack pollution and integrates keyboard shortcuts for undo/redo actions.

**Undo/Redo System Implementation:**

* Added `undoStack` and `redoStack` to the `CanvasState`, along with `undo` and `redo` actions, enabling users to revert and reapply changes to the canvas imports. The stacks are capped at 50 entries each to manage memory usage. [[1]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R43-R48) [[2]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L451-R559)
* Updated all relevant import-modifying actions (`addImport`, `removeImport`, `clearImports`, `loadLayout`, `cutImport`, `pasteImport`) to push snapshots to the undo stack, ensuring all user-driven changes are tracked. [[1]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L130-R183) [[2]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L157-R201) [[3]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L230-R286) [[4]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L249-R298) [[5]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R446) [[6]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R461)

**Gesture-based Undo Integration:**

* Implemented `snapshotForGesture` and `commitGesture` methods to take a snapshot before a gesture (drag, scale, rotate) begins and commit it to the undo stack only if the gesture results in a change, preventing unnecessary undo entries. [[1]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R115-R152) [[2]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L451-R559)
* Updated all gesture-related mouse event handlers in `PlotCanvas.tsx` to call `snapshotForGesture` on gesture start and `commitGesture` on mouse up. [[1]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR460) [[2]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR495) [[3]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR526) [[4]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR559) [[5]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR630) [[6]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR672) [[7]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR911-R912)

**Toolbar and Keyboard Shortcut Integration:**

* Exposed `undo` and `redo` actions in the toolbar, and added support for standard keyboard shortcuts: Ctrl+Z (undo), Ctrl+Shift+Z and Ctrl+Y (redo), with proper handling to avoid interfering with text input fields. [[1]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R301-R302) [[2]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R821-R824) [[3]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R912-R923)

**Testing Support:**

* Updated the canvas store test setup to initialize `undoStack` and `redoStack`, ensuring consistency in unit tests.