### PR TITLE
Use resolved URL from probe in rest client

### DIFF
--- a/src/machine/fluidnc.ts
+++ b/src/machine/fluidnc.ts
@@ -648,6 +648,7 @@ export class FluidNCClient extends EventEmitter {
         // Use the resolved IP for all subsequent HTTP calls — Node's fetch
         // (undici) cannot resolve mDNS .local names on Windows.
         this.baseUrl = probeBaseUrl;
+        this.restClient.setBaseUrl(probeBaseUrl);
       }
 
       // Auto-detect via [ESP800] using the resolved IP.

--- a/tests/unit/fluidnc.test.ts
+++ b/tests/unit/fluidnc.test.ts
@@ -593,6 +593,33 @@ describe("FluidNCClient", () => {
     probeSpy.mockRestore();
   });
 
+  it("connectWebSocket updates REST base URL to resolved IP for subsequent commands", async () => {
+    const openWsSpy = vi
+      .spyOn(client as any, "openWs")
+      .mockImplementation(() => {});
+    const resolveHostSpy = vi
+      .spyOn(client as any, "resolveHost")
+      .mockResolvedValue("192.168.1.10");
+    const probeSpy = vi
+      .spyOn(client as any, "probeFirmwareVersion")
+      .mockResolvedValue({ major: 4, version: "4.0.1", wsPort: 80 });
+
+    await client.connectWebSocket("myplotter.local", 80);
+
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValueOnce(mockResponse("ok"));
+    await client.sendCommand("$H");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("http://192.168.1.10:80/command?commandText="),
+      expect.objectContaining({ method: "GET" }),
+    );
+
+    openWsSpy.mockRestore();
+    resolveHostSpy.mockRestore();
+    probeSpy.mockRestore();
+  });
+
   it("connectWebSocket emits firmware event on probe success", async () => {
     const openWsSpy = vi
       .spyOn(client as any, "openWs")


### PR DESCRIPTION
This pull request ensures that after resolving the IP address for a FluidNC device using mDNS, all subsequent REST commands use the resolved IP instead of the original hostname. This prevents issues on platforms like Windows where mDNS hostnames (e.g., `.local`) are not always resolvable by HTTP clients. The change is verified by a new unit test.

REST client behavior improvement:

* Updated `FluidNCClient` so that after resolving the device's IP address, the REST client's base URL is set to the resolved IP, ensuring all subsequent HTTP requests use the correct address.

Testing enhancements:

* Added a unit test in `fluidnc.test.ts` to verify that after connecting via WebSocket and resolving the hostname, REST commands are sent to the resolved IP address.