### PR TITLE
Pan not working over selecting imports

### DIFF
--- a/src/renderer/src/features/canvas/hooks/useCanvasInteractionHandlers.ts
+++ b/src/renderer/src/features/canvas/hooks/useCanvasInteractionHandlers.ts
@@ -22,10 +22,8 @@ export function useCanvasInteractionHandlers({
 }: UseCanvasInteractionHandlersOptions) {
   const onContainerMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.button === 1) {
-        e.preventDefault();
-        startPan(e.clientX, e.clientY);
-      } else if (e.button === 0 && spaceRef.current) {
+      const isPanButton = e.button === 1 || e.button === 2;
+      if (isPanButton || (e.button === 0 && spaceRef.current)) {
         e.preventDefault();
         startPan(e.clientX, e.clientY);
       }

--- a/src/renderer/src/features/canvas/hooks/useGroupOBB.ts
+++ b/src/renderer/src/features/canvas/hooks/useGroupOBB.ts
@@ -52,6 +52,9 @@ export function useGroupOBB(
   const [persistentGroupOBB, setPersistentGroupOBB] =
     useState<PersistentGroupOBB | null>(null);
 
+  const isNonPrimaryButton = (button: number | undefined) =>
+    button !== undefined && button !== 0;
+
   // Ref mirror so gesture callbacks can read the latest value without deps.
   const persistentGroupOBBRef = useRef(persistentGroupOBB);
   persistentGroupOBBRef.current = persistentGroupOBB;
@@ -81,6 +84,7 @@ export function useGroupOBB(
 
   const onGroupHandleMouseDown = useCallback(
     (e: React.MouseEvent<SVGCircleElement>, handle: HandlePos) => {
+      if (isNonPrimaryButton(e.button)) return;
       e.stopPropagation();
       useCanvasStore.getState().snapshotForGesture();
       const state = useCanvasStore.getState();
@@ -157,6 +161,7 @@ export function useGroupOBB(
       gHW: number,
       gHH: number,
     ) => {
+      if (isNonPrimaryButton(e.button)) return;
       e.stopPropagation();
       useCanvasStore.getState().snapshotForGesture();
       const state = useCanvasStore.getState();

--- a/src/renderer/src/features/canvas/hooks/useObjectDrag.ts
+++ b/src/renderer/src/features/canvas/hooks/useObjectDrag.ts
@@ -24,8 +24,12 @@ export function useObjectDrag(
   const [dragging, setDragging] = useState<DraggingState | null>(null);
   const justDraggedRef = useRef(false);
 
+  const isNonPrimaryButton = (button: number | undefined) =>
+    button !== undefined && button !== 0;
+
   const onImportMouseDown = useCallback(
     (e: React.MouseEvent, id: string) => {
+      if (isNonPrimaryButton(e.button)) return;
       if (spaceRef.current) return; // space held → pan mode, not drag
       e.stopPropagation();
       const state = useCanvasStore.getState();
@@ -82,6 +86,7 @@ export function useObjectDrag(
 
   const onGroupMouseDown = useCallback(
     (e: React.MouseEvent<SVGRectElement>) => {
+      if (isNonPrimaryButton(e.button)) return;
       if (spaceRef.current) return;
       e.stopPropagation();
       useCanvasStore.getState().snapshotForGesture();

--- a/src/renderer/src/features/canvas/hooks/useObjectScaleRotate.ts
+++ b/src/renderer/src/features/canvas/hooks/useObjectScaleRotate.ts
@@ -25,8 +25,12 @@ export function useObjectScaleRotate(
   const [scaling, setScaling] = useState<ScalingState | null>(null);
   const [rotating, setRotating] = useState<RotatingState | null>(null);
 
+  const isNonPrimaryButton = (button: number | undefined) =>
+    button !== undefined && button !== 0;
+
   const onHandleMouseDown = useCallback(
     (e: React.MouseEvent<SVGCircleElement>, id: string, handle: HandlePos) => {
+      if (isNonPrimaryButton(e.button)) return;
       e.stopPropagation();
       useCanvasStore.getState().snapshotForGesture();
       const imp = useCanvasStore.getState().imports.find((i) => i.id === id);
@@ -58,6 +62,7 @@ export function useObjectScaleRotate(
       cxSvg: number,
       cySvg: number,
     ) => {
+      if (isNonPrimaryButton(e.button)) return;
       e.stopPropagation();
       useCanvasStore.getState().snapshotForGesture();
       const imp = useCanvasStore.getState().imports.find((i) => i.id === id);

--- a/tests/component/PlotCanvas.test.tsx
+++ b/tests/component/PlotCanvas.test.tsx
@@ -36,6 +36,27 @@ beforeEach(() => {
 });
 
 describe("PlotCanvas", () => {
+  const setupRO = () => {
+    const Original = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      _cb: ResizeObserverCallback;
+      constructor(cb: ResizeObserverCallback) {
+        this._cb = cb;
+      }
+      observe(el: Element) {
+        this._cb(
+          [{ contentRect: { width: 800, height: 600 } } as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+    return () => {
+      globalThis.ResizeObserver = Original;
+    };
+  };
+
   // ── Basic rendering ─────────────────────────────────────────────────
 
   it("renders without crashing", () => {
@@ -473,12 +494,54 @@ describe("PlotCanvas", () => {
   // ── Middle-click pan ───────────────────────────────────────────────
 
   it("middle-click on container starts pan (does not crash)", () => {
+    const restore = setupRO();
     const { container } = render(<PlotCanvas />);
     const div = container.querySelector("div")!;
+    const svg = container.querySelector("svg")!;
+    const before = svg.getAttribute("viewBox");
     fireEvent.mouseDown(div, { button: 1, clientX: 200, clientY: 200 });
     fireEvent.mouseMove(window, { clientX: 210, clientY: 205 });
     fireEvent.mouseUp(window);
-    expect(container.querySelector("svg")).toBeTruthy();
+    expect(svg.getAttribute("viewBox")).not.toBe(before);
+    restore();
+  });
+
+  it("right-click on container starts pan", () => {
+    const restore = setupRO();
+    const { container } = render(<PlotCanvas />);
+    const div = container.querySelector("div")!;
+    const svg = container.querySelector("svg")!;
+    const before = svg.getAttribute("viewBox");
+    fireEvent.mouseDown(div, { button: 2, clientX: 220, clientY: 220 });
+    fireEvent.mouseMove(window, { clientX: 245, clientY: 235 });
+    fireEvent.mouseUp(window);
+    expect(svg.getAttribute("viewBox")).not.toBe(before);
+    restore();
+  });
+
+  it("right-click on import pans canvas without moving the import", () => {
+    const restore = setupRO();
+    const path = createSvgPath({ d: "M0,0 L100,100" });
+    const imp = createSvgImport({ name: "pan-target", paths: [path] });
+    useCanvasStore.setState({ imports: [imp] });
+    const { container } = render(<PlotCanvas />);
+    const svg = container.querySelector("svg")!;
+    const beforeViewBox = svg.getAttribute("viewBox");
+    const beforeImport = useCanvasStore.getState().imports[0];
+    const hitRect = container.querySelector("rect[fill='transparent']")!;
+
+    fireEvent.mouseDown(hitRect, {
+      button: 2,
+      clientX: 180,
+      clientY: 180,
+    });
+    fireEvent.mouseMove(window, { clientX: 210, clientY: 195 });
+    fireEvent.mouseUp(window);
+
+    const afterImport = useCanvasStore.getState().imports[0];
+    expect(svg.getAttribute("viewBox")).not.toBe(beforeViewBox);
+    expect(afterImport.x).toBe(beforeImport.x);
+    expect(afterImport.y).toBe(beforeImport.y);
   });
 
   // ── SVG onClick deselects ──────────────────────────────────────────
@@ -624,27 +687,6 @@ describe("PlotCanvas", () => {
   });
 
   // ── HandleOverlay interactions (require ResizeObserver with size) ──
-
-  const setupRO = () => {
-    const Original = globalThis.ResizeObserver;
-    globalThis.ResizeObserver = class {
-      _cb: ResizeObserverCallback;
-      constructor(cb: ResizeObserverCallback) {
-        this._cb = cb;
-      }
-      observe(el: Element) {
-        this._cb(
-          [{ contentRect: { width: 800, height: 600 } } as ResizeObserverEntry],
-          this as unknown as ResizeObserver,
-        );
-      }
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof ResizeObserver;
-    return () => {
-      globalThis.ResizeObserver = Original;
-    };
-  };
 
   it("handle-delete button removes the selected import", () => {
     const restore = setupRO();


### PR DESCRIPTION
This pull request improves mouse interaction handling on the canvas by making right-click (mouse button 2) consistently initiate panning, in addition to the existing middle-click (button 1) support. It also ensures that only primary mouse button interactions trigger object manipulation (drag, scale, rotate, group bounding box handles), preventing accidental gestures with right or middle clicks. The tests are updated to cover these behaviors.

**Mouse interaction and event handling improvements:**

* Updated `useCanvasInteractionHandlers` to allow both right-click (button 2) and middle-click (button 1) to start panning the canvas, and to prevent default browser behavior for these buttons.
* Added a shared `isNonPrimaryButton` utility in several hooks (`useObjectDrag`, `useObjectScaleRotate`, `useGroupOBB`) to ensure that only primary button (button 0, usually left-click) can trigger object drag, scale, rotate, or group bounding box handle actions. [[1]](diffhunk://#diff-c2d800572d3620a8a7434b25f92df7260f7faa846d08cf8b70e9e5f374775c16R27-R32) [[2]](diffhunk://#diff-c2d800572d3620a8a7434b25f92df7260f7faa846d08cf8b70e9e5f374775c16R89) [[3]](diffhunk://#diff-d378b22926105e44226efbe10534a774507eae7410a78fa7b676d8205483f341R28-R33) [[4]](diffhunk://#diff-d378b22926105e44226efbe10534a774507eae7410a78fa7b676d8205483f341R65) [[5]](diffhunk://#diff-22e083ba41338a0db1722092e4378a2fbfd4cbee34df6b8ea04b89fc61d5742aR55-R57) [[6]](diffhunk://#diff-22e083ba41338a0db1722092e4378a2fbfd4cbee34df6b8ea04b89fc61d5742aR87) [[7]](diffhunk://#diff-22e083ba41338a0db1722092e4378a2fbfd4cbee34df6b8ea04b89fc61d5742aR164)

**Testing enhancements:**

* Added and improved tests in `PlotCanvas.test.tsx` to verify that right-click can pan the canvas, and that right-clicking on an import pans the canvas without moving the import itself. Also, refactored the `ResizeObserver` setup utility for reuse and removed duplicate code. [[1]](diffhunk://#diff-2349326bb72ff2ef6985eb89625a88c90b2847406d0deba138e3349208e88663R39-R59) [[2]](diffhunk://#diff-2349326bb72ff2ef6985eb89625a88c90b2847406d0deba138e3349208e88663R497-R544) [[3]](diffhunk://#diff-2349326bb72ff2ef6985eb89625a88c90b2847406d0deba138e3349208e88663L628-L648)