### PR TITLE
Page template

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { SerialClient } from "../machine/serial";
 import { TaskManager } from "../tasks/taskManager";
 import type {
   MachineConfig,
+  PageSize,
   VectorObject,
   GcodeOptions,
   MachineStatus,
@@ -333,6 +334,42 @@ function getDefaultConfigs(): MachineConfig[] {
   ];
 }
 
+// ─── Page-Size Persistence ────────────────────────────────────────────────────
+// Users can customise the available page sizes by editing page-sizes.json in the
+// app's userData directory.  If the file is absent the built-in defaults are used.
+
+const pageSizesPath = join(app.getPath("userData"), "page-sizes.json");
+
+const BUILT_IN_PAGE_SIZES: PageSize[] = [
+  { id: "a2", name: "A2", widthMM: 420, heightMM: 594 },
+  { id: "a3", name: "A3", widthMM: 297, heightMM: 420 },
+  { id: "a4", name: "A4", widthMM: 210, heightMM: 297 },
+  { id: "a5", name: "A5", widthMM: 148, heightMM: 210 },
+  { id: "a6", name: "A6", widthMM: 105, heightMM: 148 },
+  { id: "letter", name: "Letter", widthMM: 215.9, heightMM: 279.4 },
+  { id: "legal", name: "Legal", widthMM: 215.9, heightMM: 355.6 },
+  { id: "tabloid", name: "Tabloid", widthMM: 279.4, heightMM: 431.8 },
+];
+
+async function loadPageSizes(): Promise<PageSize[]> {
+  if (!existsSync(pageSizesPath)) {
+    await writeFile(
+      pageSizesPath,
+      JSON.stringify(BUILT_IN_PAGE_SIZES, null, 2),
+      "utf-8",
+    );
+    return BUILT_IN_PAGE_SIZES;
+  }
+  try {
+    const raw = await readFile(pageSizesPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed as PageSize[];
+    return BUILT_IN_PAGE_SIZES;
+  } catch {
+    return BUILT_IN_PAGE_SIZES;
+  }
+}
+
 // ─── IPC Handlers — Config ────────────────────────────────────────────────────
 
 ipcMain.handle("config:getMachineConfigs", () => loadConfigs());
@@ -441,6 +478,21 @@ ipcMain.handle("config:importConfigs", async () => {
     await saveConfigs([...existing, ...toAdd]);
   }
   return { added: toAdd.length, skipped };
+});
+
+ipcMain.handle("config:loadPageSizes", () => loadPageSizes());
+
+ipcMain.handle("config:openPageSizesFile", async () => {
+  // Write the built-in defaults if the file doesn't exist yet so the user has
+  // a well-formed starting point to edit.
+  if (!existsSync(pageSizesPath)) {
+    await writeFile(
+      pageSizesPath,
+      JSON.stringify(BUILT_IN_PAGE_SIZES, null, 2),
+      "utf-8",
+    );
+  }
+  shell.openPath(pageSizesPath);
 });
 
 // ─── IPC Handlers — App ───────────────────────────────────────────────────────

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -173,6 +173,8 @@ const config: TerraForgeAPI["config"] = {
   exportConfigs: () => invoke<string | null>("config:exportConfigs"),
   importConfigs: () =>
     invoke<{ added: number; skipped: number }>("config:importConfigs"),
+  loadPageSizes: () => invoke("config:loadPageSizes"),
+  openPageSizesFile: () => invoke("config:openPageSizesFile"),
 };
 
 // ─── App API ─────────────────────────────────────────────────────────────────

--- a/src/renderer/src/components/GcodeOptionsDialog.tsx
+++ b/src/renderer/src/components/GcodeOptionsDialog.tsx
@@ -31,6 +31,13 @@ export interface GcodePrefs {
   returnToHome: boolean;
   customStartGcode: string;
   customEndGcode: string;
+  /** How to clip G-code when a page template is active.
+   *  "none"   — no page clip (machine bed only)
+   *  "margin" — clip to the margin boundary shown on canvas
+   *  "page"   — clip to the page edge (with optional clipOffsetMM safety inset) */
+  clipMode: "none" | "page" | "margin";
+  /** Safety inset in mm applied when clipMode is "page" (default 0). */
+  clipOffsetMM: number;
 }
 
 const DEFAULTS: GcodePrefs = {
@@ -44,6 +51,8 @@ const DEFAULTS: GcodePrefs = {
   returnToHome: false,
   customStartGcode: "",
   customEndGcode: "",
+  clipMode: "none",
+  clipOffsetMM: 0,
 };
 
 export function loadGcodePrefs(): GcodePrefs {
@@ -81,7 +90,11 @@ interface Props {
 export function GcodeOptionsDialog({ onConfirm, onCancel }: Props) {
   const connected = useMachineStore((s) => s.connected);
   const layerGroupCount = useCanvasStore((s) => s.layerGroups.length);
+  const pageTemplate = useCanvasStore((s) => s.pageTemplate);
   const [prefs, setPrefs] = useState<GcodePrefs>(loadPrefs);
+  const [pathsOpen, setPathsOpen] = useState(false);
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const [outputOpen, setOutputOpen] = useState(true);
   const [customGcodeOpen, setCustomGcodeOpen] = useState(false);
 
   const toggle = (key: keyof GcodePrefs) =>
@@ -120,260 +133,371 @@ export function GcodeOptionsDialog({ onConfirm, onCancel }: Props) {
       <div className="bg-[#16213e] border border-[#0f3460] rounded-lg shadow-2xl w-[420px] p-5 flex flex-col gap-4">
         {/* Title */}
         <h2 className="text-white font-semibold text-sm tracking-widest uppercase">
-          Options
+          Generate G-code
         </h2>
 
-        {/* Options */}
-        <div className="flex flex-col gap-4">
-          {/* ── Optimise paths ── */}
-          <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              aria-label="Optimise paths"
-              className="mt-0.5 accent-[#e94560] cursor-pointer"
-              checked={prefs.optimise}
-              onChange={() => toggle("optimise")}
-            />
-            <div>
-              <div className="text-sm text-white font-medium">
-                Optimise paths
-              </div>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Reorder subpaths with a nearest-neighbour algorithm to minimise
-                total rapid-travel distance between strokes.
-              </div>
-            </div>
-          </label>
-
-          {/* ── Join nearby paths ── */}
-          <div className="flex items-start gap-3 select-none">
-            <input
-              type="checkbox"
-              aria-label="Join nearby paths"
-              className="mt-0.5 accent-[#e94560] cursor-pointer flex-shrink-0"
-              checked={prefs.joinPaths}
-              onChange={() => toggle("joinPaths")}
-              id="join-paths-cb"
-            />
-            <div className="flex-1 min-w-0">
-              <label
-                htmlFor="join-paths-cb"
-                className="cursor-pointer flex items-center gap-2 flex-wrap"
-              >
-                <span className="text-sm text-white font-medium">
-                  Join nearby paths
-                </span>
-                <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 border border-amber-500/30 leading-none">
-                  Experimental
-                </span>
-              </label>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Connect path endpoints within the tolerance below, skipping pen
-                up/down between nearly-touching strokes.
-              </div>
-              <div
-                className={`flex items-center gap-2 mt-2 transition-opacity ${prefs.joinPaths ? "opacity-100" : "opacity-30 pointer-events-none"}`}
-              >
-                <label className="text-xs text-gray-400 whitespace-nowrap">
-                  Tolerance
+        {/* ── Collapsible sections ── */}
+        <div className="flex flex-col gap-1">
+          {/* ────────────── PATHS ────────────── */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setPathsOpen((o) => !o)}
+              className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 hover:text-gray-300 uppercase tracking-wider transition-colors select-none w-full text-left py-1"
+            >
+              <ChevronDown
+                size={13}
+                className={`transition-transform duration-150 flex-shrink-0 ${pathsOpen ? "rotate-0" : "-rotate-90"}`}
+              />
+              Paths
+            </button>
+            {pathsOpen && (
+              <div className="flex flex-col gap-4 mt-2 mb-1">
+                {/* ── Optimise paths ── */}
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Optimise paths"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer"
+                    checked={prefs.optimise}
+                    onChange={() => toggle("optimise")}
+                  />
+                  <div>
+                    <div className="text-sm text-white font-medium">
+                      Optimise paths
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Reorder subpaths with a nearest-neighbour algorithm to
+                      minimise total rapid-travel distance between strokes.
+                    </div>
+                  </div>
                 </label>
-                <input
-                  type="number"
-                  min="0.01"
-                  max="10"
-                  step="0.05"
-                  value={prefs.joinTolerance}
-                  onChange={(e) => setJoinTolerance(e.target.value)}
-                  disabled={!prefs.joinPaths}
-                  className="w-20 px-2 py-0.5 text-xs rounded bg-[#0f3460] border border-[#1a4a8a] text-white focus:outline-none focus:border-[#e94560]"
-                />
-                <span className="text-xs text-gray-400">mm</span>
-              </div>
-            </div>
-          </div>
 
-          <div className="border-t border-[#0f3460]" />
-
-          {/* ── Options (lift / return) ── */}
-          <div className="text-xs text-gray-500 uppercase tracking-wider -mb-1">
-            Options
-          </div>
-
-          {/* Lift pen at end */}
-          <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              aria-label="Lift pen at end"
-              className="mt-0.5 accent-[#e94560] cursor-pointer"
-              checked={prefs.liftPenAtEnd}
-              onChange={() => toggle("liftPenAtEnd")}
-            />
-            <div>
-              <div className="text-sm text-white font-medium">
-                Lift pen at end
+                {/* ── Join nearby paths ── */}
+                <div className="flex items-start gap-3 select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Join nearby paths"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer flex-shrink-0"
+                    checked={prefs.joinPaths}
+                    onChange={() => toggle("joinPaths")}
+                    id="join-paths-cb"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <label
+                      htmlFor="join-paths-cb"
+                      className="cursor-pointer flex items-center gap-2 flex-wrap"
+                    >
+                      <span className="text-sm text-white font-medium">
+                        Join nearby paths
+                      </span>
+                      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 border border-amber-500/30 leading-none">
+                        Experimental
+                      </span>
+                    </label>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Connect path endpoints within the tolerance below,
+                      skipping pen up/down between nearly-touching strokes.
+                    </div>
+                    <div
+                      className={`flex items-center gap-2 mt-2 transition-opacity ${prefs.joinPaths ? "opacity-100" : "opacity-30 pointer-events-none"}`}
+                    >
+                      <label className="text-xs text-gray-400 whitespace-nowrap">
+                        Tolerance
+                      </label>
+                      <input
+                        type="number"
+                        min="0.01"
+                        max="10"
+                        step="0.05"
+                        value={prefs.joinTolerance}
+                        onChange={(e) => setJoinTolerance(e.target.value)}
+                        disabled={!prefs.joinPaths}
+                        className="w-20 px-2 py-0.5 text-xs rounded bg-[#0f3460] border border-[#1a4a8a] text-white focus:outline-none focus:border-[#e94560]"
+                      />
+                      <span className="text-xs text-gray-400">mm</span>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Send the pen-up command after the last stroke. Recommended to
-                avoid leaving the pen pressed on the paper.
-              </div>
-            </div>
-          </label>
-
-          {/* Return to home */}
-          <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              aria-label="Return to home (X0 Y0)"
-              className="mt-0.5 accent-[#e94560] cursor-pointer"
-              checked={prefs.returnToHome}
-              onChange={() => toggle("returnToHome")}
-            />
-            <div>
-              <div className="text-sm text-white font-medium">
-                Return to home (X0 Y0)
-              </div>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Send the pen to the origin after the job finishes.
-              </div>
-            </div>
-          </label>
-
-          {/* ── Custom G-code collapsible ── */}
-          <button
-            type="button"
-            onClick={() => setCustomGcodeOpen((o) => !o)}
-            className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors select-none w-fit"
-          >
-            <ChevronDown
-              size={14}
-              className={`transition-transform duration-150 ${
-                customGcodeOpen ? "rotate-0" : "-rotate-90"
-              }`}
-            />
-            Custom G-code
-            {(prefs.customStartGcode || prefs.customEndGcode) && (
-              <span className="ml-1 w-1.5 h-1.5 rounded-full bg-[#e94560] inline-block" />
             )}
-          </button>
-
-          {customGcodeOpen && (
-            <div className="flex flex-col gap-3 pl-1">
-              {/* Custom start G-code */}
-              <div className="flex flex-col gap-1">
-                <label className="text-xs text-gray-400 select-none">
-                  Start G-code
-                  <span className="ml-1 text-gray-600">(after preamble)</span>
-                </label>
-                <textarea
-                  aria-label="Custom start G-code"
-                  rows={3}
-                  value={prefs.customStartGcode}
-                  onChange={(e) =>
-                    setTextField("customStartGcode")(e.target.value)
-                  }
-                  placeholder="; e.g. M3 S0"
-                  spellCheck={false}
-                  className="w-full px-2 py-1.5 text-xs font-mono rounded bg-[#0f3460] border border-[#1a4a8a] text-white placeholder-gray-600 focus:outline-none focus:border-[#e94560] resize-none"
-                />
-              </div>
-              {/* Custom end G-code */}
-              <div className="flex flex-col gap-1">
-                <label className="text-xs text-gray-400 select-none">
-                  End G-code
-                  <span className="ml-1 text-gray-600">
-                    (after lift / return)
-                  </span>
-                </label>
-                <textarea
-                  aria-label="Custom end G-code"
-                  rows={3}
-                  value={prefs.customEndGcode}
-                  onChange={(e) =>
-                    setTextField("customEndGcode")(e.target.value)
-                  }
-                  placeholder="; e.g. M5"
-                  spellCheck={false}
-                  className="w-full px-2 py-1.5 text-xs font-mono rounded bg-[#0f3460] border border-[#1a4a8a] text-white placeholder-gray-600 focus:outline-none focus:border-[#e94560] resize-none"
-                />
-              </div>
-            </div>
-          )}
+          </div>
 
           <div className="border-t border-[#0f3460]" />
 
-          <div className="text-xs text-gray-500 uppercase tracking-wider -mb-1">
-            Output
-          </div>
+          {/* ────────────── OPTIONS ────────────── */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setOptionsOpen((o) => !o)}
+              className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 hover:text-gray-300 uppercase tracking-wider transition-colors select-none w-full text-left py-1"
+            >
+              <ChevronDown
+                size={13}
+                className={`transition-transform duration-150 flex-shrink-0 ${optionsOpen ? "rotate-0" : "-rotate-90"}`}
+              />
+              Options
+            </button>
+            {optionsOpen && (
+              <div className="flex flex-col gap-4 mt-2 mb-1">
+                {/* Lift pen at end */}
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Lift pen at end"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer"
+                    checked={prefs.liftPenAtEnd}
+                    onChange={() => toggle("liftPenAtEnd")}
+                  />
+                  <div>
+                    <div className="text-sm text-white font-medium">
+                      Lift pen at end
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Send the pen-up command after the last stroke. Recommended
+                      to avoid leaving the pen pressed on the paper.
+                    </div>
+                  </div>
+                </label>
 
-          {/* ── Upload to SD card ── */}
-          <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              aria-label="Upload to SD card"
-              className="mt-0.5 accent-[#e94560] cursor-pointer"
-              checked={prefs.uploadToSd}
-              onChange={() => toggle("uploadToSd")}
-            />
-            <div className="min-w-0">
-              <div className="text-sm text-white font-medium flex items-center flex-wrap gap-x-1.5">
-                Upload to SD card
-                {!connected && (
-                  <span className="text-xs text-amber-400 font-normal">
-                    (not connected — will be skipped)
-                  </span>
+                {/* Return to home */}
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Return to home (X0 Y0)"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer"
+                    checked={prefs.returnToHome}
+                    onChange={() => toggle("returnToHome")}
+                  />
+                  <div>
+                    <div className="text-sm text-white font-medium">
+                      Return to home (X0 Y0)
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Send the pen to the origin after the job finishes.
+                    </div>
+                  </div>
+                </label>
+
+                {/* ── Page clipping — only shown when a page template is active ── */}
+                {pageTemplate && (
+                  <div className="flex flex-col gap-1.5 select-none">
+                    <div className="text-sm text-white font-medium">
+                      Page clipping
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      {(["none", "margin", "page"] as const).map((mode) => (
+                        <label
+                          key={mode}
+                          className="flex items-center gap-2 cursor-pointer"
+                        >
+                          <input
+                            type="radio"
+                            name="clipMode"
+                            value={mode}
+                            checked={prefs.clipMode === mode}
+                            onChange={() =>
+                              setPrefs((p) => ({ ...p, clipMode: mode }))
+                            }
+                            className="accent-[#e94560] cursor-pointer"
+                          />
+                          <span className="text-xs text-gray-300">
+                            {mode === "none"
+                              ? "No clipping"
+                              : mode === "margin"
+                                ? "Clip to margin"
+                                : "Clip to page edge"}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                    {prefs.clipMode === "page" && (
+                      <div className="flex items-center gap-2 mt-1">
+                        <span className="text-xs text-gray-400 whitespace-nowrap">
+                          Safety inset
+                        </span>
+                        <input
+                          type="number"
+                          min="0"
+                          max="50"
+                          step="0.5"
+                          value={prefs.clipOffsetMM}
+                          onChange={(e) => {
+                            const n = parseFloat(e.target.value);
+                            if (!isNaN(n) && n >= 0)
+                              setPrefs((p) => ({ ...p, clipOffsetMM: n }));
+                          }}
+                          className="w-20 px-2 py-0.5 text-xs rounded bg-[#0f3460] border border-[#1a4a8a] text-white focus:outline-none focus:border-[#e94560]"
+                        />
+                        <span className="text-xs text-gray-400">
+                          mm from edge
+                        </span>
+                      </div>
+                    )}
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      {prefs.clipMode === "none" &&
+                        "G-code is clipped to the machine bed only."}
+                      {prefs.clipMode === "margin" &&
+                        "Clips to the margin boundary shown on canvas."}
+                      {prefs.clipMode === "page" &&
+                        "Clips to the page edge. Add an inset to keep the pen safely on the paper."}
+                    </div>
+                  </div>
+                )}
+
+                {/* ── Custom G-code sub-collapsible ── */}
+                <button
+                  type="button"
+                  onClick={() => setCustomGcodeOpen((o) => !o)}
+                  className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors select-none w-fit"
+                >
+                  <ChevronDown
+                    size={14}
+                    className={`transition-transform duration-150 ${customGcodeOpen ? "rotate-0" : "-rotate-90"}`}
+                  />
+                  Custom G-code
+                  {(prefs.customStartGcode || prefs.customEndGcode) && (
+                    <span className="ml-1 w-1.5 h-1.5 rounded-full bg-[#e94560] inline-block" />
+                  )}
+                </button>
+
+                {customGcodeOpen && (
+                  <div className="flex flex-col gap-3 pl-1">
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs text-gray-400 select-none">
+                        Start G-code
+                        <span className="ml-1 text-gray-600">
+                          (after preamble)
+                        </span>
+                      </label>
+                      <textarea
+                        aria-label="Custom start G-code"
+                        rows={3}
+                        value={prefs.customStartGcode}
+                        onChange={(e) =>
+                          setTextField("customStartGcode")(e.target.value)
+                        }
+                        placeholder="; e.g. M3 S0"
+                        spellCheck={false}
+                        className="w-full px-2 py-1.5 text-xs font-mono rounded bg-[#0f3460] border border-[#1a4a8a] text-white placeholder-gray-600 focus:outline-none focus:border-[#e94560] resize-none"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs text-gray-400 select-none">
+                        End G-code
+                        <span className="ml-1 text-gray-600">
+                          (after lift / return)
+                        </span>
+                      </label>
+                      <textarea
+                        aria-label="Custom end G-code"
+                        rows={3}
+                        value={prefs.customEndGcode}
+                        onChange={(e) =>
+                          setTextField("customEndGcode")(e.target.value)
+                        }
+                        placeholder="; e.g. M5"
+                        spellCheck={false}
+                        className="w-full px-2 py-1.5 text-xs font-mono rounded bg-[#0f3460] border border-[#1a4a8a] text-white placeholder-gray-600 focus:outline-none focus:border-[#e94560] resize-none"
+                      />
+                    </div>
+                  </div>
                 )}
               </div>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Upload the generated file directly to the machine SD card root.
-                Auto-selects it as the queued job.
-              </div>
-            </div>
-          </label>
+            )}
+          </div>
 
-          {/* ── Save to local computer ── */}
-          <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              aria-label="Save to computer"
-              className="mt-0.5 accent-[#e94560] cursor-pointer"
-              checked={prefs.saveLocally}
-              onChange={() => toggle("saveLocally")}
-            />
-            <div>
-              <div className="text-sm text-white font-medium">
-                Save to computer
-              </div>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Open a save dialog to choose where to write the G-code file on
-                this computer.
-              </div>
-            </div>
-          </label>
+          <div className="border-t border-[#0f3460]" />
 
-          {/* ── Export one file per group ── */}
-          <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              aria-label="Export one file per group"
-              className="mt-0.5 accent-[#e94560] cursor-pointer"
-              checked={prefs.exportPerGroup}
-              onChange={() => toggle("exportPerGroup")}
-            />
-            <div>
-              <div className="text-sm text-white font-medium">
-                Export one file per group
+          {/* ────────────── OUTPUT ────────────── */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setOutputOpen((o) => !o)}
+              className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 hover:text-gray-300 uppercase tracking-wider transition-colors select-none w-full text-left py-1"
+            >
+              <ChevronDown
+                size={13}
+                className={`transition-transform duration-150 flex-shrink-0 ${outputOpen ? "rotate-0" : "-rotate-90"}`}
+              />
+              Output
+            </button>
+            {outputOpen && (
+              <div className="flex flex-col gap-4 mt-2 mb-1">
+                {/* Upload to SD card */}
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Upload to SD card"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer"
+                    checked={prefs.uploadToSd}
+                    onChange={() => toggle("uploadToSd")}
+                  />
+                  <div className="min-w-0">
+                    <div className="text-sm text-white font-medium flex items-center flex-wrap gap-x-1.5">
+                      Upload to SD card
+                      {!connected && (
+                        <span className="text-xs text-amber-400 font-normal">
+                          (not connected — will be skipped)
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Upload the generated file directly to the machine SD card
+                      root. Auto-selects it as the queued job.
+                    </div>
+                  </div>
+                </label>
+
+                {/* Save to local computer */}
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Save to computer"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer"
+                    checked={prefs.saveLocally}
+                    onChange={() => toggle("saveLocally")}
+                  />
+                  <div>
+                    <div className="text-sm text-white font-medium">
+                      Save to computer
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Open a save dialog to choose where to write the G-code
+                      file on this computer.
+                    </div>
+                  </div>
+                </label>
+
+                {/* Export one file per group */}
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    aria-label="Export one file per group"
+                    className="mt-0.5 accent-[#e94560] cursor-pointer"
+                    checked={prefs.exportPerGroup}
+                    onChange={() => toggle("exportPerGroup")}
+                  />
+                  <div>
+                    <div className="text-sm text-white font-medium">
+                      Export one file per group
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">
+                      Generate a separate G-code file for each layer group —
+                      ideal for multi-colour pen plots. Each file is named after
+                      its group.
+                    </div>
+                    {prefs.exportPerGroup && layerGroupCount === 0 && (
+                      <div className="text-xs text-amber-400 mt-1">
+                        No groups defined — add groups in the Properties panel
+                        first.
+                      </div>
+                    )}
+                  </div>
+                </label>
               </div>
-              <div className="text-xs text-gray-400 mt-0.5">
-                Generate a separate G-code file for each layer group — ideal for
-                multi-colour pen plots. Each file is named after its group.
-              </div>
-              {prefs.exportPerGroup && layerGroupCount === 0 && (
-                <div className="text-xs text-amber-400 mt-1">
-                  No groups defined — add groups in the Properties panel first.
-                </div>
-              )}
-            </div>
-          </label>
+            )}
+          </div>
         </div>
 
         {/* Validation warning */}

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -72,6 +72,8 @@ export function PlotCanvas() {
   const plotProgressCuts = useCanvasStore((s) => s.plotProgressCuts);
   const plotProgressRapids = useCanvasStore((s) => s.plotProgressRapids);
   const layerGroups = useCanvasStore((s) => s.layerGroups);
+  const pageTemplate = useCanvasStore((s) => s.pageTemplate);
+  const pageSizes = useCanvasStore((s) => s.pageSizes);
   const activeConfig = useMachineStore((s) => s.activeConfig);
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
@@ -1565,6 +1567,62 @@ export function PlotCanvas() {
         ))}
 
         {/* Rulers are rendered as a screen-space overlay — see below */}
+
+        {/* Page template overlay — non-interactive amber dashed rectangle
+             showing the chosen paper size relative to the machine origin.
+             Hidden from the layers panel; cannot be selected or edited. */}
+        {pageTemplate &&
+          (() => {
+            const activeSize = pageSizes.find(
+              (ps) => ps.id === pageTemplate.sizeId,
+            );
+            if (!activeSize) return null;
+            const pgW = pageTemplate.landscape
+              ? activeSize.heightMM
+              : activeSize.widthMM;
+            const pgH = pageTemplate.landscape
+              ? activeSize.widthMM
+              : activeSize.heightMM;
+            // Convert page corners from machine mm to SVG canvas px.
+            const svgX0 = getBedX(0);
+            const svgX1 = getBedX(pgW);
+            const svgY0 = getBedY(pgH); // top edge (H mm from origin)
+            const svgY1 = getBedY(0); // origin edge
+            const rectX = Math.min(svgX0, svgX1);
+            const rectY = Math.min(svgY0, svgY1);
+            const rectW = Math.abs(svgX1 - svgX0);
+            const rectH = Math.abs(svgY1 - svgY0);
+            const label = `${activeSize.name} ${pageTemplate.landscape ? "Landscape" : "Portrait"}`;
+            // Keep label at a fixed ~11px screen size regardless of zoom level.
+            const labelSize = 11 / vp.zoom;
+            return (
+              <g pointerEvents="none">
+                <rect
+                  x={rectX}
+                  y={rectY}
+                  width={rectW}
+                  height={rectH}
+                  fill="none"
+                  stroke="#f59e0b"
+                  strokeWidth={1}
+                  strokeDasharray="6 3"
+                  vectorEffect="non-scaling-stroke"
+                  opacity={0.65}
+                />
+                <text
+                  x={rectX + 4 / vp.zoom}
+                  y={rectY - 4 / vp.zoom}
+                  fontSize={labelSize}
+                  fill="#f59e0b"
+                  opacity={0.65}
+                  vectorEffect="non-scaling-stroke"
+                  fontFamily="monospace"
+                >
+                  {label}
+                </text>
+              </g>
+            );
+          })()}
 
         {/* G-code toolpath hit-area (paths rendered on the canvas overlay below). */}
         {gcodeToolpath &&

--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -1595,6 +1595,12 @@ export function PlotCanvas() {
             const label = `${activeSize.name} ${pageTemplate.landscape ? "Landscape" : "Portrait"}`;
             // Keep label at a fixed ~11px screen size regardless of zoom level.
             const labelSize = 11 / vp.zoom;
+            // Margin inset rect (in SVG px).
+            const marginPx = (pageTemplate.marginMM ?? 20) * MM_TO_PX;
+            const mX = rectX + marginPx;
+            const mY = rectY + marginPx;
+            const mW = rectW - marginPx * 2;
+            const mH = rectH - marginPx * 2;
             return (
               <g pointerEvents="none">
                 <rect
@@ -1609,6 +1615,20 @@ export function PlotCanvas() {
                   vectorEffect="non-scaling-stroke"
                   opacity={0.65}
                 />
+                {mW > 0 && mH > 0 && (
+                  <rect
+                    x={mX}
+                    y={mY}
+                    width={mW}
+                    height={mH}
+                    fill="none"
+                    stroke="#f59e0b"
+                    strokeWidth={1}
+                    strokeDasharray="3 3"
+                    vectorEffect="non-scaling-stroke"
+                    opacity={0.35}
+                  />
+                )}
                 <text
                   x={rectX + 4 / vp.zoom}
                   y={rectY - 4 / vp.zoom}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { v4 as uuid } from "uuid";
+import { PenLine } from "lucide-react";
 import { useMachineStore } from "../store/machineStore";
 import { useCanvasStore } from "../store/canvasStore";
 import { useTaskStore } from "../store/taskStore";
@@ -10,6 +11,7 @@ import {
   type SvgImport,
   type SvgPath,
   type CanvasLayout,
+  type PageTemplate,
   DEFAULT_HATCH_SPACING_MM,
   DEFAULT_HATCH_ANGLE_DEG,
 } from "../../../types";
@@ -307,6 +309,10 @@ export function Toolbar({
   const allImportsSelected = useCanvasStore((s) => s.allImportsSelected);
   const undo = useCanvasStore((s) => s.undo);
   const redo = useCanvasStore((s) => s.redo);
+  const pageTemplate = useCanvasStore((s) => s.pageTemplate);
+  const setPageTemplate = useCanvasStore((s) => s.setPageTemplate);
+  const pageSizes = useCanvasStore((s) => s.pageSizes);
+  const setPageSizes = useCanvasStore((s) => s.setPageSizes);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const registerCancelCallback = useTaskStore((s) => s.registerCancelCallback);
   const unregisterCancelCallback = useTaskStore(
@@ -716,6 +722,7 @@ export function Toolbar({
         savedAt: new Date().toISOString(),
         imports,
         layerGroups,
+        pageTemplate,
       };
       await window.terraForge.fs.writeFile(
         savePath,
@@ -773,7 +780,7 @@ export function Toolbar({
         // Canvas already has content — ask before overwriting.
         setPendingLayout(layout);
       } else {
-        loadLayout(layout.imports, layout.layerGroups);
+        loadLayout(layout.imports, layout.layerGroups, layout.pageTemplate);
       }
     } catch (err) {
       upsertTask({
@@ -943,6 +950,19 @@ export function Toolbar({
       unsubSelectAll();
       window.removeEventListener("keydown", onKeyDown);
     };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load custom page sizes from the main process on mount.
+  // Falls back to the built-in defaults (already in the store) if IPC fails.
+  useEffect(() => {
+    window.terraForge.config
+      .loadPageSizes()
+      .then((sizes) => {
+        if (sizes.length > 0) setPageSizes(sizes);
+      })
+      .catch(() => {
+        /* keep built-in defaults */
+      });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Keep Save Layout / Close Layout menu items enabled only when there are imports.
@@ -1353,6 +1373,94 @@ export function Toolbar({
 
       <div className="h-4 w-px bg-[#0f3460]" />
 
+      {/* ── Page Template ─────────────────────────────────────────────────────
+           Shows a non-interactive page-size overlay on the canvas.
+           Sizes come from the store (loaded from IPC / built-in defaults). */}
+      <div className="flex items-center gap-1">
+        <select
+          className="bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-sm text-gray-200 max-w-[110px]"
+          value={pageTemplate?.sizeId ?? "none"}
+          title="Page template — adds a size guide overlay to the canvas"
+          onChange={(e) => {
+            const id = e.target.value;
+            if (id === "none") {
+              setPageTemplate(null);
+            } else {
+              setPageTemplate({
+                sizeId: id,
+                landscape: pageTemplate?.landscape ?? true,
+              });
+            }
+          }}
+        >
+          <option value="none">No page</option>
+          {pageSizes.map((ps) => (
+            <option key={ps.id} value={ps.id}>
+              {ps.name}
+            </option>
+          ))}
+        </select>
+
+        {/* Portrait / landscape toggle — only shown when a page is selected */}
+        {pageTemplate && (
+          <button
+            onClick={() =>
+              setPageTemplate({
+                ...pageTemplate,
+                landscape: !pageTemplate.landscape,
+              })
+            }
+            className="w-7 h-7 rounded bg-[#0f3460] hover:bg-[#1a4a8a] transition-colors flex items-center justify-center text-gray-300"
+            title={
+              pageTemplate.landscape
+                ? "Landscape — click to switch to portrait"
+                : "Portrait — click to switch to landscape"
+            }
+          >
+            {pageTemplate.landscape ? (
+              /* Landscape page icon */
+              <svg
+                width="16"
+                height="12"
+                viewBox="0 0 16 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="0.75" y="0.75" width="14.5" height="10.5" rx="1" />
+              </svg>
+            ) : (
+              /* Portrait page icon */
+              <svg
+                width="11"
+                height="15"
+                viewBox="0 0 11 15"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="0.75" y="0.75" width="9.5" height="13.5" rx="1" />
+              </svg>
+            )}
+          </button>
+        )}
+
+        {/* Edit custom page sizes file */}
+        <button
+          onClick={() => window.terraForge.config.openPageSizesFile()}
+          className="w-7 h-7 rounded bg-[#0f3460] hover:bg-[#1a4a8a] transition-colors flex items-center justify-center text-gray-400"
+          title="Edit custom page sizes (opens page-sizes.json in your default editor)"
+        >
+          <PenLine size={12} />
+        </button>
+      </div>
+
+      <div className="h-4 w-px bg-[#0f3460]" />
+
       {/* Home */}
       <button
         onClick={() => window.terraForge.fluidnc.sendCommand("$H")}
@@ -1439,7 +1547,11 @@ export function Toolbar({
           message={`The canvas already has ${imports.length} object${imports.length !== 1 ? "s" : ""}. Opening this layout will replace it.\n\nContinue?`}
           confirmLabel="Replace"
           onConfirm={() => {
-            loadLayout(pendingLayout.imports, pendingLayout.layerGroups);
+            loadLayout(
+              pendingLayout.imports,
+              pendingLayout.layerGroups,
+              pendingLayout.pageTemplate,
+            );
             setPendingLayout(null);
           }}
           onCancel={() => setPendingLayout(null)}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1318,6 +1318,7 @@ export function Toolbar({
 
       {/* Machine selector — locked while connected */}
       <select
+        aria-label="Machine selector"
         className="bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-sm text-gray-200 min-w-[180px] disabled:opacity-50 disabled:cursor-not-allowed"
         value={activeConfigId ?? ""}
         onChange={(e) => setActiveConfigId(e.target.value || null)}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1389,6 +1389,7 @@ export function Toolbar({
               setPageTemplate({
                 sizeId: id,
                 landscape: pageTemplate?.landscape ?? true,
+                marginMM: pageTemplate?.marginMM ?? 20,
               });
             }
           }}
@@ -1408,6 +1409,7 @@ export function Toolbar({
               setPageTemplate({
                 ...pageTemplate,
                 landscape: !pageTemplate.landscape,
+                marginMM: pageTemplate.marginMM ?? 20,
               })
             }
             className="w-7 h-7 rounded bg-[#0f3460] hover:bg-[#1a4a8a] transition-colors flex items-center justify-center text-gray-300"
@@ -1447,6 +1449,28 @@ export function Toolbar({
               </svg>
             )}
           </button>
+        )}
+
+        {/* Margin input — only shown when a page is selected */}
+        {pageTemplate && (
+          <div className="flex items-center gap-1">
+            <input
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={pageTemplate.marginMM ?? 20}
+              onChange={(e) =>
+                setPageTemplate({
+                  ...pageTemplate,
+                  marginMM: Math.max(0, Math.min(100, Number(e.target.value) || 0)),
+                })
+              }
+              className="w-14 bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-sm text-gray-200 text-right"
+              title="Page margin in mm"
+            />
+            <span className="text-xs text-gray-400">mm</span>
+          </div>
         )}
 
         {/* Edit custom page sizes file */}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -987,6 +987,9 @@ export function Toolbar({
 
     setGenerating(true);
     const taskId = uuid();
+    const activePageSize = pageTemplate
+      ? pageSizes.find((ps) => ps.id === pageTemplate.sizeId)
+      : undefined;
     const options: GcodeOptions = {
       arcFitting: false,
       arcTolerance: 0.01,
@@ -997,6 +1000,21 @@ export function Toolbar({
       returnToHome: prefs.returnToHome,
       customStartGcode: prefs.customStartGcode,
       customEndGcode: prefs.customEndGcode,
+      pageClip:
+        activePageSize && prefs.clipMode !== "none"
+          ? {
+              widthMM: pageTemplate!.landscape
+                ? activePageSize.heightMM
+                : activePageSize.widthMM,
+              heightMM: pageTemplate!.landscape
+                ? activePageSize.widthMM
+                : activePageSize.heightMM,
+              marginMM:
+                prefs.clipMode === "margin"
+                  ? (pageTemplate!.marginMM ?? 20)
+                  : (prefs.clipOffsetMM ?? 0),
+            }
+          : undefined,
     };
 
     const worker = new Worker(
@@ -1143,6 +1161,9 @@ export function Toolbar({
     cfg: ReturnType<typeof activeConfig>,
   ) => {
     if (!cfg) return;
+    const activePageSize = pageTemplate
+      ? pageSizes.find((ps) => ps.id === pageTemplate.sizeId)
+      : undefined;
     const options: GcodeOptions = {
       arcFitting: false,
       arcTolerance: 0.01,
@@ -1153,6 +1174,21 @@ export function Toolbar({
       returnToHome: prefs.returnToHome,
       customStartGcode: prefs.customStartGcode,
       customEndGcode: prefs.customEndGcode,
+      pageClip:
+        activePageSize && prefs.clipMode !== "none"
+          ? {
+              widthMM: pageTemplate!.landscape
+                ? activePageSize.heightMM
+                : activePageSize.widthMM,
+              heightMM: pageTemplate!.landscape
+                ? activePageSize.widthMM
+                : activePageSize.heightMM,
+              marginMM:
+                prefs.clipMode === "margin"
+                  ? (pageTemplate!.marginMM ?? 20)
+                  : (prefs.clipOffsetMM ?? 0),
+            }
+          : undefined,
     };
 
     // Only process groups that have at least one visible path in them.
@@ -1463,7 +1499,10 @@ export function Toolbar({
               onChange={(e) =>
                 setPageTemplate({
                   ...pageTemplate,
-                  marginMM: Math.max(0, Math.min(100, Number(e.target.value) || 0)),
+                  marginMM: Math.max(
+                    0,
+                    Math.min(100, Number(e.target.value) || 0),
+                  ),
                 })
               }
               className="w-14 bg-[#1a1a2e] border border-[#0f3460] rounded px-2 py-1 text-sm text-gray-200 text-right"

--- a/src/renderer/src/store/canvasStore.ts
+++ b/src/renderer/src/store/canvasStore.ts
@@ -6,6 +6,9 @@ import {
   type SvgPath,
   type VectorObject,
   type LayerGroup,
+  type PageSize,
+  type PageTemplate,
+  BUILT_IN_PAGE_SIZES,
   DEFAULT_HATCH_SPACING_MM,
   DEFAULT_HATCH_ANGLE_DEG,
 } from "../../../types";
@@ -80,7 +83,11 @@ interface CanvasState {
   selectToolpath: (selected: boolean) => void;
   clearImports: () => void;
   /** Replace the entire imports list atomically — used by canvas layout load. */
-  loadLayout: (imports: SvgImport[], layerGroups?: LayerGroup[]) => void;
+  loadLayout: (
+    imports: SvgImport[],
+    layerGroups?: LayerGroup[],
+    pageTemplate?: PageTemplate | null,
+  ) => void;
   selectedImport: () => SvgImport | undefined;
   setGcodeToolpath: (tp: GcodeToolpath | null) => void;
   setGcodeSource: (
@@ -119,6 +126,14 @@ interface CanvasState {
   /** Commit the gesture snapshot to the undo stack only if imports actually changed.
    *  Discards the snapshot if nothing was modified (e.g. click without drag). */
   commitGesture: () => void;
+
+  // ─── Page Template ────────────────────────────────────────────────────────
+  /** Active page template overlay shown on the canvas (null = none). */
+  pageTemplate: PageTemplate | null;
+  setPageTemplate: (t: PageTemplate | null) => void;
+  /** Available page sizes — loaded from IPC on startup; falls back to built-in defaults. */
+  pageSizes: PageSize[];
+  setPageSizes: (sizes: PageSize[]) => void;
 
   // ─── Layer Groups ─────────────────────────────────────────────────────────
   layerGroups: LayerGroup[];
@@ -183,6 +198,8 @@ export const useCanvasStore = create<CanvasState>()(
       plotProgressCuts: "",
       plotProgressRapids: "",
       gcodePreviewLoading: false,
+      pageTemplate: null,
+      pageSizes: BUILT_IN_PAGE_SIZES,
       layerGroups: [],
       setGcodePreviewLoading: (loading) =>
         set((state) => {
@@ -318,7 +335,7 @@ export const useCanvasStore = create<CanvasState>()(
         });
       },
 
-      loadLayout: (newImports, newLayerGroups) => {
+      loadLayout: (newImports, newLayerGroups, newPageTemplate) => {
         pushUndo();
         set((state) => {
           state.imports = newImports.map((imp) => ({
@@ -332,8 +349,19 @@ export const useCanvasStore = create<CanvasState>()(
           state.allImportsSelected = false;
           state.selectedGroupId = null;
           state.layerGroups = newLayerGroups ?? [];
+          state.pageTemplate = newPageTemplate ?? null;
         });
       },
+
+      setPageTemplate: (t) =>
+        set((state) => {
+          state.pageTemplate = t;
+        }),
+
+      setPageSizes: (sizes) =>
+        set((state) => {
+          state.pageSizes = sizes;
+        }),
 
       selectedImport: () => {
         const { imports, selectedImportId } = get();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -151,6 +151,8 @@ export interface PageTemplate {
   /** Matches PageSize.id */
   sizeId: string;
   landscape: boolean;
+  /** Margin in mm drawn as a second inset overlay inside the page boundary. */
+  marginMM: number;
 }
 
 /** Built-in page sizes used as defaults when no custom page-sizes.json exists. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -134,6 +134,37 @@ export interface SvgImport {
   strokeWidthMM?: number;
 }
 
+// ─── Page Templates ──────────────────────────────────────────────────────────
+
+/** A named paper/page size definition. Dimensions are in portrait orientation. */
+export interface PageSize {
+  id: string;
+  name: string;
+  /** Width in portrait orientation (mm) */
+  widthMM: number;
+  /** Height in portrait orientation (mm) */
+  heightMM: number;
+}
+
+/** The active page template overlay shown on the canvas. */
+export interface PageTemplate {
+  /** Matches PageSize.id */
+  sizeId: string;
+  landscape: boolean;
+}
+
+/** Built-in page sizes used as defaults when no custom page-sizes.json exists. */
+export const BUILT_IN_PAGE_SIZES: PageSize[] = [
+  { id: "a2", name: "A2", widthMM: 420, heightMM: 594 },
+  { id: "a3", name: "A3", widthMM: 297, heightMM: 420 },
+  { id: "a4", name: "A4", widthMM: 210, heightMM: 297 },
+  { id: "a5", name: "A5", widthMM: 148, heightMM: 210 },
+  { id: "a6", name: "A6", widthMM: 105, heightMM: 148 },
+  { id: "letter", name: "Letter", widthMM: 215.9, heightMM: 279.4 },
+  { id: "legal", name: "Legal", widthMM: 215.9, heightMM: 355.6 },
+  { id: "tabloid", name: "Tabloid", widthMM: 279.4, heightMM: 431.8 },
+];
+
 // ─── Canvas Layout ──────────────────────────────────────────────────────────────
 
 /** Serialised canvas layout — saved/loaded as .tforge JSON. */
@@ -144,6 +175,8 @@ export interface CanvasLayout {
   imports: SvgImport[];
   /** Layer groups — optional for backward compatibility with older layout files. */
   layerGroups?: LayerGroup[];
+  /** Active page template — optional for backward compatibility. */
+  pageTemplate?: PageTemplate | null;
 }
 
 // ─── Layer Groups ────────────────────────────────────────────────────────────
@@ -349,6 +382,10 @@ export interface ConfigApi {
   exportConfigs: () => Promise<string | null>;
   /** Import configs from a .json file chosen by the user. Returns counts of added and skipped configs. */
   importConfigs: () => Promise<{ added: number; skipped: number }>;
+  /** Load page size definitions — returns custom sizes from userData or the built-in defaults. */
+  loadPageSizes: () => Promise<PageSize[]>;
+  /** Ensure page-sizes.json exists in userData (writing defaults if needed), then open it in the OS editor. */
+  openPageSizesFile: () => Promise<void>;
 }
 
 export interface AppApi {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -219,6 +219,9 @@ export interface GcodeOptions {
   returnToHome: boolean; // send G0 X0 Y0 at end of job (default false)
   customStartGcode: string; // raw G-code lines inserted after the preamble, before paths
   customEndGcode: string; // raw G-code lines appended after lift/return, before EOF comment
+  /** When a page template is active, clip G-code to the page's printable area
+   *  (page dimensions minus margin on all sides) instead of the full machine bed. */
+  pageClip?: { widthMM: number; heightMM: number; marginMM: number };
 }
 
 // ─── Background Tasks ─────────────────────────────────────────────────────────

--- a/src/workers/gcodeEngine.ts
+++ b/src/workers/gcodeEngine.ts
@@ -735,21 +735,19 @@ function liangBarsky(
 }
 
 /**
- * Clips an array of polyline subpaths (already in machine mm coordinates)
- * against the bed rectangle implied by config.  A single input subpath may
- * split into several output subpaths when its segments exit and re-enter the
- * bed area.  Segments entirely outside the bed are silently dropped.
+ * Clips an array of polyline subpaths against an explicit axis-aligned
+ * rectangle [xMin, xMax] × [yMin, yMax] (all in machine mm).
+ * A single input subpath may split into several output subpaths when its
+ * segments exit and re-enter the rectangle.  Segments entirely outside are
+ * silently dropped.
  */
-export function clipSubpathsToBed(
+export function clipSubpathsToRect(
   subpaths: Subpath[],
-  config: MachineConfig,
+  xMin: number,
+  xMax: number,
+  yMin: number,
+  yMax: number,
 ): Subpath[] {
-  const isCenter = config.origin === "center";
-  const xMin = isCenter ? -config.bedWidth / 2 : 0;
-  const xMax = isCenter ? config.bedWidth / 2 : config.bedWidth;
-  const yMin = isCenter ? -config.bedHeight / 2 : 0;
-  const yMax = isCenter ? config.bedHeight / 2 : config.bedHeight;
-
   const result: Subpath[] = [];
 
   for (const subpath of subpaths) {
@@ -775,18 +773,18 @@ export function clipSubpathsToBed(
       const [t0, t1] = clip;
 
       if (t0 > 1e-9) {
-        // Segment enters the bed mid-way — flush previous run and start fresh.
+        // Segment enters the rect mid-way — flush previous run and start fresh.
         if (current.length >= 2) result.push(current);
         current = [interp(p0, p1, t0)];
       } else if (current.length === 0) {
-        // Starting a new run from inside (or right on) the bed boundary.
+        // Starting a new run from inside (or right on) the rect boundary.
         current.push(p0);
       }
       // Append the exit point.
       current.push(interp(p0, p1, t1));
 
       if (t1 < 1 - 1e-9) {
-        // Segment exits the bed before reaching p1 — flush this run.
+        // Segment exits the rect before reaching p1 — flush this run.
         if (current.length >= 2) result.push(current);
         current = [];
       }
@@ -796,6 +794,24 @@ export function clipSubpathsToBed(
   }
 
   return result;
+}
+
+/**
+ * Clips an array of polyline subpaths (already in machine mm coordinates)
+ * against the bed rectangle implied by config.  A single input subpath may
+ * split into several output subpaths when its segments exit and re-enter the
+ * bed area.  Segments entirely outside the bed are silently dropped.
+ */
+export function clipSubpathsToBed(
+  subpaths: Subpath[],
+  config: MachineConfig,
+): Subpath[] {
+  const isCenter = config.origin === "center";
+  const xMin = isCenter ? -config.bedWidth / 2 : 0;
+  const xMax = isCenter ? config.bedWidth / 2 : config.bedWidth;
+  const yMin = isCenter ? -config.bedHeight / 2 : 0;
+  const yMax = isCenter ? config.bedHeight / 2 : config.bedHeight;
+  return clipSubpathsToRect(subpaths, xMin, xMax, yMin, yMax);
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/workers/svgWorker.ts
+++ b/src/workers/svgWorker.ts
@@ -17,6 +17,7 @@ import type { VectorObject, MachineConfig, GcodeOptions } from "../types";
 import {
   flattenToSubpaths,
   clipSubpathsToBed,
+  clipSubpathsToRect,
   nearestNeighbourSort,
   joinSubpaths,
   fmtCoord as fmt,
@@ -73,6 +74,12 @@ async function generate(msg: GenerateMessage): Promise<void> {
   lines.push(`; Machine  : ${config.name}`);
   lines.push(`; Bed      : ${config.bedWidth} x ${config.bedHeight} mm`);
   lines.push(`; Origin   : ${config.origin}`);
+  if (options?.pageClip) {
+    const pc = options.pageClip;
+    lines.push(
+      `; Page clip: ${pc.widthMM} x ${pc.heightMM} mm (${pc.marginMM} mm margin)`,
+    );
+  }
   lines.push(`; Optimised: ${optimise ? "yes (nearest-neighbour)" : "no"}`);
   lines.push(`; Joined   : ${doJoin ? `yes (tolerance ${joinTol} mm)` : "no"}`);
   lines.push(`; Lift end : ${liftPenAtEnd ? "yes" : "no"}`);
@@ -126,7 +133,16 @@ async function generate(msg: GenerateMessage): Promise<void> {
       return;
     }
     const raw = flattenToSubpaths(visibleObjects[i], config);
-    for (const sp of clipSubpathsToBed(raw, config)) {
+    const clipped = options?.pageClip
+      ? clipSubpathsToRect(
+          raw,
+          options.pageClip.marginMM,
+          options.pageClip.widthMM - options.pageClip.marginMM,
+          options.pageClip.marginMM,
+          options.pageClip.heightMM - options.pageClip.marginMM,
+        )
+      : clipSubpathsToBed(raw, config);
+    for (const sp of clipped) {
       if (sp.length >= 2) allSubpaths.push(sp);
     }
     const pct = Math.round(((i + 1) / visibleObjects.length) * 40);

--- a/tests/component/GcodeOptionsDialog.test.tsx
+++ b/tests/component/GcodeOptionsDialog.test.tsx
@@ -98,7 +98,7 @@ describe("GcodeOptionsDialog", () => {
   it("renders the Options heading", () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
     expect(
-      screen.getByRole("heading", { name: "Options" }),
+      screen.getByRole("heading", { name: "Generate G-code" }),
     ).toBeInTheDocument();
   });
 
@@ -118,6 +118,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("saves prefs to localStorage on confirm", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /paths/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: "Optimise paths" }),
     );
@@ -126,7 +127,7 @@ describe("GcodeOptionsDialog", () => {
     expect(stored.optimise).toBe(false);
   });
 
-  it("loads prefs from localStorage on mount", () => {
+  it("loads prefs from localStorage on mount", async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -142,6 +143,8 @@ describe("GcodeOptionsDialog", () => {
       }),
     );
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     expect(
       screen.getByRole("checkbox", { name: "Optimise paths" }),
     ).not.toBeChecked();
@@ -217,6 +220,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("toggles Lift pen at end checkbox", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     const cb = screen.getByRole("checkbox", { name: "Lift pen at end" });
     expect(cb).toBeChecked(); // default true
     await userEvent.click(cb);
@@ -225,6 +229,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("toggles Return to home checkbox", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     const cb = screen.getByRole("checkbox", { name: "Return to home (X0 Y0)" });
     expect(cb).not.toBeChecked(); // default false
     await userEvent.click(cb);
@@ -233,6 +238,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("toggles Join nearby paths checkbox", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
     const cb = screen.getByRole("checkbox", { name: "Join nearby paths" });
     expect(cb).not.toBeChecked();
     await userEvent.click(cb);
@@ -241,6 +247,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("tolerance input becomes interactive when Join paths is checked", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
     const joinCb = screen.getByRole("checkbox", { name: "Join nearby paths" });
     const toleranceInput = screen.getByRole("spinbutton");
     expect(toleranceInput).toBeDisabled();
@@ -250,6 +257,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("updates join tolerance value on valid input", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: "Join nearby paths" }),
     );
@@ -263,6 +271,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("ignores invalid tolerance input (NaN stays at previous value)", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: "Join nearby paths" }),
     );
@@ -278,6 +287,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("ignores zero tolerance input", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: "Join nearby paths" }),
     );
@@ -311,8 +321,9 @@ describe("GcodeOptionsDialog", () => {
 
   // ── Custom G-code section ─────────────────────────────────────────────────
 
-  it("Custom G-code section is collapsed by default", () => {
+  it("Custom G-code section is collapsed by default", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     expect(
       screen.queryByLabelText("Custom start G-code"),
     ).not.toBeInTheDocument();
@@ -320,6 +331,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("clicking Custom G-code expands the section", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     await userEvent.click(screen.getByText("Custom G-code"));
     expect(screen.getByLabelText("Custom start G-code")).toBeInTheDocument();
     expect(screen.getByLabelText("Custom end G-code")).toBeInTheDocument();
@@ -327,6 +339,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("clicking Custom G-code again collapses the section", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     await userEvent.click(screen.getByText("Custom G-code"));
     await userEvent.click(screen.getByText("Custom G-code"));
     expect(
@@ -348,6 +361,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("types into custom start G-code textarea", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     await userEvent.click(screen.getByText("Custom G-code"));
     const startInput = screen.getByLabelText("Custom start G-code");
     await userEvent.type(startInput, "M3 S0");
@@ -359,6 +373,7 @@ describe("GcodeOptionsDialog", () => {
 
   it("types into custom end G-code textarea", async () => {
     render(<GcodeOptionsDialog onConfirm={onConfirm} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: /^options$/i }));
     await userEvent.click(screen.getByText("Custom G-code"));
     const endInput = screen.getByLabelText("Custom end G-code");
     await userEvent.type(endInput, "M5");
@@ -382,6 +397,8 @@ describe("GcodeOptionsDialog", () => {
       customStartGcode: "",
       customEndGcode: "",
       exportPerGroup: false,
+      clipMode: "none",
+      clipOffsetMM: 0,
     });
   });
 });

--- a/tests/component/Toolbar.test.tsx
+++ b/tests/component/Toolbar.test.tsx
@@ -142,7 +142,7 @@ describe("Toolbar", () => {
     const cfg = createMachineConfig({ name: "My Plotter" });
     useMachineStore.setState({ configs: [cfg], connected: true });
     render(<Toolbar />);
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox", { name: "Machine selector" });
     expect(select).toBeDisabled();
   });
 
@@ -298,7 +298,7 @@ describe("Toolbar", () => {
     const c2 = createMachineConfig({ name: "Beta" });
     useMachineStore.setState({ configs: [c1, c2], activeConfigId: c1.id });
     render(<Toolbar />);
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox", { name: "Machine selector" });
     await userEvent.selectOptions(select, c2.id);
     expect(useMachineStore.getState().activeConfigId).toBe(c2.id);
   });
@@ -317,7 +317,7 @@ describe("Toolbar", () => {
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
       expect(
-        screen.getByRole("heading", { name: "Options" }),
+        screen.getByRole("heading", { name: "Generate G-code" }),
       ).toBeInTheDocument();
     });
 
@@ -326,6 +326,7 @@ describe("Toolbar", () => {
       useCanvasStore.setState({ imports: [imp] });
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       expect(screen.getByText("Optimise paths")).toBeInTheDocument();
       expect(screen.getByText("Upload to SD card")).toBeInTheDocument();
       expect(screen.getByText("Save to computer")).toBeInTheDocument();
@@ -336,6 +337,7 @@ describe("Toolbar", () => {
       useCanvasStore.setState({ imports: [imp] });
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       expect(
         screen.getByRole("checkbox", { name: "Optimise paths" }),
       ).toBeChecked();
@@ -356,11 +358,11 @@ describe("Toolbar", () => {
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
       expect(
-        screen.getByRole("heading", { name: "Options" }),
+        screen.getByRole("heading", { name: "Generate G-code" }),
       ).toBeInTheDocument();
       await userEvent.click(screen.getByText("Cancel"));
       expect(
-        screen.queryByRole("heading", { name: "Options" }),
+        screen.queryByRole("heading", { name: "Generate G-code" }),
       ).not.toBeInTheDocument();
       // No gcode-generate task should have been created
       const tasks = Object.values(useTaskStore.getState().tasks);
@@ -407,7 +409,7 @@ describe("Toolbar", () => {
 
       // Dialog closes after confirm
       expect(
-        screen.queryByRole("heading", { name: "Options" }),
+        screen.queryByRole("heading", { name: "Generate G-code" }),
       ).not.toBeInTheDocument();
 
       // A gcode-generate task should be registered in the store
@@ -477,6 +479,7 @@ describe("Toolbar", () => {
 
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Optimise paths" }),
       );
@@ -527,6 +530,7 @@ describe("Toolbar", () => {
       useCanvasStore.setState({ imports: [imp] });
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       expect(screen.getByText("Join nearby paths")).toBeInTheDocument();
       expect(screen.getByText("Experimental")).toBeInTheDocument();
     });
@@ -536,6 +540,7 @@ describe("Toolbar", () => {
       useCanvasStore.setState({ imports: [imp] });
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       // Tolerance input is always rendered
       expect(screen.getByText("Tolerance")).toBeInTheDocument();
       // The number input should be disabled while join is off
@@ -548,6 +553,7 @@ describe("Toolbar", () => {
       useCanvasStore.setState({ imports: [imp] });
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Join nearby paths" }),
       );
@@ -579,6 +585,7 @@ describe("Toolbar", () => {
 
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Join nearby paths" }),
       );
@@ -648,6 +655,7 @@ describe("Toolbar", () => {
 
       render(<Toolbar />);
       await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: /^paths$/i }));
       await userEvent.click(
         screen.getByRole("checkbox", { name: "Join nearby paths" }),
       );

--- a/tests/e2e/gcode-generation.spec.ts
+++ b/tests/e2e/gcode-generation.spec.ts
@@ -122,16 +122,22 @@ test("clicking Generate G-code opens the options dialog", async () => {
   const btn = window.locator("button:has-text('Generate G-code')");
   await btn.click();
 
-  // Dialog should show the Optimise paths checkbox
+  // Dialog should be open — verify by the dialog heading
+  await expect(window.locator("h2:has-text('Generate G-code')")).toBeVisible({
+    timeout: 3_000,
+  });
+
+  // Expand the Paths section and confirm Optimise paths is present
+  await window.locator("button:has-text('Paths')").click();
   await expect(window.locator("text=Optimise paths")).toBeVisible({
     timeout: 3_000,
   });
 
   // Cancel to close without generating
   await window.locator("button:has-text('Cancel')").click();
-  await expect(window.locator("text=Optimise paths")).not.toBeVisible({
-    timeout: 3_000,
-  });
+  await expect(
+    window.locator("h2:has-text('Generate G-code')"),
+  ).not.toBeVisible({ timeout: 3_000 });
 });
 
 test("generating with Optimise paths checked produces optimised G-code", async () => {
@@ -143,6 +149,9 @@ test("generating with Optimise paths checked produces optimised G-code", async (
   // Wait for the options dialog to appear
   const cancelBtn = window.locator("button:has-text('Cancel')");
   await expect(cancelBtn).toBeVisible({ timeout: 5_000 });
+
+  // Expand the Paths section so the checkbox is accessible
+  await window.locator("button:has-text('Paths')").click();
 
   // Ensure Optimise paths is checked
   const optimiseCheckbox = window.locator(

--- a/tests/e2e/gcode-preview.spec.ts
+++ b/tests/e2e/gcode-preview.spec.ts
@@ -110,7 +110,9 @@ test.beforeAll(async () => {
 
   // ── Connect to the mocked machine ─────────────────────────────────────────
   // Select the test machine in the toolbar dropdown.
-  await window.locator("select").selectOption({ label: TEST_CONFIG.name });
+  await window
+    .locator("select[aria-label='Machine selector']")
+    .selectOption({ label: TEST_CONFIG.name });
 
   // Click Connect — the mocked handler resolves immediately.
   await window.locator("button:has-text('Connect')").click();

--- a/tests/e2e/launch.spec.ts
+++ b/tests/e2e/launch.spec.ts
@@ -48,7 +48,7 @@ test("toolbar renders with brand name", async () => {
 });
 
 test("machine selector dropdown is present and visible", async () => {
-  const select = window.locator("select").first();
+  const select = window.locator("select[aria-label='Machine selector']");
   await expect(select).toBeVisible();
 });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -189,6 +189,8 @@ if (typeof window !== "undefined") {
       deleteMachineConfig: vi.fn().mockResolvedValue(undefined),
       exportConfigs: vi.fn().mockResolvedValue(null),
       importConfigs: vi.fn().mockResolvedValue({ added: 0, skipped: 0 }),
+      loadPageSizes: vi.fn().mockResolvedValue([]),
+      openPageSizesFile: vi.fn().mockResolvedValue(undefined),
     },
     app: {
       getVersion: vi.fn().mockResolvedValue("1.0.0"),


### PR DESCRIPTION
This pull request introduces a new "Page Template" feature that allows users to display a customizable page-size overlay on the canvas, helping guide layout and design for specific paper sizes. Users can select from built-in or custom page sizes, toggle between portrait and landscape, and adjust margins. Custom page sizes can be edited via a JSON file, with changes persisted between sessions. The implementation touches the main process, preload, renderer components, and shared types.

<img width="1782" height="1021" alt="image" src="https://github.com/user-attachments/assets/dba5f1c7-a065-46e3-a305-13cb8676a154" />

Key changes include:

**Page Template Feature Implementation:**

- Added `PageTemplate` and `PageSize` types, along with a `BUILT_IN_PAGE_SIZES` constant, to `src/types/index.ts` for representing paper sizes and the active overlay state.
- Enhanced the `PlotCanvas` component to render a non-interactive, configurable page template overlay on the canvas, including orientation and margin visualizations. [[1]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR75-R76) [[2]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR1571-R1646)

**Toolbar Integration and UI Controls:**

- Updated the `Toolbar` component to provide UI controls for selecting page size, toggling orientation, setting margin, and opening the custom page sizes JSON file in the user's editor. The toolbar now also loads available page sizes from the main process on mount and persists the selected page template in layout files. [[1]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R14) [[2]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R312-R315) [[3]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R1376-R1487) [[4]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64L776-R783) [[5]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R725) [[6]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64L1442-R1578) [[7]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R955-R967) [[8]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64R3)

**State Management Enhancements:**

- Extended the `canvasStore` to manage the `pageTemplate` and `pageSizes` state, including new setters and updates to the `loadLayout` method to support restoring page template state from saved layouts. [[1]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R9-R11) [[2]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L83-R90) [[3]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R130-R137) [[4]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R201-R202) [[5]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43L321-R338) [[6]](diffhunk://#diff-3bf41b9fdfa47f3a86c18e57921d793219906cf559f74060932139cc09c0fb43R352-R365)

**Main Process and IPC Support:**

- Added main process logic in `src/main/index.ts` to handle loading, persisting, and editing custom page sizes via IPC handlers. If the user has not customized page sizes, built-in defaults are used. [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR11) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR337-R372) [[3]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR483-R497)
- Updated the preload script to expose IPC functions for loading and editing page sizes to the renderer process.

These changes collectively enable users to visually plan their work for specific paper sizes, customize available sizes, and ensure consistent page layout across sessions and shared layouts.