### PR TITLE
Add debug logging and machine config option to enable and disable it

### DIFF
--- a/src/machine/fluidnc.ts
+++ b/src/machine/fluidnc.ts
@@ -35,6 +35,7 @@ export class FluidNCClient extends EventEmitter {
   private wsPort = 80;
   private wsRetryDelay = 3000; // ms — doubles on each 503, resets on success
   private wsEnabled = false; // set false on disconnect to stop retry loop
+  private debugLoggingEnabled = false;
   /**
    * Firmware major version detected during connectWebSocket.
    * null = unknown (probe failed or not yet connected).
@@ -70,6 +71,15 @@ export class FluidNCClient extends EventEmitter {
     this.wsPort = port;
   }
 
+  setDebugLoggingEnabled(enabled: boolean): void {
+    this.debugLoggingEnabled = enabled;
+  }
+
+  private emitDebugConsole(message: string): void {
+    if (!this.debugLoggingEnabled) return;
+    this.emit("console", message);
+  }
+
   /**
    * Resolve a hostname to an IP address using Node's native DNS resolver,
    * which honours the system resolver (including mDNS/.local on Windows).
@@ -97,6 +107,17 @@ export class FluidNCClient extends EventEmitter {
   // ─── Commands ─────────────────────────────────────────────────────────────
 
   async sendCommand(cmd: string): Promise<string> {
+    // Keep raw command execution unchanged; this only makes log output readable
+    // and safe by escaping control characters and capping length.
+    const logCmd = cmd
+      .replace(/\r/g, "\\r")
+      .replace(/\n/g, "\\n")
+      .replace(
+        /[\x00-\x1F\x7F]/g,
+        (ch) => `\\x${ch.charCodeAt(0).toString(16).padStart(2, "0")}`,
+      )
+      .slice(0, 200);
+    const encodedCmd = encodeURIComponent(cmd);
     // FluidNC 3.x and 4.x require different command conventions.
     //
     // 3.x: POST /command with x-www-form-urlencoded body:
@@ -107,25 +128,54 @@ export class FluidNCClient extends EventEmitter {
     // Some builds still accept GET /command?plain=CMD, so for 4.x/unknown we
     // try commandText first (matching WebUI) and fall back to plain.
     if (this.fwMajor !== null && this.fwMajor < 4) {
+      this.emitDebugConsole(
+        `[terraForge] CMD HTTP POST /command commandText=${logCmd}`,
+      );
       const res = await this.restClient.post(
         "/command",
-        `commandText=${encodeURIComponent(cmd)}`,
+        `commandText=${encodedCmd}`,
       );
-      return res.text();
+      const body = await res.text();
+      const preview = body.trim().slice(0, 160).replace(/\n/g, "↵");
+      this.emitDebugConsole(
+        `[terraForge] CMD OK POST /command (${preview || "(empty)"})`,
+      );
+      return body;
     }
     // 4.x (or unknown — assume modern)
     try {
+      this.emitDebugConsole(
+        `[terraForge] CMD HTTP GET /command?commandText=${encodedCmd} (decoded: ${logCmd})`,
+      );
       const res = await this.restClient.get(
-        `/command?commandText=${encodeURIComponent(cmd)}`,
+        `/command?commandText=${encodedCmd}`,
         10_000,
       );
-      return res.text();
-    } catch {
+      const body = await res.text();
+      const preview = body.trim().slice(0, 160).replace(/\n/g, "↵");
+      this.emitDebugConsole(
+        `[terraForge] CMD OK GET commandText (${preview || "(empty)"})`,
+      );
+      return body;
+    } catch (error) {
+      this.emitDebugConsole(
+        `[terraForge] CMD RETRY GET plain (commandText failed: ${
+          error instanceof Error ? error.message : String(error)
+        })`,
+      );
+      this.emitDebugConsole(
+        `[terraForge] CMD HTTP GET /command?plain=${encodedCmd} (decoded: ${logCmd})`,
+      );
       const res = await this.restClient.get(
-        `/command?plain=${encodeURIComponent(cmd)}`,
+        `/command?plain=${encodedCmd}`,
         10_000,
       );
-      return res.text();
+      const body = await res.text();
+      const preview = body.trim().slice(0, 160).replace(/\n/g, "↵");
+      this.emitDebugConsole(
+        `[terraForge] CMD OK GET plain (${preview || "(empty)"})`,
+      );
+      return body;
     }
   }
 

--- a/src/main/config/persistence.ts
+++ b/src/main/config/persistence.ts
@@ -1,14 +1,17 @@
 import { existsSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
-import type { MachineConfig, PageSize, PenType } from "../../types";
+import type { AppConfig, MachineConfig, PageSize, PenType } from "../../types";
 
 export interface MainPersistence {
   configPath: string;
   pageSizesPath: string;
+  appConfigPath: string;
   loadConfigs: () => Promise<MachineConfig[]>;
   saveConfigs: (configs: MachineConfig[]) => Promise<void>;
   loadPageSizes: () => Promise<PageSize[]>;
+  loadAppConfig: () => Promise<AppConfig>;
+  saveAppConfig: (config: AppConfig) => Promise<void>;
 }
 
 export const DEFAULT_MACHINE_CONFIGS: MachineConfig[] = [
@@ -43,6 +46,10 @@ export const BUILT_IN_PAGE_SIZES: PageSize[] = [
   { id: "legal", name: "Legal", widthMM: 215.9, heightMM: 355.6 },
   { id: "tabloid", name: "Tabloid", widthMM: 279.4, heightMM: 431.8 },
 ];
+
+export const DEFAULT_APP_CONFIG: AppConfig = {
+  debugLoggingEnabled: false,
+};
 
 function cloneMachineConfigs(configs: MachineConfig[]): MachineConfig[] {
   return configs.map((config) => ({
@@ -105,6 +112,7 @@ function clonePageSizes(pageSizes: PageSize[]): PageSize[] {
 export function createPersistence(userDataPath: string): MainPersistence {
   const configPath = join(userDataPath, "machine-configs.json");
   const pageSizesPath = join(userDataPath, "page-sizes.json");
+  const appConfigPath = join(userDataPath, "app-config.json");
 
   async function loadConfigs(): Promise<MachineConfig[]> {
     if (!existsSync(configPath))
@@ -144,11 +152,34 @@ export function createPersistence(userDataPath: string): MainPersistence {
     }
   }
 
+  async function loadAppConfig(): Promise<AppConfig> {
+    if (!existsSync(appConfigPath)) return { ...DEFAULT_APP_CONFIG };
+    try {
+      const raw = await readFile(appConfigPath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<AppConfig>;
+      return {
+        debugLoggingEnabled:
+          typeof parsed.debugLoggingEnabled === "boolean"
+            ? parsed.debugLoggingEnabled
+            : DEFAULT_APP_CONFIG.debugLoggingEnabled,
+      };
+    } catch {
+      return { ...DEFAULT_APP_CONFIG };
+    }
+  }
+
+  async function saveAppConfig(config: AppConfig): Promise<void> {
+    await writeFile(appConfigPath, JSON.stringify(config, null, 2), "utf-8");
+  }
+
   return {
     configPath,
     pageSizesPath,
+    appConfigPath,
     loadConfigs,
     saveConfigs,
     loadPageSizes,
+    loadAppConfig,
+    saveAppConfig,
   };
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,9 +56,23 @@ registerConfigIpcHandlers({
   loadConfigs: persistence.loadConfigs,
   saveConfigs: persistence.saveConfigs,
   loadPageSizes: persistence.loadPageSizes,
+  loadAppConfig: persistence.loadAppConfig,
+  saveAppConfig: persistence.saveAppConfig,
+  onAppConfigSaved: (config) => {
+    fluidnc.setDebugLoggingEnabled(config.debugLoggingEnabled);
+  },
   pageSizesPath: persistence.pageSizesPath,
   builtInPageSizes: BUILT_IN_PAGE_SIZES,
 });
+
+void persistence
+  .loadAppConfig()
+  .then((config) => {
+    fluidnc.setDebugLoggingEnabled(config.debugLoggingEnabled);
+  })
+  .catch(() => {
+    fluidnc.setDebugLoggingEnabled(false);
+  });
 
 registerAppIpcHandlers();
 

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -1,6 +1,6 @@
 import { dialog, ipcMain, shell, type BrowserWindow } from "electron";
 import { readFile, writeFile } from "fs/promises";
-import type { MachineConfig, PageSize, PenType } from "../../types";
+import type { AppConfig, MachineConfig, PageSize, PenType } from "../../types";
 
 function defaultPenDownDelayMs(penType: PenType): number {
   switch (penType) {
@@ -50,6 +50,9 @@ interface ConfigIpcOptions {
   loadConfigs: () => Promise<MachineConfig[]>;
   saveConfigs: (configs: MachineConfig[]) => Promise<void>;
   loadPageSizes: () => Promise<PageSize[]>;
+  loadAppConfig: () => Promise<AppConfig>;
+  saveAppConfig: (config: AppConfig) => Promise<void>;
+  onAppConfigSaved?: (config: AppConfig) => void;
   pageSizesPath: string;
   builtInPageSizes: PageSize[];
 }
@@ -59,6 +62,9 @@ export function registerConfigIpcHandlers({
   loadConfigs,
   saveConfigs,
   loadPageSizes,
+  loadAppConfig,
+  saveAppConfig,
+  onAppConfigSaved,
   pageSizesPath,
   builtInPageSizes,
 }: ConfigIpcOptions): void {
@@ -79,6 +85,13 @@ export function registerConfigIpcHandlers({
   ipcMain.handle("config:deleteMachineConfig", async (_e, id: string) => {
     const configs = await loadConfigs();
     await saveConfigs(configs.filter((config) => config.id !== id));
+  });
+
+  ipcMain.handle("config:getAppConfig", () => loadAppConfig());
+
+  ipcMain.handle("config:saveAppConfig", async (_e, config: AppConfig) => {
+    await saveAppConfig(config);
+    onAppConfigSaved?.(config);
   });
 
   ipcMain.handle("config:exportConfigs", async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type {
   TerraForgeAPI,
+  AppConfig,
   MachineConfig,
   MachineStatus,
   RemoteFile,
@@ -170,6 +171,8 @@ const config: TerraForgeAPI["config"] = {
   getMachineConfigs: () => invoke<MachineConfig[]>("config:getMachineConfigs"),
   saveMachineConfig: (cfg) => invoke<void>("config:saveMachineConfig", cfg),
   deleteMachineConfig: (id) => invoke<void>("config:deleteMachineConfig", id),
+  getAppConfig: () => invoke<AppConfig>("config:getAppConfig"),
+  saveAppConfig: (cfg) => invoke<void>("config:saveAppConfig", cfg),
   exportConfigs: () => invoke<string | null>("config:exportConfigs"),
   importConfigs: () =>
     invoke<{ added: number; skipped: number }>("config:importConfigs"),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import { JogControls } from "./components/JogControls";
 import { useMachineStore } from "./store/machineStore";
 import { useTaskStore } from "./store/taskStore";
 import { useConsoleStore } from "./store/consoleStore";
+import { useAppConfigStore } from "./store/appConfigStore";
 import { useThemeStore, applyTheme } from "./store/themeStore";
 
 export default function App() {
@@ -18,6 +19,9 @@ export default function App() {
   const setFwInfo = useMachineStore((s) => s.setFwInfo);
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const appendLine = useConsoleStore((s) => s.appendLine);
+  const setDebugLoggingEnabled = useAppConfigStore(
+    (s) => s.setDebugLoggingEnabled,
+  );
   const theme = useThemeStore((s) => s.theme);
 
   // Keep <html> class in sync with theme store
@@ -73,6 +77,10 @@ export default function App() {
   useEffect(() => {
     // Load machine configs
     window.terraForge.config.getMachineConfigs().then(setConfigs);
+    window.terraForge.config
+      .getAppConfig()
+      .then((cfg) => setDebugLoggingEnabled(cfg.debugLoggingEnabled))
+      .catch(() => {});
 
     // Subscribe to status updates pushed from main process
     const offStatus = window.terraForge.fluidnc.onStatusUpdate(setStatus);
@@ -103,7 +111,15 @@ export default function App() {
       offFirmware();
       if (pingTimer) clearTimeout(pingTimer);
     };
-  }, [setConfigs, setStatus, setWsLive, setFwInfo, upsertTask, appendLine]);
+  }, [
+    setConfigs,
+    setStatus,
+    setWsLive,
+    setFwInfo,
+    upsertTask,
+    appendLine,
+    setDebugLoggingEnabled,
+  ]);
 
   return (
     <div className="flex flex-col h-screen bg-app text-content overflow-hidden">

--- a/src/renderer/src/components/MachineConfigDialog.tsx
+++ b/src/renderer/src/components/MachineConfigDialog.tsx
@@ -89,8 +89,14 @@ export function MachineConfigDialog({ onClose }: Props) {
   const enablePerPathPasses = useAppConfigStore(
     (state) => state.enablePerPathPasses,
   );
+  const debugLoggingEnabled = useAppConfigStore(
+    (state) => state.debugLoggingEnabled,
+  );
   const setEnablePerPathPasses = useAppConfigStore(
     (state) => state.setEnablePerPathPasses,
+  );
+  const setDebugLoggingEnabled = useAppConfigStore(
+    (state) => state.setDebugLoggingEnabled,
   );
 
   const {
@@ -287,6 +293,13 @@ export function MachineConfigDialog({ onClose }: Props) {
 
   const handleActivate = () => {
     if (selectedId) setActiveConfig(selectedId);
+  };
+
+  const handleDebugLoggingChange = (enabled: boolean) => {
+    setDebugLoggingEnabled(enabled);
+    void window.terraForge.config.saveAppConfig({
+      debugLoggingEnabled: enabled,
+    });
   };
 
   return (
@@ -729,7 +742,7 @@ export function MachineConfigDialog({ onClose }: Props) {
               </div>
             </div>
           ) : (
-            <div className="flex-1 overflow-y-auto p-6">
+            <div className="flex-1 overflow-y-auto p-6 space-y-6">
               <Section title="G-code Pass Settings">
                 <label className="flex items-start gap-3 cursor-pointer">
                   <input
@@ -747,6 +760,28 @@ export function MachineConfigDialog({ onClose }: Props) {
                     <p className="text-xs text-content-faint">
                       Off by default. When disabled, pass settings are managed
                       at the layer/colour level only.
+                    </p>
+                  </div>
+                </label>
+              </Section>
+
+              <Section title="Logging">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={debugLoggingEnabled}
+                    onChange={(e) =>
+                      handleDebugLoggingChange(e.currentTarget.checked)
+                    }
+                    className="mt-0.5 accent-accent"
+                  />
+                  <div className="space-y-1">
+                    <div className="text-sm text-content">
+                      Enable debug command logging in console
+                    </div>
+                    <p className="text-xs text-content-faint">
+                      Shows low-level command transport details (HTTP endpoint,
+                      retries, and response preview). Keep off for normal use.
                     </p>
                   </div>
                 </label>

--- a/src/renderer/src/store/appConfigStore.ts
+++ b/src/renderer/src/store/appConfigStore.ts
@@ -3,15 +3,20 @@ import { persist } from "zustand/middleware";
 
 interface AppConfigState {
   enablePerPathPasses: boolean;
+  debugLoggingEnabled: boolean;
   setEnablePerPathPasses: (enabled: boolean) => void;
+  setDebugLoggingEnabled: (enabled: boolean) => void;
 }
 
 export const useAppConfigStore = create<AppConfigState>()(
   persist(
     (set) => ({
       enablePerPathPasses: false,
+      debugLoggingEnabled: false,
       setEnablePerPathPasses: (enabled) =>
         set({ enablePerPathPasses: enabled }),
+      setDebugLoggingEnabled: (enabled) =>
+        set({ debugLoggingEnabled: enabled }),
     }),
     { name: "terraforge-app-config" },
   ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,11 @@ export interface MachineConfig {
   connection: MachineConnection;
 }
 
+export interface AppConfig {
+  /** Enables verbose debug command transport logs in the console panel. */
+  debugLoggingEnabled: boolean;
+}
+
 // ─── Pass Configuration ──────────────────────────────────────────────────────
 
 /**
@@ -470,6 +475,8 @@ export interface ConfigApi {
   getMachineConfigs: () => Promise<MachineConfig[]>;
   saveMachineConfig: (config: MachineConfig) => Promise<void>;
   deleteMachineConfig: (id: string) => Promise<void>;
+  getAppConfig: () => Promise<AppConfig>;
+  saveAppConfig: (config: AppConfig) => Promise<void>;
   /** Export all configs to a user-chosen .json file. Returns the path written, or null if cancelled. */
   exportConfigs: () => Promise<string | null>;
   /** Import configs from a .json file chosen by the user. Returns counts of added and skipped configs. */

--- a/tests/component/MachineConfigDialog.test.tsx
+++ b/tests/component/MachineConfigDialog.test.tsx
@@ -25,7 +25,10 @@ beforeEach(() => {
     wsLive: false,
     selectedJobFile: null,
   });
-  useAppConfigStore.setState({ enablePerPathPasses: false });
+  useAppConfigStore.setState({
+    enablePerPathPasses: false,
+    debugLoggingEnabled: false,
+  });
   vi.clearAllMocks();
   // listPorts is called on mount
   (
@@ -51,16 +54,33 @@ describe("MachineConfigDialog", () => {
         "Enable per-path pass overrides in the Properties panel",
       ),
     ).toBeInTheDocument();
-    const checkbox = screen.getByRole("checkbox");
+    const checkbox = screen.getByRole("checkbox", {
+      name: /Enable per-path pass overrides in the Properties panel/i,
+    });
     expect(checkbox).not.toBeChecked();
   });
 
   it("updates persisted app setting when per-path override checkbox toggled", async () => {
     render(<MachineConfigDialog onClose={onClose} />);
     await userEvent.click(screen.getByText("Application Configuration"));
-    const checkbox = screen.getByRole("checkbox");
+    const checkbox = screen.getByRole("checkbox", {
+      name: /Enable per-path pass overrides in the Properties panel/i,
+    });
     await userEvent.click(checkbox);
     expect(useAppConfigStore.getState().enablePerPathPasses).toBe(true);
+  });
+
+  it("saves debug logging setting when toggled", async () => {
+    render(<MachineConfigDialog onClose={onClose} />);
+    await userEvent.click(screen.getByText("Application Configuration"));
+    const checkbox = screen.getByRole("checkbox", {
+      name: /Enable debug command logging in console/i,
+    });
+    await userEvent.click(checkbox);
+    expect(useAppConfigStore.getState().debugLoggingEnabled).toBe(true);
+    expect(window.terraForge.config.saveAppConfig).toHaveBeenCalledWith({
+      debugLoggingEnabled: true,
+    });
   });
 
   it("shows the existing config in the sidebar", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -187,6 +187,8 @@ if (typeof window !== "undefined") {
       getMachineConfigs: vi.fn().mockResolvedValue([]),
       saveMachineConfig: vi.fn().mockResolvedValue(undefined),
       deleteMachineConfig: vi.fn().mockResolvedValue(undefined),
+      getAppConfig: vi.fn().mockResolvedValue({ debugLoggingEnabled: false }),
+      saveAppConfig: vi.fn().mockResolvedValue(undefined),
       exportConfigs: vi.fn().mockResolvedValue(null),
       importConfigs: vi.fn().mockResolvedValue({ added: 0, skipped: 0 }),
       loadPageSizes: vi.fn().mockResolvedValue([]),


### PR DESCRIPTION
This pull request introduces a new application-wide debug logging feature, allowing users to enable or disable verbose command transport logs in the console panel. The implementation includes changes across the backend, frontend, IPC, persistence, and type definitions to support saving, loading, and toggling this setting. The most important changes are grouped below:

**Debug Logging Feature Implementation**

* Added a `debugLoggingEnabled` property to the new `AppConfig` interface, with support for saving/loading this setting in the app's persistent config (`app-config.json`). [[1]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R46-R50) [[2]](diffhunk://#diff-ab14e4b7f4878c718dda48fca92c6d76023a9063b01b199be026335cd525c728R50-R53) [[3]](diffhunk://#diff-ab14e4b7f4878c718dda48fca92c6d76023a9063b01b199be026335cd525c728R155-R183)
* Updated the `FluidNCClient` class to emit debug console logs for command transport details when debug logging is enabled, and provided methods to control this setting. [[1]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR38) [[2]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR74-R82) [[3]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR110-R120) [[4]](diffhunk://#diff-1a43d33b061dcdb446a3b751c59acbd313c85c629beac0ff8e81160248e6397aR131-R178)
* Added IPC handlers and preload API methods to get and set the app config, ensuring the debug logging setting is synchronized between renderer and main process. [[1]](diffhunk://#diff-50a77b726289cb265fed461d36d0b38adc35d108790d619feb81cb66ddc1942fR53-R55) [[2]](diffhunk://#diff-50a77b726289cb265fed461d36d0b38adc35d108790d619feb81cb66ddc1942fR65-R67) [[3]](diffhunk://#diff-50a77b726289cb265fed461d36d0b38adc35d108790d619feb81cb66ddc1942fR90-R96) [[4]](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0R4) [[5]](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0R174-R175) [[6]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR59-R76)

**UI Integration**

* Extended the `MachineConfigDialog` with a new "Logging" section, allowing users to toggle debug command logging from the UI, and wired up state management via `useAppConfigStore`. [[1]](diffhunk://#diff-f4dd03beefc207a7798fbf3f724cc3d25060296a76e85cf46b05c378115963c8R92-R100) [[2]](diffhunk://#diff-f4dd03beefc207a7798fbf3f724cc3d25060296a76e85cf46b05c378115963c8R298-R304) [[3]](diffhunk://#diff-f4dd03beefc207a7798fbf3f724cc3d25060296a76e85cf46b05c378115963c8L732-R745) [[4]](diffhunk://#diff-f4dd03beefc207a7798fbf3f724cc3d25060296a76e85cf46b05c378115963c8R767-R788) [[5]](diffhunk://#diff-96aed5f081ca243e3764d329aee71adc2fe3dbdabc963c4aa76c35d97435880cR6-R19)
* Updated the main `App` component to load the debug logging setting on startup and keep state in sync. [[1]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR12) [[2]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR22-R24) [[3]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR80-R83) [[4]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL106-R122)

**Type and Test Updates**

* Updated type definitions to include `AppConfig` and the new config API methods, and adjusted tests to initialize the new state property. [[1]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R478-R479) [[2]](diffhunk://#diff-95c20daf87686aad1736d72f978fdf90d564c766c5b5e24f28f646731929b108L28-R31)

These changes collectively provide users with fine-grained control over debug logging for command transport, improving troubleshooting capabilities while keeping the feature unobtrusive for normal use.