### PR TITLE
Change light mode red toolbar buttons text colour from black to white

### DIFF
--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1350,7 +1350,7 @@ export function Toolbar({
         <button
           onClick={handleConnect}
           disabled={!activeConfigId || isConnecting}
-          className="px-3 py-1 rounded text-sm bg-accent hover:bg-accent-hover disabled:opacity-40 transition-colors flex items-center gap-1.5"
+          className="px-3 py-1 rounded text-sm bg-accent hover:bg-accent-hover disabled:opacity-40 transition-colors text-white flex items-center gap-1.5"
         >
           {isConnecting ? (
             <>
@@ -1397,7 +1397,7 @@ export function Toolbar({
       <button
         onClick={() => setShowGcodeDialog(true)}
         disabled={generating || imports.length === 0}
-        className="px-3 py-1 rounded text-sm bg-accent hover:bg-accent-hover disabled:opacity-40 transition-colors"
+        className="px-3 py-1 rounded text-sm bg-accent hover:bg-accent-hover disabled:opacity-40 transition-colors text-white"
         title="Choose generation options then generate G-code"
       >
         {generating ? "Generating…" : "Generate G-code"}
@@ -1543,7 +1543,7 @@ export function Toolbar({
       {/* Jog toggle */}
       <button
         onClick={onToggleJog}
-        className={`px-3 py-1 rounded text-sm transition-colors ${showJog ? "bg-accent" : "bg-secondary hover:bg-secondary-hover"}`}
+        className={`px-3 py-1 rounded text-sm transition-colors ${showJog ? "bg-accent text-white" : "bg-secondary hover:bg-secondary-hover text-content"}`}
       >
         Jog
       </button>


### PR DESCRIPTION
This pull request makes small visual improvements to the `Toolbar` component by ensuring button text is more consistently styled for readability and contrast.

<img width="893" height="115" alt="image" src="https://github.com/user-attachments/assets/f83d7686-9528-4966-aecc-95e8ab2ec400" />

- UI consistency and accessibility:
  * Added the `text-white` class to primary accent buttons to ensure button text appears white, improving readability against the accent background. (`src/renderer/src/components/Toolbar.tsx`) [[1]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64L1353-R1353) [[2]](diffhunk://#diff-7e3228694f93150a45e354e5b6880747f722afcf41c42d39e6a9abcac6629e64L1400-R1400)
  * Updated the jog toggle button to use `text-white` when active and `text-content` when inactive, for better visual feedback and consistency. (`src/renderer/src/components/Toolbar.tsx`)