### PR TITLE
Ensure canvas colour updates on theme change

### DIFF
--- a/src/renderer/src/components/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas.tsx
@@ -14,6 +14,7 @@
 import { useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useCanvasStore } from "../store/canvasStore";
+import { useThemeStore } from "../store/themeStore";
 import {
   selectPlotCanvasCanvasState,
   selectPlotCanvasToolpathState,
@@ -79,6 +80,7 @@ export function PlotCanvas() {
     plotProgressRapids,
   } = useCanvasStore(useShallow(selectPlotCanvasToolpathState));
   const activeConfig = useMachineStore((s) => s.activeConfig);
+  const theme = useThemeStore((s) => s.theme);
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
   const machineStatus = useMachineStore((s) => s.status);
@@ -293,6 +295,7 @@ export function PlotCanvas() {
         toolpathSelected={toolpathSelected}
         plotProgressCuts={plotProgressCuts ?? null}
         plotProgressRapids={plotProgressRapids ?? null}
+        theme={theme}
       />
 
       {/* ── Canvas SVG — fills the container; viewBox drives pan/zoom so the

--- a/src/renderer/src/features/canvas/components/ToolpathOverlay.test.tsx
+++ b/src/renderer/src/features/canvas/components/ToolpathOverlay.test.tsx
@@ -32,6 +32,7 @@ function makeProps(
     toolpathSelected: false,
     plotProgressCuts: null,
     plotProgressRapids: null,
+    theme: "dark",
     ...overrides,
   };
 }

--- a/src/renderer/src/features/canvas/components/ToolpathOverlay.tsx
+++ b/src/renderer/src/features/canvas/components/ToolpathOverlay.tsx
@@ -16,6 +16,7 @@ import { MM_TO_PX, PAD } from "../constants";
 import type { Vp } from "../types";
 import type { SvgImport, LayerGroup } from "../../../../../types";
 import type { GcodeToolpath } from "../../../utils/gcodeParser";
+import type { Theme } from "../../../store/themeStore";
 import {
   drawImportsLayer,
   drawToolpathLayer,
@@ -46,6 +47,7 @@ export interface ToolpathOverlayProps {
   toolpathSelected: boolean;
   plotProgressCuts: string | null;
   plotProgressRapids: string | null;
+  theme: Theme;
 }
 
 export function ToolpathOverlay({
@@ -70,6 +72,7 @@ export function ToolpathOverlay({
   toolpathSelected,
   plotProgressCuts,
   plotProgressRapids,
+  theme,
 }: ToolpathOverlayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -206,6 +209,7 @@ export function ToolpathOverlay({
     allImportsSelected,
     layerGroups,
     canvasH,
+    theme,
   ]);
 
   return (

--- a/src/renderer/src/store/themeStore.ts
+++ b/src/renderer/src/store/themeStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-type Theme = "dark" | "light";
+export type Theme = "dark" | "light";
 
 interface ThemeState {
   theme: Theme;


### PR DESCRIPTION
This pull request introduces support for theming in the `ToolpathOverlay` component by passing the current theme from the global store down through the component hierarchy. It also updates related type definitions and test utilities to accommodate the new `theme` prop.

**Theming support:**

* Added a `theme` prop to the `ToolpathOverlay` component and its props interface, enabling it to receive and utilize the current theme (`"dark"` or `"light"`). [[1]](diffhunk://#diff-af4efe8e7815cc5fa204e37f69320e7d5054330e2c90fb7a63126fc8d0f68731R50) [[2]](diffhunk://#diff-af4efe8e7815cc5fa204e37f69320e7d5054330e2c90fb7a63126fc8d0f68731R75)
* Passed the current theme from the `PlotCanvas` component to `ToolpathOverlay` by reading it from the `themeStore`. [[1]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR17) [[2]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR83) [[3]](diffhunk://#diff-3cd8df8849ee1c4159f9ec09538cc3581b9686d4404a4030f2b20712284a3f1bR298)
* Exported the `Theme` type from `themeStore.ts` for use in other files. [[1]](diffhunk://#diff-b9b312feb48556c3ae272a036d5f8aa43d5d2059baba57b3ab402a730b81c70bL4-R4) [[2]](diffhunk://#diff-af4efe8e7815cc5fa204e37f69320e7d5054330e2c90fb7a63126fc8d0f68731R19)

**Testing updates:**

* Updated the test utility in `ToolpathOverlay.test.tsx` to include a default `theme` prop, ensuring tests remain valid with the new requirement.