### PR TITLE
Handle inkscape SVG layers

### DIFF
--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -43,8 +43,31 @@ function hasExplicitDisplay(el: Element): boolean {
   return /\bdisplay\s*:/.test(el.getAttribute("style") ?? "");
 }
 
+/**
+ * Returns true when the element is explicitly marked as an Inkscape layer
+ * (`inkscape:groupmode="layer"`).
+ */
+function hasInkscapeLayerMarker(el: Element): boolean {
+  const ns = "http://www.inkscape.org/namespaces/inkscape";
+  return (
+    (el.getAttribute("inkscape:groupmode") ??
+      el.getAttributeNS(ns, "groupmode")) === "layer"
+  );
+}
+
+/**
+ * A `<g>` is a logical SVG sub-layer when it either has explicit display
+ * styling (legacy behaviour) or an Inkscape layer marker.
+ */
+function isLayerGroup(el: Element): boolean {
+  return hasExplicitDisplay(el) || hasInkscapeLayerMarker(el);
+}
+
 function isDisplayNone(el: Element): boolean {
-  return /display\s*:\s*none/.test(el.getAttribute("style") ?? "");
+  const styleHidden = /display\s*:\s*none/.test(el.getAttribute("style") ?? "");
+  const attrHidden =
+    (el.getAttribute("display") ?? "").trim().toLowerCase() === "none";
+  return styleHidden || attrHidden;
 }
 
 /**
@@ -513,8 +536,7 @@ export function Toolbar({
       // `display` declaration in its inline style (e.g. Inkscape sub-layers)
       // and is not inside a non-rendering context (defs, clipPath, mask…).
       const layerGroupEls = Array.from(doc.querySelectorAll("g")).filter(
-        (g) =>
-          !g.closest("defs, clipPath, mask, symbol") && hasExplicitDisplay(g),
+        (g) => !g.closest("defs, clipPath, mask, symbol") && isLayerGroup(g),
       );
       const layers: SvgLayer[] = layerGroupEls.map((g, i) => ({
         id: g.id || `layer_${i}`,

--- a/tests/component/Toolbar.test.tsx
+++ b/tests/component/Toolbar.test.tsx
@@ -1117,6 +1117,68 @@ describe("Toolbar", () => {
       expect(visiblePaths).toHaveLength(1);
     });
 
+    it("detects Inkscape layer groups via inkscape:groupmode and maps layer ids", async () => {
+      const svgXml = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="100mm" height="100mm" viewBox="0 0 100 100">
+        <g id="layer-a" inkscape:groupmode="layer" inkscape:label="Layer A">
+          <path d="M 0,0 L 50,50" stroke="red" fill="none" />
+        </g>
+        <g id="layer-b" inkscape:groupmode="layer" inkscape:label="Layer B">
+          <path d="M 10,10 L 90,90" stroke="blue" fill="none" />
+        </g>
+      </svg>`;
+      (
+        window.terraForge.fs.openImportDialog as ReturnType<typeof vi.fn>
+      ).mockResolvedValue("/inkscape-layers.svg");
+      (
+        window.terraForge.fs.readFile as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(svgXml);
+
+      render(<Toolbar />);
+      await userEvent.click(screen.getByText("Import"));
+      await waitFor(() => {
+        expect(useCanvasStore.getState().imports.length).toBe(1);
+      });
+
+      const imp = useCanvasStore.getState().imports[0];
+      expect(imp.layers).toBeDefined();
+      expect(imp.layers).toHaveLength(2);
+
+      const layerA = imp.layers!.find((l) => l.id === "layer-a");
+      const layerB = imp.layers!.find((l) => l.id === "layer-b");
+      expect(layerA?.name).toBe("Layer A");
+      expect(layerB?.name).toBe("Layer B");
+      expect(layerA?.visible).toBe(true);
+      expect(layerB?.visible).toBe(true);
+
+      expect(imp.paths.filter((p) => p.layer === "layer-a")).toHaveLength(1);
+      expect(imp.paths.filter((p) => p.layer === "layer-b")).toHaveLength(1);
+    });
+
+    it("does not treat plain groups without markers as layers", async () => {
+      const svgXml = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100mm" viewBox="0 0 100 100">
+        <g id="plain-group">
+          <path d="M 0,0 L 50,50" stroke="red" fill="none" />
+        </g>
+      </svg>`;
+      (
+        window.terraForge.fs.openImportDialog as ReturnType<typeof vi.fn>
+      ).mockResolvedValue("/plain-group.svg");
+      (
+        window.terraForge.fs.readFile as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(svgXml);
+
+      render(<Toolbar />);
+      await userEvent.click(screen.getByText("Import"));
+      await waitFor(() => {
+        expect(useCanvasStore.getState().imports.length).toBe(1);
+      });
+
+      const imp = useCanvasStore.getState().imports[0];
+      expect(imp.layers).toBeUndefined();
+      expect(imp.paths).toHaveLength(1);
+      expect(imp.paths[0].layer).toBeUndefined();
+    });
+
     it("shows error task when SVG has no vector paths", async () => {
       const svgXml = `<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100mm" viewBox="0 0 100 100">
         <text x="10" y="50">Hello</text>


### PR DESCRIPTION
This pull request improves the detection and handling of SVG layers, particularly for files created with Inkscape. It introduces logic to recognize Inkscape-specific layer markers, ensuring that layers are correctly identified during import, and updates the relevant tests to verify this behavior.

**SVG Layer Detection Improvements:**

* Added a new function `hasInkscapeLayerMarker` to detect Inkscape layer groups via the `inkscape:groupmode="layer"` attribute, and updated the logic to treat such groups as layers in addition to those with explicit display styling. (`src/renderer/src/components/Toolbar.tsx`)
* Updated the filtering logic in the `Toolbar` component to use the new `isLayerGroup` function, ensuring Inkscape layers are recognized as logical layers. (`src/renderer/src/components/Toolbar.tsx`)

**Testing Enhancements:**

* Added tests to verify that Inkscape layer groups are detected and mapped correctly, and that plain groups without layer markers are not treated as layers. (`tests/component/Toolbar.test.tsx`)