### PR TITLE
Update e2e tests

### DIFF
--- a/tests/e2e/connected-file-browser.spec.ts
+++ b/tests/e2e/connected-file-browser.spec.ts
@@ -1,0 +1,368 @@
+/**
+ * E2E: File browser — connected machine state.
+ *
+ * Uses IPC mocking to simulate a connected FluidNC machine with an SD card
+ * populated by test data.  Tests verify file listing, directory navigation,
+ * file selection, upload flow, delete confirmation, refresh, and the
+ * download action.
+ *
+ * The same pattern as gcode-preview.spec.ts is used for connecting: mock
+ * the relevant IPC handlers, reload the renderer, select the machine, and
+ * click Connect.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  fixturePath,
+  mockOpenDialog,
+  mockIpcInvoke,
+  pushRendererEvent,
+} from "./helpers";
+import type { ElectronApplication, Page } from "playwright";
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userDataDir: string;
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────────
+
+const TEST_CONFIG = {
+  id: "e2e-fb",
+  name: "E2E File Browser Machine",
+  connection: {
+    type: "wifi" as const,
+    host: "127.0.0.1",
+    port: 80,
+    wsPort: 81,
+  },
+  bedWidth: 300,
+  bedHeight: 300,
+  penUpCommand: "M3 S0",
+  penDownCommand: "M3 S1",
+  penType: "solenoid" as const,
+  maxSpeed: 3000,
+  travelSpeed: 3000,
+};
+
+const ROOT_FILES = [
+  { name: "plot.gcode", path: "/plot.gcode", size: 2048, isDirectory: false },
+  {
+    name: "sketch.gcode",
+    path: "/sketch.gcode",
+    size: 512,
+    isDirectory: false,
+  },
+  { name: "subdir", path: "/subdir", size: 0, isDirectory: true },
+];
+
+const SUBDIR_FILES = [
+  {
+    name: "nested.gcode",
+    path: "/subdir/nested.gcode",
+    size: 256,
+    isDirectory: false,
+  },
+];
+
+const REMOTE_GCODE =
+  "G21\nG90\nG0 Z5\nM3 S0\nG0 X0 Y0\nG1 X50 Y50 F1000\nM3 S0\nG0 X0 Y0\nM2\n";
+
+// ─── Setup ─────────────────────────────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp());
+
+  // Machine config and connection mocks.
+  await mockIpcInvoke(electronApp, "config:getMachineConfigs", [TEST_CONFIG]);
+  await mockIpcInvoke(electronApp, "fluidnc:connectWebSocket", undefined);
+
+  // SD card listing — root returns ROOT_FILES; sub-path returns SUBDIR_FILES.
+  await electronApp.evaluate(
+    ({ ipcMain }, { root, subdir }) => {
+      ipcMain.removeHandler("fluidnc:listSDFiles");
+      ipcMain.handle(
+        "fluidnc:listSDFiles",
+        (_e: Electron.IpcMainInvokeEvent, dirPath: string) =>
+          dirPath === "/subdir" ? subdir : root,
+      );
+      ipcMain.removeHandler("fluidnc:listFiles");
+      ipcMain.handle("fluidnc:listFiles", async () => []);
+    },
+    { root: ROOT_FILES, subdir: SUBDIR_FILES },
+  );
+
+  // Immediate resolve for operations we will trigger in tests.
+  await mockIpcInvoke(electronApp, "fluidnc:deleteFile", undefined);
+  await mockIpcInvoke(electronApp, "fluidnc:runFile", undefined);
+  await mockIpcInvoke(electronApp, "fluidnc:uploadFile", undefined);
+  await mockIpcInvoke(electronApp, "fluidnc:fetchFileText", REMOTE_GCODE);
+
+  // Reload so the renderer picks up the mocked configs.
+  await window.reload();
+  await window.waitForLoadState("domcontentloaded");
+  await window
+    .locator("select[aria-label='Machine selector']")
+    .first()
+    .waitFor({ timeout: 15_000 });
+
+  // Select the machine and connect.
+  await window
+    .locator("select[aria-label='Machine selector']")
+    .selectOption({ label: TEST_CONFIG.name });
+  await window.locator("button:has-text('Connect')").click();
+  await expect(window.locator("text=Connected").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Wait for file listing to populate.
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test.afterAll(async () => {
+  if (electronApp) await closeApp(electronApp, userDataDir);
+});
+
+// ─── Group 1: File listing ────────────────────────────────────────────────────
+
+test("file browser shows gcode files after connecting", async () => {
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible();
+  await expect(window.locator("text=sketch.gcode").first()).toBeVisible();
+});
+
+test("file browser shows directories with a folder icon", async () => {
+  const subdirRow = window.locator("[data-testid='file-row-subdir']");
+  await expect(subdirRow).toBeVisible();
+  await expect(subdirRow.locator("text=📁")).toBeVisible();
+});
+
+test("file browser shows file size labels for gcode files", async () => {
+  // plot.gcode is 2048 bytes → should display "2K"
+  const plotRow = window.locator("[data-testid='file-row-plot.gcode']");
+  await expect(plotRow.locator("text=/\\d+[KMB]/")).toBeVisible({
+    timeout: 3000,
+  });
+});
+
+// ─── Group 2: File selection ──────────────────────────────────────────────────
+
+test("clicking a gcode file selects it and highlights the row", async () => {
+  const plotRow = window.locator("[data-testid='file-row-plot.gcode']");
+  await plotRow.click();
+
+  // Selection applies bg-[var(--tf-file-selected)] class
+  await expect(plotRow).toHaveClass(/tf-file-selected/, { timeout: 3000 });
+});
+
+test("selected gcode file name appears in the Job Controls panel", async () => {
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible();
+});
+
+test("clicking a selected file again deselects it", async () => {
+  const plotRow = window.locator("[data-testid='file-row-plot.gcode']");
+  // It should already be selected from the previous test.
+  await plotRow.click();
+
+  await expect(plotRow).not.toHaveClass(/tf-file-selected/, { timeout: 3000 });
+});
+
+// ─── Group 3: Directory navigation ───────────────────────────────────────────
+
+test("clicking a directory navigates into it and shows its contents", async () => {
+  const subdirRow = window.locator("[data-testid='file-row-subdir']");
+  await subdirRow.click();
+
+  await expect(window.locator("text=nested.gcode").first()).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test("breadcrumb shows the current subdirectory segment", async () => {
+  // Breadcrumb renders path segments as clickable buttons.
+  await expect(
+    window.locator("button:has-text('subdir')").first(),
+  ).toBeVisible();
+});
+
+test("clicking the root '/' breadcrumb navigates back to root", async () => {
+  // The Breadcrumb component renders a "/" root button.
+  await window.locator("button:has-text('/')").first().click();
+
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Subdir content should no longer be visible.
+  await expect(window.locator("text=nested.gcode")).not.toBeVisible({
+    timeout: 3000,
+  });
+});
+
+test("the '↑ Up' button navigates to the parent directory", async () => {
+  // Navigate into subdir first.
+  await window.locator("[data-testid='file-row-subdir']").click();
+  await expect(window.locator("text=nested.gcode").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Click the Up (↑) button in the breadcrumb bar.
+  await window.locator("button[title='Up']").first().click();
+
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+// ─── Group 4: Refresh ─────────────────────────────────────────────────────────
+
+test("Refresh button (↻) is enabled when connected", async () => {
+  const refreshBtn = window.locator("button[aria-label='Refresh']").first();
+  await expect(refreshBtn).toBeEnabled({ timeout: 3000 });
+});
+
+test("clicking Refresh re-fetches the file listing", async () => {
+  const refreshBtn = window.locator("button[aria-label='Refresh']").first();
+  await refreshBtn.click();
+
+  // Files should still be visible after refresh.
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+// ─── Group 5: Upload ────────────────────────────────────────────────────────
+
+test("Upload footer button is visible and enabled when connected", async () => {
+  // Upload button text includes "↑ Upload to"
+  const uploadBtn = window.locator("button:has-text('↑ Upload to')").first();
+  await expect(uploadBtn).toBeEnabled({ timeout: 3000 });
+});
+
+test("clicking Upload triggers a file open dialog", async () => {
+  // Mock the dialog to return sample.gcode.
+  await mockOpenDialog(electronApp, fixturePath("sample.gcode"));
+
+  const uploadBtn = window.locator("button:has-text('↑ Upload to')").first();
+  await uploadBtn.click();
+
+  // The mocked uploadFile IPC should be called.
+  // We can verify the task bar shows an upload task label.
+  await expect(window.locator("text=/Upload|upload/").first()).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+// ─── Group 6: Delete ────────────────────────────────────────────────────────
+
+test("hovering a file row reveals the Delete action button", async () => {
+  const plotRow = window.locator("[data-testid='file-row-plot.gcode']");
+  await plotRow.hover();
+
+  const deleteBtn = window.locator(
+    "[data-testid='file-actions-plot.gcode'] button[title='Delete']",
+  );
+  await expect(deleteBtn).toBeVisible({ timeout: 3000 });
+});
+
+test("clicking Delete shows a ConfirmDialog with the file name", async () => {
+  const plotRow = window.locator("[data-testid='file-row-plot.gcode']");
+  await plotRow.hover();
+
+  const deleteBtn = window.locator(
+    "[data-testid='file-actions-plot.gcode'] button[title='Delete']",
+  );
+  await deleteBtn.click();
+
+  const dialog = window.locator("[role='dialog']");
+  await expect(dialog).toBeVisible({ timeout: 3000 });
+  await expect(dialog.locator("text=plot.gcode")).toBeVisible();
+});
+
+test("cancelling Delete dialog keeps the file in the list", async () => {
+  const cancelBtn = window.locator("[role='dialog'] button:has-text('Cancel')");
+  await cancelBtn.click();
+
+  await expect(window.locator("text=plot.gcode").first()).toBeVisible({
+    timeout: 3000,
+  });
+});
+
+test("confirming Delete calls deleteFile IPC and removes the file row", async () => {
+  // Trigger delete again.
+  const plotRow = window.locator("[data-testid='file-row-plot.gcode']");
+  await plotRow.hover();
+
+  const deleteBtn = window.locator(
+    "[data-testid='file-actions-plot.gcode'] button[title='Delete']",
+  );
+  await deleteBtn.click();
+
+  const confirmBtn = window.locator(
+    "[role='dialog'] button:has-text('Delete')",
+  );
+  await expect(confirmBtn).toBeVisible({ timeout: 3000 });
+  await confirmBtn.click();
+
+  // After confirming, the dialog should close.
+  await expect(window.locator("[role='dialog']")).not.toBeVisible({
+    timeout: 3000,
+  });
+});
+
+// ─── Group 7: Preview toolpath ────────────────────────────────────────────────
+
+test("Preview toolpath button is visible on hover for a gcode file", async () => {
+  const sketchRow = window.locator("[data-testid='file-row-sketch.gcode']");
+  await sketchRow.hover();
+
+  const previewBtn = window.locator(
+    "[data-testid='file-actions-sketch.gcode'] button[title='Preview toolpath']",
+  );
+  await expect(previewBtn).toBeVisible({ timeout: 3000 });
+});
+
+test("clicking Preview fetches the file text and loads the canvas toolpath", async () => {
+  const sketchRow = window.locator("[data-testid='file-row-sketch.gcode']");
+  await sketchRow.hover();
+
+  const previewBtn = window.locator(
+    "[data-testid='file-actions-sketch.gcode'] button[title='Preview toolpath']",
+  );
+  await previewBtn.click();
+
+  // If a toolpath was already loaded a confirm dialog may appear; accept it.
+  const replaceBtn = window.locator(
+    "[role='dialog'] button:has-text('Replace')",
+  );
+  if (await replaceBtn.isVisible({ timeout: 1500 })) {
+    await replaceBtn.click();
+  }
+
+  // The canvas SVG should update (toolpath rendered as paths).
+  const canvas = window.locator("svg").first();
+  await expect(canvas).toBeVisible({ timeout: 10_000 });
+});
+
+// ─── Group 8: Run file ────────────────────────────────────────────────────────
+
+test("'Run job now' button is visible for a gcode file when not running", async () => {
+  // Make sure the machine is idle first.
+  await pushRendererEvent(electronApp, "fluidnc:status", {
+    state: "Idle",
+    mpos: { x: 0, y: 0, z: 0 },
+  });
+  await window.waitForTimeout(300);
+
+  const sketchRow = window.locator("[data-testid='file-row-sketch.gcode']");
+
+  // Click to select the file (so it is the active job).
+  await sketchRow.click();
+  await sketchRow.hover();
+
+  const runBtn = window.locator(
+    "[data-testid='file-actions-sketch.gcode'] button[title='Run job now']",
+  );
+  await expect(runBtn).toBeVisible({ timeout: 3000 });
+});

--- a/tests/e2e/gcode-preview.spec.ts
+++ b/tests/e2e/gcode-preview.spec.ts
@@ -368,3 +368,75 @@ test("file browser: pause ⏸ reverts to play ▶ when the job ends (Idle)", asy
   );
   await expect(pauseBtn).not.toBeVisible({ timeout: 5_000 });
 });
+
+// ── Group 6: Job abort ────────────────────────────────────────────────────────
+//
+// Simulate a running job via a status push, then exercise the Abort button
+// and its ConfirmDialog, verifying that the IPC call is made and the UI
+// reverts to idle state on confirmation.
+
+test("Abort button is visible while a job is running", async () => {
+  await pushRendererEvent(electronApp, "fluidnc:status", {
+    state: "Run",
+    mpos: { x: 0, y: 0, z: 0 },
+  });
+  await window.waitForTimeout(200);
+
+  const abortBtn = window.locator("button:has-text('✕ Abort')");
+  await expect(abortBtn).toBeVisible({ timeout: 3_000 });
+});
+
+test("clicking Abort shows a confirmation dialog", async () => {
+  const abortBtn = window.locator("button:has-text('✕ Abort')");
+  await expect(abortBtn).toBeVisible({ timeout: 3_000 });
+  await abortBtn.click();
+
+  const confirmBtn = window.locator("[role='dialog'] button:has-text('Abort')");
+  await expect(confirmBtn).toBeVisible({ timeout: 3_000 });
+});
+
+test("confirming Abort calls abortJob and machine returns to Idle", async () => {
+  await mockIpcInvoke(electronApp, "fluidnc:abortJob", undefined);
+
+  const confirmBtn = window.locator("[role='dialog'] button:has-text('Abort')");
+  await confirmBtn.click();
+
+  // Simulate the machine transitioning back to Idle after abort.
+  await pushRendererEvent(electronApp, "fluidnc:status", {
+    state: "Idle",
+    mpos: { x: 0, y: 0, z: 0 },
+  });
+  await window.waitForTimeout(300);
+
+  // Abort button should be gone; Start job button should be visible.
+  await expect(window.locator("button:has-text('✕ Abort')")).not.toBeVisible({
+    timeout: 3_000,
+  });
+
+  await expect(window.locator("button:has-text('▶ Start job')")).toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+test("cancelling the Abort dialog keeps the job running", async () => {
+  // Re-enter Run state.
+  await pushRendererEvent(electronApp, "fluidnc:status", {
+    state: "Run",
+    mpos: { x: 5, y: 5, z: 0 },
+  });
+  await window.waitForTimeout(200);
+
+  const abortBtn = window.locator("button:has-text('✕ Abort')");
+  await expect(abortBtn).toBeVisible({ timeout: 3_000 });
+  await abortBtn.click();
+
+  const cancelBtn = window.locator("[role='dialog'] button:has-text('Cancel')");
+  await expect(cancelBtn).toBeVisible({ timeout: 3_000 });
+  await cancelBtn.click();
+
+  // Dialog dismissed — abort button should still be showing (job still running).
+  await expect(abortBtn).toBeVisible({ timeout: 3_000 });
+  await expect(window.locator("[role='dialog']")).not.toBeVisible({
+    timeout: 2_000,
+  });
+});

--- a/tests/e2e/jog-controls.spec.ts
+++ b/tests/e2e/jog-controls.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * E2E: Jog controls — button visibility and command dispatch.
+ *
+ * The JogControls panel is shown by default (showJog starts true in App.tsx).
+ * Tests verify that each directional button, pen command, positioning shortcut,
+ * step-size selector, and feedrate input emit the expected G-code string via
+ * the fluidnc:sendCommand IPC channel.
+ *
+ * Strategy: override the fluidnc:sendCommand handler in the Electron main
+ * process to push received commands into a global `__jogCmds` array so each
+ * test can read and assert the emitted sequence without real hardware.
+ *
+ * The machine config is mocked so that `activeConfig` in JogControls returns
+ * a solenoid machine with penUpCommand "M3 S0" and penDownCommand "M3 S1",
+ * which is required for pen-up / pen-down assertions.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  mockIpcInvoke,
+  pushRendererEvent,
+} from "./helpers";
+import type { ElectronApplication, Page } from "playwright";
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userDataDir: string;
+
+const TEST_CONFIG = {
+  id: "e2e-jog",
+  name: "E2E Jog Machine",
+  connection: {
+    type: "wifi" as const,
+    host: "127.0.0.1",
+    port: 80,
+    wsPort: 81,
+  },
+  bedWidth: 300,
+  bedHeight: 300,
+  penUpCommand: "M3 S0",
+  penDownCommand: "M3 S1",
+  penType: "solenoid" as const,
+  maxSpeed: 3000,
+  travelSpeed: 3000,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Install the tracking sendCommand handler in the main process. */
+async function installCommandTracker(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ ipcMain }) => {
+    (global as any).__jogCmds = [];
+    ipcMain.removeHandler("fluidnc:sendCommand");
+    ipcMain.handle(
+      "fluidnc:sendCommand",
+      (_e: Electron.IpcMainInvokeEvent, cmd: string) => {
+        (global as any).__jogCmds.push(cmd);
+      },
+    );
+  });
+}
+
+async function getTrackedCommands(app: ElectronApplication): Promise<string[]> {
+  return app.evaluate(() => (global as any).__jogCmds as string[]);
+}
+
+async function clearTrackedCommands(app: ElectronApplication): Promise<void> {
+  await app.evaluate(() => {
+    (global as any).__jogCmds = [];
+  });
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp());
+
+  // Provide the test machine config so the toolbar dropdown + activeConfig work.
+  await mockIpcInvoke(electronApp, "config:getMachineConfigs", [TEST_CONFIG]);
+  await mockIpcInvoke(electronApp, "fluidnc:connectWebSocket", undefined);
+
+  // Reload so the app picks up the mocked configs.
+  await window.reload();
+  await window.waitForLoadState("domcontentloaded");
+  await window
+    .locator("select[aria-label='Machine selector']")
+    .first()
+    .waitFor({ timeout: 15_000 });
+
+  // Select and connect so activeConfig is populated.
+  await window
+    .locator("select[aria-label='Machine selector']")
+    .selectOption({ label: TEST_CONFIG.name });
+  await window.locator("button:has-text('Connect')").click();
+  await expect(window.locator("text=Connected").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Install the command tracker on top of the real handler.
+  await installCommandTracker(electronApp);
+});
+
+test.afterAll(async () => {
+  if (electronApp) await closeApp(electronApp, userDataDir);
+});
+
+test.beforeEach(async () => {
+  // Fresh command log before each test.
+  await clearTrackedCommands(electronApp);
+});
+
+// ─── Panel visibility ─────────────────────────────────────────────────────────
+
+test("Jog Controls panel is visible by default", async () => {
+  await expect(window.locator("text=Jog Controls")).toBeVisible();
+});
+
+test("step size buttons 0.1 / 1 / 10 / 100 are all visible", async () => {
+  // Use exact-text filter: has-text is a substring match so '1' would also match '0.1', '10', '100'.
+  await expect(
+    window
+      .locator("button")
+      .filter({ hasText: /^0\.1$/ })
+      .first(),
+  ).toBeVisible();
+  await expect(
+    window.locator("button").filter({ hasText: /^1$/ }).first(),
+  ).toBeVisible();
+  await expect(
+    window.locator("button").filter({ hasText: /^10$/ }).first(),
+  ).toBeVisible();
+  await expect(
+    window.locator("button").filter({ hasText: /^100$/ }).first(),
+  ).toBeVisible();
+});
+
+// ─── Step selector ────────────────────────────────────────────────────────────
+
+test("clicking step '10' makes it the active step", async () => {
+  const btn = window.locator("button").filter({ hasText: /^10$/ }).first();
+  await btn.click();
+  // Active step gets bg-accent class (see JogControls.tsx step selector)
+  await expect(btn).toHaveClass(/bg-accent/, { timeout: 2000 });
+});
+
+test("clicking step '1' restores it as the active step", async () => {
+  const btn10 = window.locator("button").filter({ hasText: /^10$/ }).first();
+  const btn1 = window.locator("button").filter({ hasText: /^1$/ }).first();
+  // Make sure step=10 is selected first
+  await btn10.click();
+  await expect(btn10).toHaveClass(/bg-accent/, { timeout: 2000 });
+
+  // Switch back to 1
+  await btn1.click();
+  await expect(btn1).toHaveClass(/bg-accent/, { timeout: 2000 });
+  await expect(btn10).not.toHaveClass(/bg-accent/, { timeout: 2000 });
+});
+
+// ─── Directional jog (step = 1, feedrate = 3000) ─────────────────────────────
+// Step=1 is active after the previous tests reset it.
+
+test("Jog Y+ sends '$J=G91 G21 Y1.000 F3000'", async () => {
+  // Ensure step=1 — use exact match so '1' doesn't match '0.1', '10', '100'
+  await window.locator("button").filter({ hasText: /^1$/ }).first().click();
+
+  await window.locator('[aria-label="Jog Y+"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("$J=G91 G21 Y1.000 F3000");
+});
+
+test("Jog Y- sends '$J=G91 G21 Y-1.000 F3000'", async () => {
+  await window.locator('[aria-label="Jog Y-"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("$J=G91 G21 Y-1.000 F3000");
+});
+
+test("Jog X+ sends '$J=G91 G21 X1.000 F3000'", async () => {
+  await window.locator('[aria-label="Jog X+"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("$J=G91 G21 X1.000 F3000");
+});
+
+test("Jog X- sends '$J=G91 G21 X-1.000 F3000'", async () => {
+  await window.locator('[aria-label="Jog X-"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("$J=G91 G21 X-1.000 F3000");
+});
+
+// ─── Step size affects jog distance ──────────────────────────────────────────
+
+test("step '10' changes jog distance: X+ sends X10.000", async () => {
+  await window.locator("button").filter({ hasText: /^10$/ }).first().click();
+  await clearTrackedCommands(electronApp);
+
+  await window.locator('[aria-label="Jog X+"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds.some((c) => c.includes("X10.000"))).toBe(true);
+});
+
+test("step '0.1' changes jog distance: Y- sends Y-0.100", async () => {
+  await window
+    .locator("button")
+    .filter({ hasText: /^0\.1$/ })
+    .first()
+    .click();
+  await clearTrackedCommands(electronApp);
+
+  await window.locator('[aria-label="Jog Y-"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds.some((c) => c.includes("Y-0.100"))).toBe(true);
+
+  // Restore step=1 for subsequent tests
+  await window.locator("button").filter({ hasText: /^1$/ }).first().click();
+});
+
+// ─── Feedrate input ───────────────────────────────────────────────────────────
+
+test("changing feedrate to 1500 is used in the next jog command", async () => {
+  const feedrateInput = window.locator("input[type='number']").last(); // Feedrate is the last number input in JogControls
+  await feedrateInput.click({ clickCount: 3 });
+  await feedrateInput.fill("1500");
+  await feedrateInput.press("Tab");
+
+  await clearTrackedCommands(electronApp);
+  await window.locator('[aria-label="Jog Y+"]').click();
+
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds.some((c) => c.includes("F1500"))).toBe(true);
+
+  // Restore feedrate for subsequent tests
+  await feedrateInput.click({ clickCount: 3 });
+  await feedrateInput.fill("3000");
+  await feedrateInput.press("Tab");
+});
+
+// ─── Positioning shortcuts ────────────────────────────────────────────────────
+
+test("'Go to origin' button sends 'G0 X0 Y0'", async () => {
+  await window.locator('[aria-label="Go to origin"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("G0 X0 Y0");
+});
+
+test("'Run Homing' button sends '$H'", async () => {
+  await window.locator("button:has-text('Run Homing')").click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("$H");
+});
+
+test("'Set Zero' button sends 'G10 L20 P1 X0 Y0'", async () => {
+  await window.locator("button:has-text('Set Zero')").click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("G10 L20 P1 X0 Y0");
+});
+
+// ─── Pen commands (solenoid) ──────────────────────────────────────────────────
+
+test("Pen down button sends the configured penDownCommand (M3 S1)", async () => {
+  const btn = window.locator('[aria-label="Pen down"]');
+  await expect(btn).toBeEnabled({ timeout: 3000 }); // enabled when penDown is configured
+  await btn.click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("M3 S1");
+});
+
+test("Pen up button sends the configured penUpCommand (M3 S0)", async () => {
+  const btn = window.locator('[aria-label="Pen up"]');
+  await expect(btn).toBeEnabled({ timeout: 3000 });
+  await btn.click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("M3 S0");
+});
+
+test("'Zero Z' button sends 'G10 L20 P1 Z0'", async () => {
+  await window.locator('[aria-label="Zero Z"]').click();
+  const cmds = await getTrackedCommands(electronApp);
+  expect(cmds).toContain("G10 L20 P1 Z0");
+});
+
+// ─── Close button ─────────────────────────────────────────────────────────────
+
+test("closing Jog Controls via ✕ hides the panel", async () => {
+  // The close button has a small ✕ inside the panel header.
+  await window
+    .locator("div:has(> span:text('Jog Controls')) button:has-text('✕')")
+    .click();
+  await expect(window.locator("text=Jog Controls")).not.toBeVisible({
+    timeout: 3000,
+  });
+});
+
+test("clicking the 'Jog' toolbar button shows the panel again", async () => {
+  await window.locator("button:has-text('Jog')").click();
+  await expect(window.locator("text=Jog Controls")).toBeVisible({
+    timeout: 3000,
+  });
+});

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * E2E: Layout save / open / close workflows.
+ *
+ * Exercises the three layout operations that are triggered by the native
+ * application menu (File → Save Layout / Open Layout / Close Layout).
+ *
+ * The menu items fire IPC events ("menu:saveLayout", "menu:openLayout",
+ * "menu:closeLayout") which the Toolbar component subscribes to.  In tests
+ * we push those events directly from the main process using pushRendererEvent,
+ * avoiding the need to navigate the native OS menu.
+ *
+ * File dialogs (fs:saveLayoutDialog, fs:openLayoutDialog) are mocked so that
+ * tests control the target / source path; actual file I/O (fs:writeFile,
+ * fs:readFile) uses the real implementation against a temp file so we can
+ * inspect the written JSON without needing extra mocks.
+ */
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import {
+  launchApp,
+  closeApp,
+  fixturePath,
+  mockOpenDialog,
+  mockIpcInvoke,
+  pushRendererEvent,
+} from "./helpers";
+import type { ElectronApplication, Page } from "playwright";
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userDataDir: string;
+
+/** Temp file path used as the layout save target across tests. */
+let layoutTempPath: string;
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp());
+
+  // Create a temp path for save/load tests.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tf-layout-e2e-"));
+  layoutTempPath = path.join(tmpDir, "test-layout.tforge");
+
+  // Import sample.svg — layouts must have at least one import, otherwise
+  // saveLayout is a no-op.
+  await mockOpenDialog(electronApp, fixturePath("sample.svg"));
+  await window.locator("button:has-text('Import')").click();
+  await expect(window.locator("text=sample").first()).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test.afterAll(async () => {
+  if (electronApp) await closeApp(electronApp, userDataDir);
+  // Clean up the temp layout file if it was created.
+  try {
+    const dir = path.dirname(layoutTempPath);
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fire a menu IPC event directly to the renderer so Toolbar handles it.
+ * This is equivalent to the user selecting the corresponding File menu item.
+ */
+async function triggerMenu(app: ElectronApplication, channel: string) {
+  await pushRendererEvent(app, channel, undefined);
+}
+
+// ─── Group 1: Save layout ─────────────────────────────────────────────────────
+
+test("save layout writes a JSON file at the chosen path", async () => {
+  // Mock the save dialog to return our temp path.
+  await mockIpcInvoke(electronApp, "fs:saveLayoutDialog", layoutTempPath);
+
+  // Trigger the save operation via menu event.
+  await triggerMenu(electronApp, "menu:saveLayout");
+
+  // The TaskBar should show "Layout saved" once the file has been written.
+  await expect(window.locator("text=Layout saved").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // The file must exist on disk.
+  expect(fs.existsSync(layoutTempPath)).toBe(true);
+});
+
+test("saved layout file contains valid JSON with tfVersion 1", async () => {
+  const raw = fs.readFileSync(layoutTempPath, "utf8");
+  const json = JSON.parse(raw);
+  expect(json.tfVersion).toBe(1);
+  expect(Array.isArray(json.imports)).toBe(true);
+});
+
+test("saved layout file includes the imported SVG", async () => {
+  const raw = fs.readFileSync(layoutTempPath, "utf8");
+  const json = JSON.parse(raw);
+  const names: string[] = json.imports.map((i: { name: string }) => i.name);
+  expect(names).toContain("sample");
+});
+
+test("saved layout file contains a valid savedAt timestamp", async () => {
+  const raw = fs.readFileSync(layoutTempPath, "utf8");
+  const json = JSON.parse(raw);
+  expect(typeof json.savedAt).toBe("string");
+  expect(() => new Date(json.savedAt)).not.toThrow();
+});
+
+// ─── Group 2: Open layout ─────────────────────────────────────────────────────
+
+test("opening a layout on an empty canvas loads its imports directly", async () => {
+  // First close (clear) the canvas without prompting — mock the dialog to
+  // avoid the CloseLayoutDialog.  We call clearImports by triggering close
+  // and then confirming via the ConfirmDialog.
+  await triggerMenu(electronApp, "menu:closeLayout");
+
+  // CloseLayoutDialog should appear — click "Exit without Saving" to discard without saving.
+  const discardBtn = window
+    .locator("[role='dialog'] button:has-text('Exit without Saving')")
+    .first();
+  await expect(discardBtn).toBeVisible({ timeout: 5_000 });
+  await discardBtn.click();
+
+  // Canvas should now be empty.
+  await expect(window.locator("text=No objects. Import an SVG.")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Mock open layout dialog to return the previously saved layout file.
+  await mockIpcInvoke(electronApp, "fs:openLayoutDialog", layoutTempPath);
+  await triggerMenu(electronApp, "menu:openLayout");
+
+  // The layout should load and display the "sample" import.
+  await expect(window.locator("text=sample").first()).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("open layout shows 'Layout ready' in the task bar", async () => {
+  // Layout was loaded in the previous test; the task should be completed.
+  await expect(window.locator("text=Layout ready").first()).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test("opening a second layout with existing canvas content shows confirm dialog", async () => {
+  // Canvas already has "sample" from the previous load.
+  // Trigger open again — this time the app should ask before overwriting.
+  await mockIpcInvoke(electronApp, "fs:openLayoutDialog", layoutTempPath);
+  await triggerMenu(electronApp, "menu:openLayout");
+
+  // A ConfirmDialog (or CloseLayoutDialog) must appear.
+  const dialog = window.locator("[role='dialog']");
+  await expect(dialog).toBeVisible({ timeout: 5_000 });
+});
+
+test("cancelling the overwrite dialog keeps the existing canvas content", async () => {
+  // Click the Cancel button in whatever dialog is open.
+  const cancelBtn = window.locator("[role='dialog'] button:has-text('Cancel')");
+  if (await cancelBtn.isVisible({ timeout: 2000 })) {
+    await cancelBtn.click();
+  }
+
+  // "sample" import must still be present.
+  await expect(window.locator("text=sample").first()).toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+// ─── Group 3: Close layout ────────────────────────────────────────────────────
+
+test("triggering close layout shows a confirmation dialog", async () => {
+  await triggerMenu(electronApp, "menu:closeLayout");
+
+  const dialog = window.locator("[role='dialog']");
+  await expect(dialog).toBeVisible({ timeout: 5_000 });
+});
+
+test("cancelling close layout keeps the imports", async () => {
+  const cancelBtn = window.locator("[role='dialog'] button:has-text('Cancel')");
+  await cancelBtn.click();
+
+  await expect(window.locator("text=sample").first()).toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+test("confirming close layout clears all imports", async () => {
+  await triggerMenu(electronApp, "menu:closeLayout");
+
+  // CloseLayoutDialog: click "Exit without Saving" to discard and clear the canvas.
+  const discardBtn = window
+    .locator("[role='dialog'] button:has-text('Exit without Saving')")
+    .first();
+  await expect(discardBtn).toBeVisible({ timeout: 5_000 });
+  await discardBtn.click();
+
+  await expect(window.locator("text=No objects. Import an SVG.")).toBeVisible({
+    timeout: 5_000,
+  });
+});

--- a/tests/e2e/pdf-import.spec.ts
+++ b/tests/e2e/pdf-import.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E: PDF import workflow.
+ *
+ * Tests the full Import PDF flow: click Import button → dialog mocked to return
+ * a fixture → PDF parsed → appears in Properties panel → paths rendered on
+ * canvas → Generate G-code becomes enabled.
+ *
+ * The fixture `sample.pdf` is a single-page PDF containing a stroked rectangle.
+ * pdfjs-dist is used by the renderer to extract operator lists; the Electron
+ * main process reads the binary and passes a Uint8Array over IPC.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  fixturePath,
+  mockOpenDialog,
+  mockCancelDialog,
+} from "./helpers";
+import type { ElectronApplication, Page } from "playwright";
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userDataDir: string;
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp());
+});
+
+test.afterAll(async () => {
+  if (electronApp) await closeApp(electronApp, userDataDir);
+});
+
+// ─── Baseline ────────────────────────────────────────────────────────────────
+
+test("Import button is visible and enabled before any import", async () => {
+  const btn = window.locator("button:has-text('Import')");
+  await expect(btn).toBeVisible();
+  await expect(btn).toBeEnabled();
+});
+
+test("Properties panel shows empty state before import", async () => {
+  const emptyMsg = window.locator("text=No objects. Import an SVG.");
+  await expect(emptyMsg).toBeVisible();
+});
+
+// ─── Cancel dialog — nothing changes ─────────────────────────────────────────
+
+test("cancelling the dialog keeps canvas empty", async () => {
+  await mockCancelDialog(electronApp);
+  await window.locator("button:has-text('Import')").click();
+
+  const emptyMsg = window.locator("text=No objects. Import an SVG.");
+  await expect(emptyMsg).toBeVisible({ timeout: 3000 });
+});
+
+// ─── Import the fixture PDF ──────────────────────────────────────────────────
+
+test("importing sample.pdf shows the import in Properties panel", async () => {
+  const pdfPath = fixturePath("sample.pdf");
+  await mockOpenDialog(electronApp, pdfPath);
+
+  await window.locator("button:has-text('Import')").click();
+
+  // The import is named after the file without extension → "sample"
+  // For a single-page PDF the name is exactly "sample" (no _p1 suffix when only one page)
+  const importEntry = window.locator("text=/sample/").first();
+  await expect(importEntry).toBeVisible({ timeout: 15_000 });
+});
+
+test("the empty state message disappears after PDF import", async () => {
+  const emptyMsg = window.locator("text=No objects. Import an SVG.");
+  await expect(emptyMsg).not.toBeVisible();
+});
+
+test("Properties panel shows path count badge after PDF import", async () => {
+  // sample.pdf has a rectangle stroke — at least 1 path
+  const pathCount = window.locator("text=/\\d+p/").first();
+  await expect(pathCount).toBeVisible({ timeout: 5_000 });
+});
+
+test("Generate G-code button becomes enabled after PDF import", async () => {
+  const btn = window.locator("button:has-text('Generate G-code')");
+  await expect(btn).toBeEnabled({ timeout: 5_000 });
+});
+
+// ─── Canvas rendering ────────────────────────────────────────────────────────
+
+test("imported PDF produces at least one path element on the canvas", async () => {
+  const svgPaths = window.locator("svg path");
+  const count = await svgPaths.count();
+  // The canvas always has bed-grid paths plus at least one from the import
+  expect(count).toBeGreaterThanOrEqual(1);
+});
+
+// ─── Multi-page: a second import is listed separately ────────────────────────
+
+test("importing sample.pdf a second time adds another entry in Properties", async () => {
+  const pdfPath = fixturePath("sample.pdf");
+  await mockOpenDialog(electronApp, pdfPath);
+
+  await window.locator("button:has-text('Import')").click();
+
+  // Both entries should be visible
+  const entries = window.locator("text=/sample/");
+  await expect(entries).toHaveCount(2, { timeout: 15_000 });
+});

--- a/tests/e2e/properties-panel.spec.ts
+++ b/tests/e2e/properties-panel.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * E2E: Properties panel interactions.
+ *
+ * Imports sample.svg once in beforeAll, then verifies:
+ *  - Import name displayed
+ *  - Inline rename (confirm via Enter, cancel via Escape)
+ *  - Visibility toggle (👁 / ○)
+ *  - Path expand / collapse
+ *  - Per-path visibility toggle and delete
+ *  - Selecting an import row shows the position (X/Y) form
+ *  - Delete import removes the row and restores empty state
+ *
+ * Tests run against the single shared app instance to minimise build-launch
+ * overhead, but each group starts from a known state.
+ */
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, fixturePath, mockOpenDialog } from "./helpers";
+import type { ElectronApplication, Page } from "playwright";
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userDataDir: string;
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  ({ electronApp, window, userDataDir } = await launchApp());
+
+  // Import sample.svg so the panel has content to work with.
+  await mockOpenDialog(electronApp, fixturePath("sample.svg"));
+  await window.locator("button:has-text('Import')").click();
+
+  // Wait until the import name appears.
+  await expect(window.locator("text=sample").first()).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test.afterAll(async () => {
+  if (electronApp) await closeApp(electronApp, userDataDir);
+});
+
+// ─── Group 1: Import name displayed ──────────────────────────────────────────
+
+test("Properties panel shows the imported file name 'sample'", async () => {
+  await expect(window.locator("text=sample").first()).toBeVisible();
+});
+
+test("Properties panel shows path count badge (e.g. '7p')", async () => {
+  const badge = window.locator("text=/\\d+p/").first();
+  await expect(badge).toBeVisible();
+  const txt = await badge.textContent();
+  // sample.svg has several paths — at least 1
+  expect(parseInt(txt ?? "0", 10)).toBeGreaterThanOrEqual(1);
+});
+
+test("empty-state message is not visible after import", async () => {
+  await expect(
+    window.locator("text=No objects. Import an SVG."),
+  ).not.toBeVisible();
+});
+
+// ─── Group 2: Visibility toggle ───────────────────────────────────────────────
+
+test("visibility indicator shows '👁' when import is visible", async () => {
+  const vis = window.locator("span[title='Toggle visibility']").first();
+  await expect(vis).toBeVisible();
+  const txt = await vis.textContent();
+  expect(txt?.trim()).toBe("👁");
+});
+
+test("clicking visibility indicator toggles it to '○' (hidden)", async () => {
+  const vis = window.locator("span[title='Toggle visibility']").first();
+  await vis.click();
+  await expect(vis).toHaveText("○", { timeout: 3000 });
+});
+
+test("clicking visibility indicator again toggles back to '👁' (visible)", async () => {
+  const vis = window.locator("span[title='Toggle visibility']").first();
+  await vis.click();
+  await expect(vis).toHaveText("👁", { timeout: 3000 });
+});
+
+// ─── Group 3: Path expand / collapse ─────────────────────────────────────────
+
+test("'Expand paths' button is present and paths are initially collapsed", async () => {
+  const expandBtn = window.locator("button[aria-label='Expand paths']").first();
+  await expect(expandBtn).toBeVisible();
+});
+
+test("clicking 'Expand paths' shows the per-path list", async () => {
+  const expandBtn = window.locator("button[aria-label='Expand paths']").first();
+  await expandBtn.click();
+
+  // Per-path rows have title="Toggle path visibility"
+  const pathRow = window
+    .locator("span[title='Toggle path visibility']")
+    .first();
+  await expect(pathRow).toBeVisible({ timeout: 3000 });
+});
+
+test("expand button label changes to 'Collapse paths' after expansion", async () => {
+  const collapseBtn = window
+    .locator("button[aria-label='Collapse paths']")
+    .first();
+  await expect(collapseBtn).toBeVisible({ timeout: 2000 });
+});
+
+test("clicking 'Collapse paths' hides the per-path list", async () => {
+  const collapseBtn = window
+    .locator("button[aria-label='Collapse paths']")
+    .first();
+  await collapseBtn.click();
+
+  const pathRows = window.locator("span[title='Toggle path visibility']");
+  await expect(pathRows).toHaveCount(0, { timeout: 3000 });
+});
+
+// ─── Group 4: Per-path operations ────────────────────────────────────────────
+
+test("expanding paths shows individual path entries", async () => {
+  const expandBtn = window.locator("button[aria-label='Expand paths']").first();
+  await expandBtn.click();
+
+  const pathRows = window.locator("span[title='Toggle path visibility']");
+  const count = await pathRows.count();
+  expect(count).toBeGreaterThanOrEqual(1);
+});
+
+test("per-path visibility toggle changes icon from '👁' to '○'", async () => {
+  const firstPathVis = window
+    .locator("span[title='Toggle path visibility']")
+    .first();
+  const before = await firstPathVis.textContent();
+  await firstPathVis.click();
+  const after = await firstPathVis.textContent();
+  expect(before?.trim()).not.toBe(after?.trim());
+});
+
+test("per-path delete button removes one path from the expanded list", async () => {
+  const pathRows = window.locator("span[title='Toggle path visibility']");
+  const before = await pathRows.count();
+
+  // Click the first per-path ✕ (title="Remove path")
+  const deleteBtn = window.locator("button[title='Remove path']").first();
+  await deleteBtn.click();
+
+  // Row count should decrease by exactly 1
+  await expect(pathRows).toHaveCount(before - 1, { timeout: 3000 });
+});
+
+// ─── Group 5: Import selection — position form ────────────────────────────────
+
+test("clicking the import row selects it and shows the X (mm) field", async () => {
+  // Collapse paths first so the row click targets the header row
+  const collapseBtn = window.locator("button[aria-label='Collapse paths']");
+  const collapseCount = await collapseBtn.count();
+  if (collapseCount > 0) await collapseBtn.first().click();
+
+  // Click the import row (the row containing the import name)
+  await window.locator("span[title='Double-click to rename']").first().click();
+
+  // The position form (numFields) should appear
+  const xInput = window.locator("#numfield-x-mm");
+  await expect(xInput).toBeVisible({ timeout: 3000 });
+});
+
+test("X position input accepts a new value", async () => {
+  const xInput = window.locator("#numfield-x-mm");
+  await xInput.click({ clickCount: 3 });
+  await xInput.fill("25");
+  await xInput.press("Tab");
+  await expect(xInput).toHaveValue("25", { timeout: 2000 });
+});
+
+test("Y position input accepts a new value", async () => {
+  const yInput = window.locator("#numfield-y-mm");
+  await yInput.click({ clickCount: 3 });
+  await yInput.fill("15");
+  await yInput.press("Tab");
+  await expect(yInput).toHaveValue("15", { timeout: 2000 });
+});
+
+// ─── Group 6: Inline rename ───────────────────────────────────────────────────
+
+test("double-clicking the import name enters edit mode (input appears)", async () => {
+  const nameSpan = window
+    .locator("span[title='Double-click to rename']")
+    .first();
+  await nameSpan.dblclick();
+
+  // An autoFocus input should appear
+  const renameInput = window
+    .locator("input.bg-app.border.border-accent")
+    .first();
+  await expect(renameInput).toBeVisible({ timeout: 3000 });
+});
+
+test("typing a new name and pressing Enter renames the import", async () => {
+  // Trigger rename again (previous test may have dismissed it)
+  const nameSpan = window
+    .locator("span[title='Double-click to rename']")
+    .first();
+  if (await nameSpan.isVisible()) {
+    await nameSpan.dblclick();
+  }
+
+  const renameInput = window
+    .locator("input.bg-app.border.border-accent")
+    .first();
+  await renameInput.waitFor({ timeout: 3000 });
+  await renameInput.fill("renamed");
+  await renameInput.press("Enter");
+
+  await expect(window.locator("text=renamed").first()).toBeVisible({
+    timeout: 3000,
+  });
+  // Update the original name for later cleanup
+});
+
+test("pressing Escape during rename cancels without changing the name", async () => {
+  const nameSpan = window
+    .locator("span[title='Double-click to rename']")
+    .first();
+  await nameSpan.dblclick();
+
+  const renameInput = window
+    .locator("input.bg-app.border.border-accent")
+    .first();
+  await renameInput.waitFor({ timeout: 3000 });
+  const originalName = await nameSpan.textContent().catch(() => "renamed");
+  await renameInput.fill("should-not-save");
+  await renameInput.press("Escape");
+
+  // Input should be gone and name unchanged
+  await expect(renameInput).not.toBeVisible({ timeout: 2000 });
+  await expect(window.locator("text=should-not-save")).not.toBeVisible({
+    timeout: 2000,
+  });
+});
+
+// ─── Group 7: Delete import ───────────────────────────────────────────────────
+
+test("clicking 'Delete import' ✕ removes the import row", async () => {
+  const deleteBtn = window.locator("button[title='Delete import']").first();
+  await expect(deleteBtn).toBeVisible();
+  await deleteBtn.click();
+
+  // After delete the import row is gone
+  await expect(window.locator("button[title='Delete import']")).toHaveCount(0, {
+    timeout: 3000,
+  });
+});
+
+test("empty state message reappears after all imports are deleted", async () => {
+  await expect(window.locator("text=No objects. Import an SVG.")).toBeVisible({
+    timeout: 3000,
+  });
+});

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /ProcSet [/PDF] >> >>
+endobj
+4 0 obj
+<< /Length 40 >>
+stream
+10 10 m
+190 10 l
+190 190 l
+10 190 l
+h
+S
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000235 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+324
+%%EOF


### PR DESCRIPTION
This pull request adds comprehensive end-to-end (E2E) tests for major UI features of the application, focusing on the file browser, jog controls, and job abort flows. The new tests use Playwright to simulate user interactions and verify UI behavior, IPC communication, and command dispatch for a connected FluidNC machine. The changes improve test coverage for file operations, machine control, and job handling.

**New E2E Test Suites and Coverage:**

*File Browser Functionality:*
- Introduces a new E2E test suite in `connected-file-browser.spec.ts` covering file listing, directory navigation, file selection, upload, delete, refresh, and preview/run actions in the file browser when connected to a mock FluidNC machine.

*Jog Controls Panel:*
- Adds a new E2E test suite in `jog-controls.spec.ts` verifying the visibility and behavior of jog controls, including directional jogging, step size, feedrate, pen commands, homing, zeroing, and panel toggling. Command dispatch is tracked and asserted for correctness.

*Job Abort Flow:*
- Expands the E2E tests in `gcode-preview.spec.ts` to cover the job abort process: showing the Abort button, confirmation dialog, IPC call for aborting, UI state transitions, and dialog cancellation behavior.