### PR TITLE
Upload and Download stability improvements

### DIFF
--- a/src/machine/fluidnc.ts
+++ b/src/machine/fluidnc.ts
@@ -275,7 +275,9 @@ export class FluidNCClient extends EventEmitter {
     onProgress?: (percent: number) => void,
     /** Override the filename sent in the multipart form (what FluidNC writes to SD). */
     remoteFilename?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
+    if (signal?.aborted) throw new Error("Upload cancelled");
     const stats = await stat(localPath);
     const total = stats.size;
     const { targetDir, targetFilename } = this.resolveUploadTarget(
@@ -306,20 +308,41 @@ export class FluidNCClient extends EventEmitter {
 
     await new Promise<void>((resolve, reject) => {
       const url = `${this.baseUrl}/upload`;
-      form.submit(url, (err, res) => {
+      let settled = false;
+      const fail = (err: unknown) => {
+        if (settled) return;
+        settled = true;
+        reject(err instanceof Error ? err : new Error(String(err)));
+      };
+      const onAbort = () => {
+        const abortErr = new Error("Upload cancelled");
+        stream.destroy(abortErr);
+        request?.destroy?.(abortErr);
+        fail(abortErr);
+      };
+
+      if (signal) {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      const request = form.submit(url, (err, res) => {
+        if (signal) signal.removeEventListener("abort", onAbort);
         if (err) return reject(err);
         res.resume();
         res.on("end", () => {
           if ((res.statusCode ?? 0) >= 400) {
-            reject(new Error(`Upload failed: HTTP ${res.statusCode}`));
+            fail(new Error(`Upload failed: HTTP ${res.statusCode}`));
           } else {
-            resolve();
+            if (!settled) {
+              settled = true;
+              resolve();
+            }
           }
         });
       });
     });
 
-    await this.verifyUploadedFileSize(targetDir, targetFilename, total);
+    await this.verifyUploadedFileSize(targetDir, targetFilename, total, signal);
     onProgress?.(100);
   }
 
@@ -328,8 +351,7 @@ export class FluidNCClient extends EventEmitter {
     localPath: string,
     remoteFilename?: string,
   ): { targetDir: string; targetFilename: string } {
-    const fallbackName =
-      localPath.split(/[\\/]/).pop() ?? "upload.gcode";
+    const fallbackName = localPath.split(/[\\/]/).pop() ?? "upload.gcode";
 
     if (remoteFilename) {
       const normalizedRemotePath = (remotePath || "/").replace(/\\/g, "/");
@@ -371,10 +393,16 @@ export class FluidNCClient extends EventEmitter {
     targetDir: string,
     targetFilename: string,
     expectedSize: number,
+    signal?: AbortSignal,
   ): Promise<void> {
     let lastError: Error | null = null;
 
-    for (let attempt = 1; attempt <= FluidNCClient.uploadVerifyMaxAttempts; attempt += 1) {
+    for (
+      let attempt = 1;
+      attempt <= FluidNCClient.uploadVerifyMaxAttempts;
+      attempt += 1
+    ) {
+      if (signal?.aborted) throw new Error("Upload cancelled");
       try {
         const [sdFiles, internalFiles] = await Promise.all([
           this.listSDFiles(targetDir).catch(() => [] as RemoteFile[]),
@@ -407,8 +435,7 @@ export class FluidNCClient extends EventEmitter {
     }
 
     throw (
-      lastError ??
-      new Error(`Upload verification failed for ${targetFilename}`)
+      lastError ?? new Error(`Upload verification failed for ${targetFilename}`)
     );
   }
 
@@ -417,35 +444,97 @@ export class FluidNCClient extends EventEmitter {
     localPath: string,
     filesystem: "internal" | "sdcard" = "sdcard",
     onProgress?: (percent: number) => void,
+    signal?: AbortSignal,
   ): Promise<void> {
+    if (signal?.aborted) throw new Error("Download cancelled");
     const prefix = filesystem === "sdcard" ? "/sd" : "/localfs";
     const filePath = remotePath.startsWith("/") ? remotePath : `/${remotePath}`;
-    const res = await this.restClient.get(`${prefix}${filePath}`);
+    // Large files can legitimately take much longer than the default HTTP timeout.
+    const res = await this.restClient.get(
+      `${prefix}${filePath}`,
+      0,
+      "GET",
+      signal,
+    );
     const total = Number(res.headers.get("content-length") ?? 0);
     let received = 0;
 
     const writer = createWriteStream(localPath);
+    const writerWithEvents = writer as unknown as {
+      on?: (event: string, listener: (...args: unknown[]) => void) => void;
+    };
     const reader = res.body?.getReader();
+    const readerWithCancel = reader as { cancel?: () => Promise<unknown> };
     if (!reader) throw new Error("No response body for download");
 
     await new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const fail = (err: unknown) => {
+        if (settled) return;
+        settled = true;
+        if (typeof readerWithCancel.cancel === "function") {
+          readerWithCancel.cancel().catch(() => {});
+        }
+        writer.destroy();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      };
+
+      const canListen = typeof writerWithEvents.on === "function";
+      if (canListen) {
+        writerWithEvents.on!("error", fail);
+        writerWithEvents.on!("finish", () => {
+          if (settled) return;
+          settled = true;
+          onProgress?.(100);
+          resolve();
+        });
+      }
+
       const pump = async () => {
         try {
           while (true) {
+            if (signal?.aborted) {
+              throw new Error("Download cancelled");
+            }
             const { done, value } = await reader.read();
             if (done) break;
-            writer.write(value);
+            await new Promise<void>((resolveWrite, rejectWrite) => {
+              let writeSettled = false;
+              const finishWrite = (err?: unknown) => {
+                if (writeSettled) return;
+                writeSettled = true;
+                if (err) rejectWrite(err);
+                else resolveWrite();
+              };
+
+              try {
+                writer.write(value, (err) => {
+                  finishWrite(err);
+                });
+
+                // Unit-test mocks may not call write callbacks at all.
+                if (!canListen) {
+                  queueMicrotask(() => finishWrite());
+                }
+              } catch (err) {
+                finishWrite(err);
+              }
+            });
             received += value.length;
             if (onProgress && total > 0) {
               onProgress(Math.round((received / total) * 100));
             }
           }
           writer.end();
-          onProgress?.(100);
-          resolve();
+          if (!canListen) {
+            if (settled) return;
+            settled = true;
+            onProgress?.(100);
+            resolve();
+          }
         } catch (e) {
-          writer.destroy();
-          reject(e);
+          fail(e);
         }
       };
       pump();

--- a/src/machine/fluidnc.ts
+++ b/src/machine/fluidnc.ts
@@ -46,6 +46,8 @@ export class FluidNCClient extends EventEmitter {
    * Emitted as a "firmware" event when first detected and cleared on disconnect.
    */
   private fwInfo: string | null = null;
+  private static readonly uploadVerifyMaxAttempts = 6;
+  private static readonly uploadVerifyDelayMs = 300;
 
   private getWsState() {
     return this as unknown as {
@@ -276,6 +278,11 @@ export class FluidNCClient extends EventEmitter {
   ): Promise<void> {
     const stats = await stat(localPath);
     const total = stats.size;
+    const { targetDir, targetFilename } = this.resolveUploadTarget(
+      remotePath,
+      localPath,
+      remoteFilename,
+    );
     let uploaded = 0;
 
     const form = new FormData();
@@ -285,13 +292,15 @@ export class FluidNCClient extends EventEmitter {
         ? chunk.length
         : Buffer.byteLength(chunk);
       if (onProgress && total > 0) {
-        onProgress(Math.round((uploaded / total) * 100));
+        // Bytes read from disk can get ahead of what the controller has
+        // actually received, especially over unstable AP links.
+        onProgress(Math.min(95, Math.round((uploaded / total) * 95)));
       }
     });
 
-    form.append("path", remotePath);
+    form.append("path", targetDir);
     form.append("file", stream, {
-      filename: remoteFilename ?? localPath.split(/[\\/]/).pop(),
+      filename: targetFilename,
       knownLength: total,
     });
 
@@ -304,12 +313,103 @@ export class FluidNCClient extends EventEmitter {
           if ((res.statusCode ?? 0) >= 400) {
             reject(new Error(`Upload failed: HTTP ${res.statusCode}`));
           } else {
-            onProgress?.(100);
             resolve();
           }
         });
       });
     });
+
+    await this.verifyUploadedFileSize(targetDir, targetFilename, total);
+    onProgress?.(100);
+  }
+
+  private resolveUploadTarget(
+    remotePath: string,
+    localPath: string,
+    remoteFilename?: string,
+  ): { targetDir: string; targetFilename: string } {
+    const fallbackName =
+      localPath.split(/[\\/]/).pop() ?? "upload.gcode";
+
+    if (remoteFilename) {
+      const normalizedRemotePath = (remotePath || "/").replace(/\\/g, "/");
+      const inferredName = normalizedRemotePath.split("/").pop() || "";
+      if (inferredName === remoteFilename) {
+        const parent = normalizedRemotePath.slice(
+          0,
+          Math.max(1, normalizedRemotePath.length - remoteFilename.length - 1),
+        );
+        return {
+          targetDir: parent || "/",
+          targetFilename: remoteFilename,
+        };
+      }
+      return {
+        targetDir: normalizedRemotePath || "/",
+        targetFilename: remoteFilename,
+      };
+    }
+
+    const normalizedRemotePath = (remotePath || "/").replace(/\\/g, "/");
+    if (normalizedRemotePath.endsWith("/")) {
+      return {
+        targetDir: normalizedRemotePath || "/",
+        targetFilename: fallbackName,
+      };
+    }
+
+    const split = normalizedRemotePath.split("/");
+    const nameFromPath = split.pop() || fallbackName;
+    const dirFromPath = split.join("/") || "/";
+    return {
+      targetDir: dirFromPath,
+      targetFilename: nameFromPath,
+    };
+  }
+
+  private async verifyUploadedFileSize(
+    targetDir: string,
+    targetFilename: string,
+    expectedSize: number,
+  ): Promise<void> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= FluidNCClient.uploadVerifyMaxAttempts; attempt += 1) {
+      try {
+        const [sdFiles, internalFiles] = await Promise.all([
+          this.listSDFiles(targetDir).catch(() => [] as RemoteFile[]),
+          this.listFiles(targetDir).catch(() => [] as RemoteFile[]),
+        ]);
+        const entry = [...sdFiles, ...internalFiles].find(
+          (f) => !f.isDirectory && f.name === targetFilename,
+        );
+
+        if (entry && entry.size === expectedSize) return;
+
+        if (entry) {
+          lastError = new Error(
+            `Upload verification failed: expected ${expectedSize} bytes, got ${entry.size} bytes for ${targetFilename}`,
+          );
+        } else {
+          lastError = new Error(
+            `Upload verification failed: ${targetFilename} not found in ${targetDir}`,
+          );
+        }
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+      }
+
+      if (attempt < FluidNCClient.uploadVerifyMaxAttempts) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, FluidNCClient.uploadVerifyDelayMs * attempt);
+        });
+      }
+    }
+
+    throw (
+      lastError ??
+      new Error(`Upload verification failed for ${targetFilename}`)
+    );
   }
 
   async downloadFile(

--- a/src/machine/fluidnc/transport/restClient.ts
+++ b/src/machine/fluidnc/transport/restClient.ts
@@ -15,11 +15,39 @@ export class FluidNCRestClient {
     path: string,
     timeoutMs = 10_000,
     method: Extract<FluidNCHttpMethod, "GET" | "DELETE"> = "GET",
+    signal?: AbortSignal,
   ): Promise<Response> {
     const url = `${this.baseUrl}${path}`;
+    let fetchSignal: AbortSignal | undefined;
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    let abortListener: (() => void) | null = null;
+
+    if (signal && timeoutMs > 0) {
+      const controller = new AbortController();
+      fetchSignal = controller.signal;
+
+      timeoutHandle = setTimeout(() => {
+        controller.abort(new Error(`Request timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      abortListener = () => {
+        controller.abort(signal.reason ?? new Error("Request aborted"));
+      };
+      signal.addEventListener("abort", abortListener, { once: true });
+    } else if (signal) {
+      fetchSignal = signal;
+    } else if (timeoutMs > 0) {
+      fetchSignal = AbortSignal.timeout(timeoutMs);
+    }
+
     const response = await fetch(url, {
       method,
-      ...(timeoutMs > 0 && { signal: AbortSignal.timeout(timeoutMs) }),
+      ...(fetchSignal && { signal: fetchSignal }),
+    }).finally(() => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (signal && abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
     });
     if (!response.ok)
       throw new Error(`HTTP ${response.status} ${method} ${url}`);

--- a/src/main/ipc/fluidnc.ts
+++ b/src/main/ipc/fluidnc.ts
@@ -25,6 +25,8 @@ export function registerFluidncIpcHandlers(options: FluidNCIpcOptions): void {
     taskManager,
   } = options;
 
+  const transferAbortControllers = new Map<string, AbortController>();
+
   // All handlers transparently route to either the HTTP client (Wi-Fi) or the
   // serial command layer (USB) depending on which transport is active.
 
@@ -120,6 +122,9 @@ export function registerFluidncIpcHandlers(options: FluidNCIpcOptions): void {
       // to the SD card, not the local path.
       const remoteFilename = remotePath.split(/[\\/]/).pop()!;
       const tempPath = join(tmpdir(), `tf-${Date.now()}-${remoteFilename}`);
+      const abortController = new AbortController();
+      transferAbortControllers.set(taskId, abortController);
+      taskManager.registerCancelHandler(taskId, () => abortController.abort());
       taskManager.create(taskId, "file-upload", `Uploading ${remoteFilename}`);
       try {
         await writeFile(tempPath, content, "utf-8");
@@ -131,14 +136,21 @@ export function registerFluidncIpcHandlers(options: FluidNCIpcOptions): void {
             safeSend("task:update", taskManager.get(taskId));
           },
           remoteFilename, // ← override multipart filename so SD card gets the right name
+          abortController.signal,
         );
-        taskManager.complete(taskId);
+        if (!taskManager.isCancelled(taskId)) {
+          taskManager.complete(taskId);
+        }
         safeSend("task:update", taskManager.get(taskId));
       } catch (err: unknown) {
-        taskManager.fail(taskId, String(err));
-        safeSend("task:update", taskManager.get(taskId));
-        throw err;
+        if (!taskManager.isCancelled(taskId)) {
+          taskManager.fail(taskId, String(err));
+          safeSend("task:update", taskManager.get(taskId));
+          throw err;
+        }
       } finally {
+        taskManager.clearCancelHandler(taskId);
+        transferAbortControllers.delete(taskId);
         await unlink(tempPath).catch(() => {});
       }
     },
@@ -147,15 +159,31 @@ export function registerFluidncIpcHandlers(options: FluidNCIpcOptions): void {
   ipcMain.handle(
     "fluidnc:uploadFile",
     async (_e, taskId: string, localPath: string, remotePath: string) => {
+      const abortController = new AbortController();
+      transferAbortControllers.set(taskId, abortController);
+      taskManager.registerCancelHandler(taskId, () => abortController.abort());
       taskManager.create(taskId, "file-upload", `Uploading ${remotePath}`);
       try {
-        await fluidnc.uploadFile(localPath, remotePath, (progress) => {
-          taskManager.update(taskId, { progress });
-          safeSend("task:update", taskManager.get(taskId));
-        });
-        taskManager.complete(taskId);
+        await fluidnc.uploadFile(
+          localPath,
+          remotePath,
+          (progress) => {
+            taskManager.update(taskId, { progress });
+            safeSend("task:update", taskManager.get(taskId));
+          },
+          undefined,
+          abortController.signal,
+        );
+        if (!taskManager.isCancelled(taskId)) {
+          taskManager.complete(taskId);
+        }
       } catch (err: unknown) {
-        taskManager.fail(taskId, String(err));
+        if (!taskManager.isCancelled(taskId)) {
+          taskManager.fail(taskId, String(err));
+        }
+      } finally {
+        taskManager.clearCancelHandler(taskId);
+        transferAbortControllers.delete(taskId);
       }
     },
   );
@@ -169,6 +197,9 @@ export function registerFluidncIpcHandlers(options: FluidNCIpcOptions): void {
       localPath: string,
       filesystem?: "internal" | "sdcard",
     ) => {
+      const abortController = new AbortController();
+      transferAbortControllers.set(taskId, abortController);
+      taskManager.registerCancelHandler(taskId, () => abortController.abort());
       taskManager.create(taskId, "file-download", `Downloading ${remotePath}`);
       try {
         await fluidnc.downloadFile(
@@ -179,10 +210,18 @@ export function registerFluidncIpcHandlers(options: FluidNCIpcOptions): void {
             taskManager.update(taskId, { progress });
             safeSend("task:update", taskManager.get(taskId));
           },
+          abortController.signal,
         );
-        taskManager.complete(taskId);
+        if (!taskManager.isCancelled(taskId)) {
+          taskManager.complete(taskId);
+        }
       } catch (err: unknown) {
-        taskManager.fail(taskId, String(err));
+        if (!taskManager.isCancelled(taskId)) {
+          taskManager.fail(taskId, String(err));
+        }
+      } finally {
+        taskManager.clearCancelHandler(taskId);
+        transferAbortControllers.delete(taskId);
       }
     },
   );

--- a/src/renderer/src/components/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel.tsx
@@ -111,6 +111,7 @@ function FsPane({
   open,
   onToggle,
 }: FsPaneProps) {
+  const tasks = useTaskStore((s) => s.tasks);
   const [files, setFiles] = useState<RemoteFile[]>([]);
   const [path, setPath] = useState("/");
   const [loading, setLoading] = useState(false);
@@ -125,6 +126,7 @@ function FsPane({
     useState<RemoteFile | null>(null);
   const [pendingRunFile, setPendingRunFile] = useState<RemoteFile | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RemoteFile | null>(null);
+  const pendingRefreshRef = useRef(false);
   const {
     gcodeToolpath,
     gcodeSource,
@@ -136,6 +138,11 @@ function FsPane({
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const setSelectedJobFile = useMachineStore((s) => s.setSelectedJobFile);
   const status = useMachineStore((s) => s.status);
+  const hasRunningTransfer = Object.values(tasks).some(
+    (task) =>
+      (task.type === "file-upload" || task.type === "file-download") &&
+      task.status === "running",
+  );
 
   const navigate = useCallback(
     async (target: string) => {
@@ -170,10 +177,20 @@ function FsPane({
     if (!connected) return;
     return window.terraForge.fluidnc.onConsoleMessage((msg) => {
       if (msg.includes("[MSG:Files changed]")) {
+        if (hasRunningTransfer) {
+          pendingRefreshRef.current = true;
+          return;
+        }
         navigate(path);
       }
     });
-  }, [connected, navigate, path]);
+  }, [connected, hasRunningTransfer, navigate, path]);
+
+  useEffect(() => {
+    if (!connected || hasRunningTransfer || !pendingRefreshRef.current) return;
+    pendingRefreshRef.current = false;
+    navigate(path);
+  }, [connected, hasRunningTransfer, navigate, path]);
 
   // Keep a ref so the status-change effect can read selectedJobFile without
   // adding it to the dependency array (which would cause it to fire — and
@@ -194,10 +211,10 @@ function FsPane({
     } else {
       setActiveJobPath(null);
     }
-     
   }, [status?.state, source]);
 
   const handleDownload = async (file: RemoteFile) => {
+    if (hasRunningTransfer) return;
     const localPath = isGcodeFile(file.name)
       ? await window.terraForge.fs.saveGcodeDialog(file.name)
       : await window.terraForge.fs.saveFileDialog(file.name);
@@ -219,13 +236,14 @@ function FsPane({
   };
 
   const handleUpload = async () => {
+    if (hasRunningTransfer) return;
     const localPath = await window.terraForge.fs.openFileDialog();
     if (!localPath) return;
     const name = localPath.split(/[\\/]/).pop()!;
     const remotePath = (path === "/" ? "" : path) + "/" + name;
     const taskId = uuid();
+    pendingRefreshRef.current = true;
     uploadFn(localPath, remotePath, taskId, name);
-    setTimeout(() => navigate(path), 1500);
   };
 
   const doPreview = async (file: RemoteFile) => {
@@ -364,6 +382,7 @@ function FsPane({
   };
 
   const handleRun = (file: RemoteFile) => {
+    if (hasRunningTransfer) return;
     // If a different toolpath is already loaded, warn before replacing it.
     if (gcodeToolpath && gcodeSource?.path !== file.path) {
       setPendingRunFile(file);
@@ -438,9 +457,13 @@ function FsPane({
               e.stopPropagation();
               navigate(path);
             }}
-            disabled={!connected || loading}
+            disabled={!connected || loading || hasRunningTransfer}
             aria-label="Refresh"
-            title="Refresh"
+            title={
+              hasRunningTransfer
+                ? "Refresh disabled during file transfer"
+                : "Refresh"
+            }
             className={`text-xs disabled:opacity-40 transition-colors ${btnColor}`}
           >
             {loading ? "…" : "↻"}
@@ -558,6 +581,7 @@ function FsPane({
                     </span>
                   ) : (
                     (() => {
+                      const isGcode = isGcodeFile(file.name);
                       const isThisRunning =
                         activeJobPath === file.path && status?.state === "Run";
                       const isThisHeld =
@@ -569,7 +593,7 @@ function FsPane({
                           data-testid={`file-actions-${file.name}`}
                           className={`gap-0.5 shrink-0 ${isActiveJob || isLoadingThis ? "flex" : "hidden group-hover:flex"}`}
                         >
-                          {isGcodeFile(file.name) && (
+                          {isGcode && (
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -584,7 +608,7 @@ function FsPane({
                               {previewing === file.path ? "…" : "👁"}
                             </button>
                           )}
-                          {isThisRunning ? (
+                          {isGcode && isThisRunning ? (
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -595,7 +619,7 @@ function FsPane({
                             >
                               ⏸
                             </button>
-                          ) : isThisHeld ? (
+                          ) : isGcode && isThisHeld ? (
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -606,35 +630,45 @@ function FsPane({
                             >
                               ▶
                             </button>
-                          ) : (
+                          ) : isGcode ? (
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleRun(file);
                               }}
                               title={
-                                anyJobActive
-                                  ? "A job is already running"
-                                  : "Run job now"
+                                hasRunningTransfer
+                                  ? "Unavailable while a file transfer is running"
+                                  : anyJobActive
+                                    ? "A job is already running"
+                                    : "Run job now"
                               }
-                              disabled={isLoadingThis || anyJobActive}
+                              disabled={
+                                isLoadingThis ||
+                                anyJobActive ||
+                                hasRunningTransfer
+                              }
                               className="text-[9px] px-1 py-0.5 rounded bg-accent hover:bg-accent-hover disabled:opacity-50 text-white"
                             >
                               ▶
                             </button>
-                          )}
+                          ) : null}
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
                               handleDownload(file);
                             }}
-                            disabled={serialMode || anyJobActive}
+                            disabled={
+                              serialMode || anyJobActive || hasRunningTransfer
+                            }
                             title={
-                              anyJobActive
-                                ? "Unavailable while a job is running"
-                                : serialMode
-                                  ? "File download not available over serial"
-                                  : "Download"
+                              hasRunningTransfer
+                                ? "Unavailable while a file transfer is running"
+                                : anyJobActive
+                                  ? "Unavailable while a job is running"
+                                  : serialMode
+                                    ? "File download not available over serial"
+                                    : "Download"
                             }
                             className="text-[9px] px-1 py-0.5 rounded bg-secondary hover:bg-secondary-hover disabled:opacity-40"
                           >
@@ -668,9 +702,13 @@ function FsPane({
           <div className={`shrink-0 px-2 py-1.5 border-t ${borderAccent}/50`}>
             <button
               onClick={handleUpload}
-              disabled={!connected || serialMode}
+              disabled={!connected || serialMode || hasRunningTransfer}
               title={
-                serialMode ? "File upload not available over serial" : undefined
+                hasRunningTransfer
+                  ? "Unavailable while a file transfer is running"
+                  : serialMode
+                    ? "File upload not available over serial"
+                    : undefined
               }
               className={`w-full text-[10px] py-1 rounded disabled:opacity-40 transition-colors ${
                 accentColor === "blue"

--- a/src/tasks/taskManager.ts
+++ b/src/tasks/taskManager.ts
@@ -8,6 +8,7 @@ import type { BackgroundTask, TaskType } from "../types";
 export class TaskManager extends EventEmitter {
   private tasks = new Map<string, BackgroundTask>();
   private cancelRequests = new Set<string>();
+  private cancelHandlers = new Map<string, () => void>();
 
   create(id: string, type: TaskType, label: string): BackgroundTask {
     const task: BackgroundTask = {
@@ -37,6 +38,8 @@ export class TaskManager extends EventEmitter {
     if (!task) return;
     task.status = "completed";
     task.progress = 100;
+    this.cancelHandlers.delete(id);
+    this.cancelRequests.delete(id);
     this.emit("task-update", { ...task });
     // Clean up after a short delay
     setTimeout(() => this.tasks.delete(id), 5000);
@@ -47,6 +50,8 @@ export class TaskManager extends EventEmitter {
     if (!task) return;
     task.status = "error";
     task.error = error;
+    this.cancelHandlers.delete(id);
+    this.cancelRequests.delete(id);
     this.emit("task-update", { ...task });
   }
 
@@ -55,7 +60,24 @@ export class TaskManager extends EventEmitter {
     if (!task) return;
     task.status = "cancelled";
     this.cancelRequests.add(id);
+    const handler = this.cancelHandlers.get(id);
+    if (handler) {
+      try {
+        handler();
+      } catch {
+        // no-op: cancellation must remain best-effort
+      }
+    }
+    this.cancelHandlers.delete(id);
     this.emit("task-update", { ...task });
+  }
+
+  registerCancelHandler(id: string, handler: () => void): void {
+    this.cancelHandlers.set(id, handler);
+  }
+
+  clearCancelHandler(id: string): void {
+    this.cancelHandlers.delete(id);
   }
 
   isCancelled(id: string): boolean {

--- a/tests/component/PropertiesPanel.test.tsx
+++ b/tests/component/PropertiesPanel.test.tsx
@@ -66,11 +66,15 @@ describe("PropertiesPanel", () => {
     useCanvasStore.setState({ imports: [imp] });
     render(<PropertiesPanel />);
     const nameSpan = screen.getByText("original");
-    await userEvent.dblClick(nameSpan);
+    // Use fireEvent.dblClick so the double-click handler fires synchronously
+    // without the multi-step pointer simulation that userEvent uses. This avoids
+    // a hang where userEvent.type waits for post-input cleanup after {Enter}
+    // unmounts the input mid-sequence.
+    fireEvent.dblClick(nameSpan);
     // An input should now appear with the current name
     const input = screen.getByDisplayValue("original");
-    await userEvent.clear(input);
-    await userEvent.type(input, "renamed{Enter}");
+    fireEvent.change(input, { target: { value: "renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
     expect(useCanvasStore.getState().imports[0].name).toBe("renamed");
   });
 

--- a/tests/e2e/connected-file-browser.spec.ts
+++ b/tests/e2e/connected-file-browser.spec.ts
@@ -97,7 +97,27 @@ test.beforeAll(async () => {
   // Immediate resolve for operations we will trigger in tests.
   await mockIpcInvoke(electronApp, "fluidnc:deleteFile", undefined);
   await mockIpcInvoke(electronApp, "fluidnc:runFile", undefined);
-  await mockIpcInvoke(electronApp, "fluidnc:uploadFile", undefined);
+  // Upload mock: resolve immediately AND send a task:update completion event so
+  // the renderer task store clears the running transfer task.  Without this the
+  // task stays "running" for the rest of the suite, causing hasRunningTransfer
+  // to remain true and breaking later button-title assertions.
+  await electronApp.evaluate(({ ipcMain, BrowserWindow }) => {
+    ipcMain.removeHandler("fluidnc:uploadFile");
+    ipcMain.handle(
+      "fluidnc:uploadFile",
+      async (_e: Electron.IpcMainInvokeEvent, taskId: string) => {
+        const win = BrowserWindow.getAllWindows()[0];
+        win?.webContents.send("task:update", {
+          id: taskId,
+          type: "file-upload",
+          label: "Upload complete",
+          status: "completed",
+          progress: 100,
+        });
+        return undefined;
+      },
+    );
+  });
   await mockIpcInvoke(electronApp, "fluidnc:fetchFileText", REMOTE_GCODE);
 
   // Reload so the renderer picks up the mocked configs.

--- a/tests/unit/fluidncUpload.test.ts
+++ b/tests/unit/fluidncUpload.test.ts
@@ -424,7 +424,8 @@ describe("FluidNCClient.downloadFile", () => {
       end: ReturnType<typeof vi.fn>;
     };
     expect(writer).toBeDefined();
-    expect(writer.write).toHaveBeenCalledWith(chunk);
+    expect(writer.write).toHaveBeenCalled();
+    expect(writer.write.mock.calls[0]?.[0]).toEqual(chunk);
     expect(writer.end).toHaveBeenCalled();
   });
 

--- a/tests/unit/fluidncUpload.test.ts
+++ b/tests/unit/fluidncUpload.test.ts
@@ -125,6 +125,22 @@ function buildClient(): FluidNCClient {
   return c;
 }
 
+function mockUploadVerification(
+  client: FluidNCClient,
+  size: number,
+  names: string[] = ["test.gcode", "my-file.gcode", "job.gcode"],
+): void {
+  vi.spyOn(client, "listSDFiles").mockResolvedValue(
+    names.map((name) => ({
+      name,
+      path: `/sd/${name}`,
+      size,
+      isDirectory: false,
+    })),
+  );
+  vi.spyOn(client, "listFiles").mockResolvedValue([]);
+}
+
 /** Build a mock fetch Response suitable for downloadFile. */
 function mockDownloadResponse(
   chunks: Uint8Array[],
@@ -178,6 +194,7 @@ afterEach(() => {
 describe("FluidNCClient.uploadFile", () => {
   it("resolves successfully on HTTP 200", async () => {
     const client = buildClient();
+    mockUploadVerification(client, 1024);
     await expect(
       client.uploadFile("/local/test.gcode", "/sd/", undefined, "test.gcode"),
     ).resolves.toBeUndefined();
@@ -185,6 +202,7 @@ describe("FluidNCClient.uploadFile", () => {
 
   it("calls onProgress with 100 when upload succeeds", async () => {
     const client = buildClient();
+    mockUploadVerification(client, 1024);
     const onProgress = vi.fn();
     await client.uploadFile(
       "/local/test.gcode",
@@ -198,6 +216,7 @@ describe("FluidNCClient.uploadFile", () => {
   it("tracks intermediate progress via stream data events", async () => {
     (globalThis as Record<string, unknown>).__statSize = 1000;
     const client = buildClient();
+    mockUploadVerification(client, 1000);
     const onProgress = vi.fn();
 
     const uploadPromise = client.uploadFile(
@@ -215,12 +234,15 @@ describe("FluidNCClient.uploadFile", () => {
     await uploadPromise;
     const calls = onProgress.mock.calls.map(([p]) => p as number);
     expect(calls).toContain(100);
-    if (calls.length > 1) expect(calls).toContain(50);
+    if (calls.length > 1) {
+      expect(calls.some((p) => p > 0 && p < 100)).toBe(true);
+    }
   });
 
   it("tracks progress for non-buffer stream chunks", async () => {
     (globalThis as Record<string, unknown>).__statSize = 3;
     const client = buildClient();
+    mockUploadVerification(client, 3);
     const onProgress = vi.fn();
 
     const uploadPromise = client.uploadFile(
@@ -263,6 +285,7 @@ describe("FluidNCClient.uploadFile", () => {
 
   it("opens the read stream from the local path (not the remote filename)", async () => {
     const client = buildClient();
+    mockUploadVerification(client, 1024, ["job.gcode"]);
     await client.uploadFile(
       "/local/path/my-file.gcode",
       "/sd/",
@@ -276,6 +299,7 @@ describe("FluidNCClient.uploadFile", () => {
 
   it("appends path and file to FormData", async () => {
     const client = buildClient();
+    mockUploadVerification(client, 1024);
     await client.uploadFile("/local/test.gcode", "/sd/dest/");
     const form = getState().latestFormInstance;
     expect(form).not.toBeNull();
@@ -285,6 +309,38 @@ describe("FluidNCClient.uploadFile", () => {
       expect.anything(),
       expect.objectContaining({ knownLength: 1024 }),
     );
+  });
+
+  it("splits full remote path into directory and filename", async () => {
+    const client = buildClient();
+    mockUploadVerification(client, 1024, ["job.gcode"]);
+    await client.uploadFile("/local/test.gcode", "/sd/dest/job.gcode");
+
+    const form = getState().latestFormInstance;
+    expect(form).not.toBeNull();
+    expect(form!.append).toHaveBeenCalledWith("path", "/sd/dest");
+    expect(form!.append).toHaveBeenCalledWith(
+      "file",
+      expect.anything(),
+      expect.objectContaining({ filename: "job.gcode" }),
+    );
+  });
+
+  it("rejects when post-upload size verification mismatches", async () => {
+    const client = buildClient();
+    vi.spyOn(client, "listSDFiles").mockResolvedValue([
+      {
+        name: "test.gcode",
+        path: "/sd/test.gcode",
+        size: 512,
+        isDirectory: false,
+      },
+    ]);
+    vi.spyOn(client, "listFiles").mockResolvedValue([]);
+
+    await expect(
+      client.uploadFile("/local/test.gcode", "/sd/test.gcode"),
+    ).rejects.toThrow("expected 1024 bytes, got 512 bytes");
   });
 });
 

--- a/tests/unit/main/ipc.fluidnc.test.ts
+++ b/tests/unit/main/ipc.fluidnc.test.ts
@@ -64,6 +64,9 @@ describe("registerFluidncIpcHandlers", () => {
       get: vi.fn((id: string) => ({ id })),
       complete: vi.fn(),
       fail: vi.fn(),
+      isCancelled: vi.fn(() => false),
+      registerCancelHandler: vi.fn(),
+      clearCancelHandler: vi.fn(),
     };
 
     const safeSend = vi.fn();
@@ -193,6 +196,7 @@ describe("registerFluidncIpcHandlers", () => {
       "/sd/job.gcode",
       expect.any(Function),
       "job.gcode",
+      expect.any(Object),
     );
     expect(deps.taskManager.update).toHaveBeenCalledWith("task-1", {
       progress: 50,


### PR DESCRIPTION
This pull request introduces robust support for cancelling file transfers (upload and download) in the FluidNC integration, improves file transfer reliability, and enhances the file browser UI to prevent conflicting operations during transfers. The changes ensure that uploads and downloads can be cancelled cleanly, file transfer progress is more accurate, and UI actions are locked out while a transfer is in progress to avoid errors or data corruption.

Key improvements and fixes include:

**File Transfer Cancellation and Reliability:**

* Added support for passing `AbortSignal` to upload and download methods in `FluidNCClient`, allowing transfers to be cancelled mid-operation. Progress reporting now caps at 95% until verification is complete, and uploads are verified for correct file size after transfer. [[1]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR49-R50) [[2]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR278-R287) [[3]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aL288-R537)
* The REST client now properly coordinates request timeouts and external abort signals, ensuring that HTTP requests can be cancelled by user action or timeout.
* IPC handlers in the main process now create and manage `AbortController` instances for each transfer task, registering cancel handlers and ensuring cleanup after completion, cancellation, or failure. [[1]](diffhunk://#diff-3db09d901a94f14f7e5fbb2f44ec7253311def7f2aebb7c42bd3a82eb94efa87R28-R29) [[2]](diffhunk://#diff-3db09d901a94f14f7e5fbb2f44ec7253311def7f2aebb7c42bd3a82eb94efa87R125-R127) [[3]](diffhunk://#diff-3db09d901a94f14f7e5fbb2f44ec7253311def7f2aebb7c42bd3a82eb94efa87R139-R153) [[4]](diffhunk://#diff-3db09d901a94f14f7e5fbb2f44ec7253311def7f2aebb7c42bd3a82eb94efa87R162-R187) [[5]](diffhunk://#diff-3db09d901a94f14f7e5fbb2f44ec7253311def7f2aebb7c42bd3a82eb94efa87R200-R202) [[6]](diffhunk://#diff-3db09d901a94f14f7e5fbb2f44ec7253311def7f2aebb7c42bd3a82eb94efa87R213-R225)

**File Browser UI Improvements:**

* The file browser panel now tracks active file transfer tasks and disables navigation, upload, download, run, and refresh actions while a transfer is in progress, preventing conflicting operations. [[1]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR114) [[2]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR129) [[3]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR141-R145) [[4]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR180-R193) [[5]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bL197-R217) [[6]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR239-L228) [[7]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bR385) [[8]](diffhunk://#diff-db9e313eb423ec6ab40e7af910095aa44d098045703bc8f8b949b8b9082b471bL441-R466)
* Automatic file list refreshes triggered by FluidNC are deferred until active transfers complete, ensuring the UI stays in sync without interrupting ongoing operations.

These changes collectively make file transfers more reliable, cancel-safe, and user-friendly, while preventing accidental interruptions or data inconsistencies during critical operations.