### PR TITLE
Improved group/layer selection gcode export naming

### DIFF
--- a/src/renderer/src/features/machine/hooks/useJobActions.ts
+++ b/src/renderer/src/features/machine/hooks/useJobActions.ts
@@ -18,6 +18,8 @@ export function useJobActions() {
   const {
     imports,
     layerGroups,
+    selectedImportId,
+    selectedGroupId,
     pageTemplate,
     pageSizes,
     setGcodeToolpath,
@@ -194,10 +196,17 @@ export function useJobActions() {
         unregisterCancelCallback(taskId);
         setGenerating(false);
 
+        const selectedGroup = selectedGroupId
+          ? layerGroups.find((group) => group.id === selectedGroupId)
+          : null;
+        const selectedImport = selectedImportId
+          ? imports.find((imp) => imp.id === selectedImportId)
+          : null;
         const baseName =
-          imports.length === 1
-            ? imports[0].name
-            : `${imports[0].name}+${imports.length - 1}`;
+          selectedGroup?.name ||
+          selectedImport?.name ||
+          imports[0]?.name ||
+          "untitled";
         const safeName = baseName
           .replace(/\.[^.]+$/, "")
           .replace(/[\\/:*?"<>|]/g, "_");

--- a/src/renderer/src/store/canvasSelectors/jobs.ts
+++ b/src/renderer/src/store/canvasSelectors/jobs.ts
@@ -3,6 +3,8 @@ import type { CanvasState } from "../canvasStore/types";
 export const selectJobActionsCanvasState = (state: CanvasState) => ({
   imports: state.imports,
   layerGroups: state.layerGroups,
+  selectedImportId: state.selectedImportId,
+  selectedGroupId: state.selectedGroupId,
   pageTemplate: state.pageTemplate,
   pageSizes: state.pageSizes,
   setGcodeToolpath: state.setGcodeToolpath,

--- a/tests/component/Toolbar.test.tsx
+++ b/tests/component/Toolbar.test.tsx
@@ -911,6 +911,217 @@ describe("Toolbar", () => {
         expect(window.terraForge.fs.writeFile).toHaveBeenCalled();
       });
     });
+
+    it("uses selected layer group name for default save filename", async () => {
+      let workerInstance: {
+        onmessage: ((e: MessageEvent) => void) | null;
+      } | null = null;
+      function MockWorker() {
+        const inst = {
+          postMessage: vi.fn(),
+          terminate: vi.fn(),
+          onmessage: null as ((e: MessageEvent) => void) | null,
+          onerror: null,
+        };
+        workerInstance = inst;
+        return inst;
+      }
+      vi.stubGlobal("Worker", MockWorker);
+      (
+        window.terraForge.fs.saveGcodeDialog as ReturnType<typeof vi.fn>
+      ).mockResolvedValue("/out/layer.gcode");
+      (
+        window.terraForge.fs.writeFile as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(undefined);
+      localStorage.setItem(
+        "terraforge.gcodePrefs",
+        JSON.stringify({
+          optimise: true,
+          uploadToSd: false,
+          saveLocally: true,
+          joinPaths: false,
+          joinTolerance: 0.2,
+          liftPenAtEnd: true,
+          returnToHome: false,
+          customStartGcode: "",
+          customEndGcode: "",
+        }),
+      );
+
+      const cfg = createMachineConfig({ name: "Test Plotter" });
+      useMachineStore.setState({
+        configs: [cfg],
+        activeConfigId: cfg.id,
+        connected: false,
+      });
+      const imp = createSvgImport({ id: "imp-a", name: "first-import" });
+      useCanvasStore.setState({
+        imports: [imp],
+        layerGroups: [
+          {
+            id: "g-a",
+            name: "Layer: 1/Top*",
+            color: "#ff0000",
+            importIds: [imp.id],
+          },
+        ],
+        selectedGroupId: "g-a",
+        selectedImportId: imp.id,
+      });
+
+      render(<Toolbar />);
+      await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+      await waitFor(() => expect(workerInstance).not.toBeNull());
+      await act(async () => {
+        workerInstance!.onmessage?.({
+          data: { type: "complete", gcode: "G0 X0 Y0\n" },
+        } as MessageEvent);
+      });
+
+      await waitFor(() => {
+        expect(window.terraForge.fs.saveGcodeDialog).toHaveBeenCalledWith(
+          "Layer_ 1_Top__opt.gcode",
+        );
+      });
+    });
+
+    it("uses selected import name when no group is selected", async () => {
+      let workerInstance: {
+        onmessage: ((e: MessageEvent) => void) | null;
+      } | null = null;
+      function MockWorker() {
+        const inst = {
+          postMessage: vi.fn(),
+          terminate: vi.fn(),
+          onmessage: null as ((e: MessageEvent) => void) | null,
+          onerror: null,
+        };
+        workerInstance = inst;
+        return inst;
+      }
+      vi.stubGlobal("Worker", MockWorker);
+      (
+        window.terraForge.fs.saveGcodeDialog as ReturnType<typeof vi.fn>
+      ).mockResolvedValue("/out/second.gcode");
+      (
+        window.terraForge.fs.writeFile as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(undefined);
+      localStorage.setItem(
+        "terraforge.gcodePrefs",
+        JSON.stringify({
+          optimise: false,
+          uploadToSd: false,
+          saveLocally: true,
+          joinPaths: false,
+          joinTolerance: 0.2,
+          liftPenAtEnd: true,
+          returnToHome: false,
+          customStartGcode: "",
+          customEndGcode: "",
+        }),
+      );
+
+      const cfg = createMachineConfig({ name: "Test Plotter" });
+      useMachineStore.setState({
+        configs: [cfg],
+        activeConfigId: cfg.id,
+        connected: false,
+      });
+      const first = createSvgImport({ id: "imp-1", name: "first-import" });
+      const second = createSvgImport({ id: "imp-2", name: "second/import" });
+      useCanvasStore.setState({
+        imports: [first, second],
+        selectedGroupId: null,
+        selectedImportId: second.id,
+      });
+
+      render(<Toolbar />);
+      await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+      await waitFor(() => expect(workerInstance).not.toBeNull());
+      await act(async () => {
+        workerInstance!.onmessage?.({
+          data: { type: "complete", gcode: "G0 X0 Y0\n" },
+        } as MessageEvent);
+      });
+
+      await waitFor(() => {
+        expect(window.terraForge.fs.saveGcodeDialog).toHaveBeenCalledWith(
+          "second_import.gcode",
+        );
+      });
+    });
+
+    it("falls back to first import name when nothing is selected", async () => {
+      let workerInstance: {
+        onmessage: ((e: MessageEvent) => void) | null;
+      } | null = null;
+      function MockWorker() {
+        const inst = {
+          postMessage: vi.fn(),
+          terminate: vi.fn(),
+          onmessage: null as ((e: MessageEvent) => void) | null,
+          onerror: null,
+        };
+        workerInstance = inst;
+        return inst;
+      }
+      vi.stubGlobal("Worker", MockWorker);
+      (
+        window.terraForge.fs.saveGcodeDialog as ReturnType<typeof vi.fn>
+      ).mockResolvedValue("/out/first.gcode");
+      (
+        window.terraForge.fs.writeFile as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(undefined);
+      localStorage.setItem(
+        "terraforge.gcodePrefs",
+        JSON.stringify({
+          optimise: false,
+          uploadToSd: false,
+          saveLocally: true,
+          joinPaths: false,
+          joinTolerance: 0.2,
+          liftPenAtEnd: true,
+          returnToHome: false,
+          customStartGcode: "",
+          customEndGcode: "",
+        }),
+      );
+
+      const cfg = createMachineConfig({ name: "Test Plotter" });
+      useMachineStore.setState({
+        configs: [cfg],
+        activeConfigId: cfg.id,
+        connected: false,
+      });
+      const first = createSvgImport({ id: "imp-1", name: "first-file.svg" });
+      const second = createSvgImport({ id: "imp-2", name: "second-file" });
+      useCanvasStore.setState({
+        imports: [first, second],
+        selectedGroupId: null,
+        selectedImportId: null,
+      });
+
+      render(<Toolbar />);
+      await userEvent.click(screen.getByText("Generate G-code"));
+      await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+      await waitFor(() => expect(workerInstance).not.toBeNull());
+      await act(async () => {
+        workerInstance!.onmessage?.({
+          data: { type: "complete", gcode: "G0 X0 Y0\n" },
+        } as MessageEvent);
+      });
+
+      await waitFor(() => {
+        expect(window.terraForge.fs.saveGcodeDialog).toHaveBeenCalledWith(
+          "first-file.gcode",
+        );
+      });
+    });
   });
 
   // ── SVG import: shape variety ──────────────────────────────────────────────


### PR DESCRIPTION
This pull request improves how the default filename is chosen when saving generated G-code, making it more intuitive and user-friendly. Now, the filename will use the selected layer group name if available, otherwise the selected import name, and finally fall back to the first import's name if nothing is selected. The changes also add thorough tests to verify this new behavior.

**Filename selection logic improvements:**

* Updated `useJobActions` to prioritize `selectedGroupId` and `selectedImportId` when determining the default save filename, falling back to the first import's name if neither is selected. This ensures filenames are more descriptive and context-aware. [[1]](diffhunk://#diff-86946183e4db65453ff4b2d39514faf1ffcd19ab8bac2d61b614069ae5cb0ae0R21-R22) [[2]](diffhunk://#diff-86946183e4db65453ff4b2d39514faf1ffcd19ab8bac2d61b614069ae5cb0ae0R199-R209)
* Updated the canvas state selector to include `selectedImportId` and `selectedGroupId`, allowing the new filename logic to access the current selection.

**Testing enhancements:**

* Added comprehensive tests in `Toolbar.test.tsx` to verify that the default save filename uses the selected layer group name, falls back to the selected import name if no group is selected, and finally uses the first import name if nothing is selected.