### PR TITLE
Fix set zero command not working by using /command instead of /plain

### DIFF
--- a/src/machine/fluidnc.ts
+++ b/src/machine/fluidnc.ts
@@ -95,17 +95,15 @@ export class FluidNCClient extends EventEmitter {
   // ─── Commands ─────────────────────────────────────────────────────────────
 
   async sendCommand(cmd: string): Promise<string> {
-    // FluidNC 3.x and 4.x require different HTTP call conventions:
+    // FluidNC 3.x and 4.x require different command conventions.
     //
-    // 4.x: GET /command?plain=CMD  — executes synchronously, returns response
-    //      POST /command commandText=CMD returns HTTP 500 for non-ESP/non-$/ cmds
+    // 3.x: POST /command with x-www-form-urlencoded body:
+    //      commandText=CMD
     //
-    // 3.x: POST /command commandText=CMD — works for all commands
-    //      GET /command?plain=CMD returns HTTP 500 for jog / G-code commands
+    // 4.x / WebUI convention: GET /command?commandText=CMD
     //
-    // We branch on fwMajor which is set during connectWebSocket. When unknown
-    // (null, e.g. probe failed) we default to 4.x behaviour as that is the
-    // current/modern firmware.
+    // Some builds still accept GET /command?plain=CMD, so for 4.x/unknown we
+    // try commandText first (matching WebUI) and fall back to plain.
     if (this.fwMajor !== null && this.fwMajor < 4) {
       const res = await this.restClient.post(
         "/command",
@@ -114,11 +112,19 @@ export class FluidNCClient extends EventEmitter {
       return res.text();
     }
     // 4.x (or unknown — assume modern)
-    const res = await this.restClient.get(
-      `/command?plain=${encodeURIComponent(cmd)}`,
-      10_000,
-    );
-    return res.text();
+    try {
+      const res = await this.restClient.get(
+        `/command?commandText=${encodeURIComponent(cmd)}`,
+        10_000,
+      );
+      return res.text();
+    } catch {
+      const res = await this.restClient.get(
+        `/command?plain=${encodeURIComponent(cmd)}`,
+        10_000,
+      );
+      return res.text();
+    }
   }
 
   // ─── Job Control ──────────────────────────────────────────────────────────

--- a/tests/unit/fluidnc.test.ts
+++ b/tests/unit/fluidnc.test.ts
@@ -19,7 +19,7 @@ const wsCapture = vi.hoisted(() => ({
 
 vi.mock("ws", () => {
   // EventEmitter must be required inside the factory (hoisted context)
-   
+
   const { EventEmitter } = require("events");
 
   class MockWebSocket extends EventEmitter {
@@ -94,13 +94,29 @@ describe("FluidNCClient", () => {
 
   // ── sendCommand ─────────────────────────────────────────────────────────
 
-  it("sends command via GET for fw 4.x (default)", async () => {
+  it("sends command via GET commandText for fw 4.x (default)", async () => {
     mockFetch.mockResolvedValueOnce(mockResponse("ok"));
     const result = await client.sendCommand("G0 X10");
     expect(result).toBe("ok");
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/command?plain="),
+      expect.stringContaining("/command?commandText="),
       expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("falls back to GET plain query when commandText query fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse("", 404))
+      .mockResolvedValueOnce(mockResponse("ok"));
+
+    const result = await client.sendCommand("G10 L20 P1 X0 Y0");
+    expect(result).toBe("ok");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][0]).toEqual(
+      expect.stringContaining("/command?commandText="),
+    );
+    expect(mockFetch.mock.calls[1][0]).toEqual(
+      expect.stringContaining("/command?plain="),
     );
   });
 
@@ -170,7 +186,9 @@ describe("FluidNCClient", () => {
   });
 
   it("throws on HTTP error from sendCommand", async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse("", 404));
+    mockFetch
+      .mockResolvedValueOnce(mockResponse("", 404))
+      .mockResolvedValueOnce(mockResponse("", 404));
     await expect(client.sendCommand("test")).rejects.toThrow("HTTP 404");
   });
 


### PR DESCRIPTION
This pull request updates the `FluidNCClient` command handling logic to better support both FluidNC 3.x and 4.x firmware conventions, improving compatibility and reliability. It also expands the test suite to verify the new behavior, including fallback logic and error handling.

**Command handling improvements:**

* Updated `sendCommand` method in `FluidNCClient` to first attempt sending commands to 4.x firmware using the `commandText` query (matching the WebUI convention), and fall back to the `plain` query if the first attempt fails. This enhances compatibility with various 4.x firmware builds. [[1]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aL98-R106) [[2]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR115-R128)

**Test suite enhancements:**

* Updated and added unit tests in `fluidnc.test.ts` to verify that `sendCommand` uses the correct query for 4.x firmware, correctly falls back to the `plain` query when the `commandText` query fails, and properly throws errors when both attempts fail. [[1]](diffhunk://#diff-546b2b85a644a00180cf5f33b8b7353235a65378cf1e7440c8a5a47fb84e166cL97-R122) [[2]](diffhunk://#diff-546b2b85a644a00180cf5f33b8b7353235a65378cf1e7440c8a5a47fb84e166cL173-R191)