### PR TITLE
Feature: Plot circle points option

### DIFF
--- a/src/renderer/src/features/imports/hooks/useImportActions.ts
+++ b/src/renderer/src/features/imports/hooks/useImportActions.ts
@@ -198,6 +198,17 @@ export function useImportActions() {
         const sourceOutlineVisible = hasVisibleStroke(el, stylesheet);
         const tag = el.tagName.toLowerCase();
         const pathIndex = fillFlags.length;
+        const pointTap =
+          tag === "circle"
+            ? (() => {
+                const cx = Number.parseFloat(el.getAttribute("cx") ?? "");
+                const cy = Number.parseFloat(el.getAttribute("cy") ?? "");
+                if (!Number.isFinite(cx) || !Number.isFinite(cy))
+                  return undefined;
+                const pt = matrix.transformPoint({ x: cx, y: cy, z: 0, w: 1 });
+                return { x: pt.x, y: pt.y };
+              })()
+            : undefined;
 
         const inkLabel =
           el.getAttribute("inkscape:label") ??
@@ -226,6 +237,7 @@ export function useImportActions() {
             sourceOutlineVisible,
             outlineVisible: sourceOutlineVisible,
             strokeEnabled: true,
+            pointTap,
             label,
             layer: findContainingLayerId(el, layerGroupIds),
           },
@@ -286,6 +298,7 @@ export function useImportActions() {
         hatchSpacingMM: DEFAULT_HATCH_SPACING_MM,
         hatchAngleDeg: DEFAULT_HATCH_ANGLE_DEG,
         strokeEnabled: true,
+        plotPointsEnabled: false,
         generatedStrokeForNoStroke: false,
         layers: layers.length > 0 ? layers : undefined,
       };

--- a/src/renderer/src/features/properties-panel/components/ImportPropertiesForm.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportPropertiesForm.tsx
@@ -7,6 +7,7 @@ import { useImportPropertiesFormModel } from "../hooks/useImportPropertiesFormMo
 import type { ImportPropertiesFormProps } from "./ImportPropertiesForm.types";
 import { AlignmentDimensionsSection } from "./AlignmentDimensionsSection";
 import { HatchFillSection } from "./HatchFillSection";
+import { PlotPointsSection } from "./PlotPointsSection";
 import { PositionFieldsRow } from "./PositionFieldsRow";
 import { StrokeOptionsSection } from "./StrokeOptionsSection";
 import { StrokeWidthSection } from "./StrokeWidthSection";
@@ -131,6 +132,8 @@ export function ImportPropertiesForm({
         defaultAngleDeg={DEFAULT_HATCH_ANGLE_DEG}
         onApplyHatch={onApplyHatch}
       />
+
+      <PlotPointsSection imp={imp} onUpdate={onUpdate} />
     </>
   );
 }

--- a/src/renderer/src/features/properties-panel/components/PlotPointsSection.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/PlotPointsSection.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { SvgImport } from "../../../../types";
+import { PlotPointsSection } from "./PlotPointsSection";
+
+function buildImport(patch: Partial<SvgImport> = {}): SvgImport {
+  return {
+    id: "imp-1",
+    name: "sample",
+    x: 0,
+    y: 0,
+    scale: 1,
+    rotation: 0,
+    visible: true,
+    svgWidth: 10,
+    svgHeight: 10,
+    viewBoxX: 0,
+    viewBoxY: 0,
+    paths: [{ id: "p1", d: "M0 0", svgSource: "<path />", visible: true }],
+    ...patch,
+  };
+}
+
+describe("PlotPointsSection", () => {
+  it("does not render when no point candidates exist", () => {
+    render(<PlotPointsSection imp={buildImport()} onUpdate={() => {}} />);
+    expect(screen.queryByText("Plot points")).toBeNull();
+  });
+
+  it("renders and toggles point plotting", () => {
+    const onUpdate = vi.fn();
+    render(
+      <PlotPointsSection
+        imp={buildImport({
+          paths: [
+            {
+              id: "p1",
+              d: "M0 0",
+              svgSource: "<circle />",
+              visible: true,
+              pointTap: { x: 2, y: 3 },
+            },
+          ],
+          plotPointsEnabled: false,
+        })}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(screen.getByText("Plot points")).toBeDefined();
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onUpdate).toHaveBeenCalledWith({ plotPointsEnabled: true });
+  });
+});

--- a/src/renderer/src/features/properties-panel/components/PlotPointsSection.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/PlotPointsSection.test.tsx
@@ -22,6 +22,30 @@ function buildImport(patch: Partial<SvgImport> = {}): SvgImport {
 }
 
 describe("PlotPointsSection", () => {
+  it("adds a tooltip describing point plotting behavior", () => {
+    render(
+      <PlotPointsSection
+        imp={buildImport({
+          paths: [
+            {
+              id: "p1",
+              d: "M0 0",
+              svgSource: "<circle />",
+              visible: true,
+              pointTap: { x: 2, y: 3 },
+            },
+          ],
+          plotPointsEnabled: false,
+        })}
+        onUpdate={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Plot points").getAttribute("title")).toBe(
+      "Plot the center point of a circle. Applies only to SVG circle elements and does not affect stroke or fill options.",
+    );
+  });
+
   it("does not render when no point candidates exist", () => {
     render(<PlotPointsSection imp={buildImport()} onUpdate={() => {}} />);
     expect(screen.queryByText("Plot points")).toBeNull();

--- a/src/renderer/src/features/properties-panel/components/PlotPointsSection.tsx
+++ b/src/renderer/src/features/properties-panel/components/PlotPointsSection.tsx
@@ -1,0 +1,41 @@
+import type { SvgImport } from "../../../../types";
+
+interface PlotPointsSectionProps {
+  imp: SvgImport;
+  onUpdate: (changes: Partial<SvgImport>) => void;
+}
+
+export function PlotPointsSection({ imp, onUpdate }: PlotPointsSectionProps) {
+  const hasPointCandidates = imp.paths.some((path) => !!path.pointTap);
+  if (!hasPointCandidates) return null;
+
+  const plotPointsEnabled = imp.plotPointsEnabled ?? false;
+
+  return (
+    <div className="mt-2 pt-2 border-t border-border-ui/30">
+      <div className="flex items-center gap-2">
+        <span
+          id={`plot-points-label-${imp.id}`}
+          className="text-[10px] text-content-muted uppercase tracking-wider flex-1"
+        >
+          Plot points
+        </span>
+        <button
+          className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border border-transparent transition-colors ${
+            plotPointsEnabled ? "bg-accent" : "bg-secondary"
+          }`}
+          role="switch"
+          aria-checked={plotPointsEnabled}
+          aria-labelledby={`plot-points-label-${imp.id}`}
+          onClick={() => onUpdate({ plotPointsEnabled: !plotPointsEnabled })}
+        >
+          <span
+            className={`pointer-events-none inline-block h-3 w-3 rounded-full bg-white shadow transition-transform mt-0.5 ${
+              plotPointsEnabled ? "translate-x-3.5" : "translate-x-0.5"
+            }`}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/features/properties-panel/components/PlotPointsSection.tsx
+++ b/src/renderer/src/features/properties-panel/components/PlotPointsSection.tsx
@@ -10,6 +10,8 @@ export function PlotPointsSection({ imp, onUpdate }: PlotPointsSectionProps) {
   if (!hasPointCandidates) return null;
 
   const plotPointsEnabled = imp.plotPointsEnabled ?? false;
+  const tooltipText =
+    "Plot the center point of a circle. Applies only to SVG circle elements and does not affect stroke or fill options.";
 
   return (
     <div className="mt-2 pt-2 border-t border-border-ui/30">
@@ -17,6 +19,7 @@ export function PlotPointsSection({ imp, onUpdate }: PlotPointsSectionProps) {
         <span
           id={`plot-points-label-${imp.id}`}
           className="text-[10px] text-content-muted uppercase tracking-wider flex-1"
+          title={tooltipText}
         >
           Plot points
         </span>
@@ -27,6 +30,7 @@ export function PlotPointsSection({ imp, onUpdate }: PlotPointsSectionProps) {
           role="switch"
           aria-checked={plotPointsEnabled}
           aria-labelledby={`plot-points-label-${imp.id}`}
+          title={tooltipText}
           onClick={() => onUpdate({ plotPointsEnabled: !plotPointsEnabled })}
         >
           <span

--- a/src/renderer/src/store/canvasStore/services/vectorObjects.test.ts
+++ b/src/renderer/src/store/canvasStore/services/vectorObjects.test.ts
@@ -128,6 +128,30 @@ describe("canvasStore vectorObjects service", () => {
     expect(vectorObjectsForImport(pathStrokeOff)).toHaveLength(0);
   });
 
+  it("projects point taps when plot-points is enabled", () => {
+    const imp = makeImport({
+      plotPointsEnabled: true,
+      paths: [
+        {
+          id: "p1",
+          d: "M0,0 L10,10",
+          svgSource: "<circle/>",
+          visible: true,
+          pointTap: { x: 5, y: 6 },
+          sourceOutlineVisible: false,
+          outlineVisible: false,
+          sourceColor: "#00aa00",
+        },
+      ],
+    });
+
+    const result = vectorObjectsForImport(imp);
+    const pointObject = result.find((vo) => vo.id === "p1-pt");
+    expect(pointObject).toBeDefined();
+    expect(pointObject?.pointTap).toEqual({ x: 5, y: 6 });
+    expect(pointObject?.sourceColor).toBe("#00aa00");
+  });
+
   it("vectorObjectsForImports aggregates all visible imports", () => {
     const impA = makeImport({ id: "a" });
     const impB = makeImport({ id: "b", visible: false });

--- a/src/renderer/src/store/canvasStore/services/vectorObjects.ts
+++ b/src/renderer/src/store/canvasStore/services/vectorObjects.ts
@@ -78,7 +78,22 @@ function projectPathToVectorObjects(
         : undefined,
     }),
   );
-  return [...outlineVOs, ...hatchVOs];
+  const pointVOs: VectorObject[] =
+    imp.plotPointsEnabled && path.pointTap
+      ? [
+          {
+            ...base,
+            id: `${path.id}-pt`,
+            path: "",
+            pointTap: path.pointTap,
+            sourceColor: path.sourceColor
+              ? normalizeSvgColor(path.sourceColor)
+              : undefined,
+          },
+        ]
+      : [];
+
+  return [...outlineVOs, ...hatchVOs, ...pointVOs];
 }
 
 export function vectorObjectsForImport(imp: SvgImport): VectorObject[] {

--- a/src/renderer/src/store/canvasStore/slices/importSlice.ts
+++ b/src/renderer/src/store/canvasStore/slices/importSlice.ts
@@ -39,6 +39,7 @@ function withDefaultHatchSettings(imp: SvgImport): SvgImport {
     hatchSpacingMM: DEFAULT_HATCH_SPACING_MM,
     hatchAngleDeg: DEFAULT_HATCH_ANGLE_DEG,
     strokeEnabled: true,
+    plotPointsEnabled: false,
     generatedStrokeForNoStroke: false,
     ...imp,
     paths: normalizedPaths,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,8 @@ export interface VectorObject {
   svgSource: string;
   /** Flattened absolute path data (d attribute) */
   path: string;
+  /** Optional point-tap source coordinate in SVG user units. */
+  pointTap?: { x: number; y: number };
   /** Position on the bed in mm from the configured origin */
   x: number;
   y: number;
@@ -281,6 +283,8 @@ export interface SvgPath {
    *  Rendered and emitted for G-code alongside the outline.  Toggled as a unit
    *  with the parent path's `visible` flag. */
   hatchLines?: string[];
+  /** Optional point-tap coordinate in SVG user units (after source transforms). */
+  pointTap?: { x: number; y: number };
   /** Number of times to repeat this path (default 1). */
   passCount?: number;
   /** How to handle multiple passes: repeat, backtrack, or penLift (default 'repeat'). */
@@ -339,6 +343,8 @@ export interface SvgImport {
   hatchAngleDeg?: number;
   /** Import-level default toggle for stroke outlines. Defaults to true. */
   strokeEnabled?: boolean;
+  /** Import-level toggle to emit point taps for paths carrying `pointTap` metadata. */
+  plotPointsEnabled?: boolean;
   /** Import-level toggle to generate outlines for source paths with no stroke. */
   generatedStrokeForNoStroke?: boolean;
   /** Preview stroke width in mm — controls how thick paths appear on the canvas.

--- a/src/workers/svgWorker.ts
+++ b/src/workers/svgWorker.ts
@@ -64,6 +64,13 @@ interface TravelSubpath {
   color?: string;
 }
 
+interface TravelPoint {
+  point: { x: number; y: number };
+  layer?: string;
+  color?: string;
+  repeats: number;
+}
+
 interface ToolpathMetadata {
   color?: string;
   layer?: string;
@@ -97,6 +104,37 @@ function distanceMM(
   const dx = b.x - a.x;
   const dy = b.y - a.y;
   return Math.hypot(dx, dy);
+}
+
+function isPointWithinBounds(
+  point: { x: number; y: number },
+  config: MachineConfig,
+  pageClip?: { widthMM: number; heightMM: number; marginMM: number },
+): boolean {
+  const xMin = pageClip
+    ? pageClip.marginMM
+    : config.origin === "center"
+      ? -config.bedWidth / 2
+      : 0;
+  const xMax = pageClip
+    ? pageClip.widthMM - pageClip.marginMM
+    : config.origin === "center"
+      ? config.bedWidth / 2
+      : config.bedWidth;
+  const yMin = pageClip
+    ? pageClip.marginMM
+    : config.origin === "center"
+      ? -config.bedHeight / 2
+      : 0;
+  const yMax = pageClip
+    ? pageClip.heightMM - pageClip.marginMM
+    : config.origin === "center"
+      ? config.bedHeight / 2
+      : config.bedHeight;
+
+  return (
+    point.x >= xMin && point.x <= xMax && point.y >= yMin && point.y <= yMax
+  );
 }
 
 function isEnabledStation(station: InkServiceStation): boolean {
@@ -673,6 +711,7 @@ async function generate(msg: GenerateMessage): Promise<void> {
 
   // ── Phase 1: collect all subpaths from all visible objects ────────────────
   const allSubpaths: TravelSubpath[] = [];
+  const allPoints: TravelPoint[] = [];
   const yieldPh1 = makeYielder();
   let lastPct1 = -1;
   let lastColor: string | undefined = undefined;
@@ -685,6 +724,23 @@ async function generate(msg: GenerateMessage): Promise<void> {
       return;
     }
     const obj = colorSortedObjects[i];
+
+    if (obj.pointTap) {
+      const transformedPoint = transformPt(
+        obj,
+        config,
+        obj.pointTap.x,
+        obj.pointTap.y,
+      );
+      if (isPointWithinBounds(transformedPoint, config, options?.pageClip)) {
+        allPoints.push({
+          point: transformedPoint,
+          layer: obj.layer,
+          color: obj.sourceColor,
+          repeats: Math.max(1, obj.passCount ?? 1),
+        });
+      }
+    }
 
     // Emit color batch comment when color changes
     if (obj.sourceColor !== lastColor && i > 0) {
@@ -800,6 +856,11 @@ async function generate(msg: GenerateMessage): Promise<void> {
   lines.push(
     `; -- ${modeLabel} path (${orderedSubpaths.length} subpaths) -----------`,
   );
+  if (allPoints.length > 0) {
+    lines.push(
+      `; -- Point taps (${allPoints.length} points) ---------------------`,
+    );
+  }
   if (skippedObjects > 0) {
     lines.push(`; NOTE: skipped ${skippedObjects} invalid path object(s)`);
   }
@@ -824,6 +885,7 @@ async function generate(msg: GenerateMessage): Promise<void> {
     !!inkService &&
     inkTriggerBase > 0 &&
     inkService.stations.some(isEnabledStation);
+  const totalOperations = orderedSubpaths.length + allPoints.length;
 
   const emitTriggeredInkService = (preferredDipStationId?: string): void => {
     if (!canEmitInkService || !inkService) return;
@@ -849,9 +911,13 @@ async function generate(msg: GenerateMessage): Promise<void> {
   let lastPct4 = -1;
 
   // Prime/dip before first stroke so paint/ink is loaded before drawing.
-  if (canEmitInkService && orderedSubpaths.length > 0) {
-    const firstColor = orderedSubpaths[0]?.color;
-    const firstLayer = orderedSubpaths[0]?.layer;
+  if (canEmitInkService && totalOperations > 0) {
+    const firstColor =
+      orderedSubpaths[0]?.color ??
+      (orderedSubpaths.length === 0 ? allPoints[0]?.color : undefined);
+    const firstLayer =
+      orderedSubpaths[0]?.layer ??
+      (orderedSubpaths.length === 0 ? allPoints[0]?.layer : undefined);
     const preferredFirstDip = resolvePreferredDipStation(
       layerDipStations,
       firstLayer,
@@ -966,7 +1032,78 @@ async function generate(msg: GenerateMessage): Promise<void> {
     }
     lines.push(config.penUpCommand + " ; Pen up");
     lines.push("");
-    const pct = 40 + Math.round(((i + 1) / orderedSubpaths.length) * 60);
+    const completedOperations = i + 1;
+    const pct =
+      totalOperations > 0
+        ? 40 + Math.round((completedOperations / totalOperations) * 60)
+        : 100;
+    if (pct !== lastPct4) {
+      lastPct4 = pct;
+      self.postMessage({ type: "progress", taskId, percent: pct });
+    }
+    await yieldPh4();
+  }
+
+  for (let i = 0; i < allPoints.length; i++) {
+    if (cancelled.has(taskId)) {
+      cancelled.delete(taskId);
+      self.postMessage({ type: "cancelled", taskId });
+      return;
+    }
+
+    const tap = allPoints[i];
+    const preferredDipStationId = resolvePreferredDipStation(
+      layerDipStations,
+      tap.layer,
+      tap.color,
+    );
+    const currentMeta: ToolpathMetadata = {
+      color: tap.color,
+      layer: tap.layer,
+      dip: preferredDipStationId,
+    };
+    const currentMetaKey = metadataKey(currentMeta);
+    const markerChanged = currentMetaKey !== lastMarkerKey;
+    if (markerChanged) {
+      emitTfMarker(lines, currentMeta);
+      lastMarkerKey = currentMetaKey;
+    }
+
+    if (
+      markerChanged &&
+      canEmitInkService &&
+      preferredDipStationId &&
+      currentDipIdRef.value !== preferredDipStationId
+    ) {
+      emitTriggeredInkService(preferredDipStationId);
+    }
+
+    const drawSpeed =
+      typeof options?.drawSpeedOverride === "number"
+        ? options.drawSpeedOverride
+        : config.drawSpeed;
+
+    for (let rep = 0; rep < tap.repeats; rep++) {
+      lines.push(`G0 X${fmt(tap.point.x)} Y${fmt(tap.point.y)} ; Point rapid`);
+      lines.push(`F${drawSpeed}`);
+      lines.push(config.penDownCommand + " ; Point tap");
+      if (penDownDelayMs > 0) {
+        lines.push(
+          `G4 P${fmtSeconds(penDownDelayMs / 1000)} ; Pen settle delay`,
+        );
+      }
+      if (penUpDelayMs > 0) {
+        lines.push(`G4 P${fmtSeconds(penUpDelayMs / 1000)} ; Pen lift delay`);
+      }
+      lines.push(config.penUpCommand + " ; Pen up");
+      lines.push("");
+    }
+
+    const completedOperations = orderedSubpaths.length + i + 1;
+    const pct =
+      totalOperations > 0
+        ? 40 + Math.round((completedOperations / totalOperations) * 60)
+        : 100;
     if (pct !== lastPct4) {
       lastPct4 = pct;
       self.postMessage({ type: "progress", taskId, percent: pct });
@@ -980,7 +1117,7 @@ async function generate(msg: GenerateMessage): Promise<void> {
           .filter(isEnabledStation)
           .find((station) => station.type === "wash")
       : undefined;
-  if (finalWashStation && orderedSubpaths.length > 0) {
+  if (finalWashStation && totalOperations > 0) {
     lines.push("; -- Final ink service: end wash --");
     lines.push(config.penUpCommand + " ; Pen up for final wash");
     emitStationContact(lines, config, finalWashStation);

--- a/tests/unit/svgWorker.test.ts
+++ b/tests/unit/svgWorker.test.ts
@@ -161,6 +161,37 @@ describe("svgWorker — G-code header", () => {
 // ── G-code body structure ─────────────────────────────────────────────────────
 
 describe("svgWorker — G-code body", () => {
+  it("emits pen taps for point-only vector objects", async () => {
+    const pointObj = createVectorObject({
+      id: "point-1",
+      svgSource: '<circle cx="5" cy="7" />',
+      path: "",
+      pointTap: { x: 5, y: 7 },
+      x: 0,
+      y: 0,
+      scale: 1,
+      rotation: 0,
+      visible: true,
+      originalWidth: 20,
+      originalHeight: 20,
+    });
+
+    dispatch({
+      type: "generate",
+      taskId: "body-point-tap",
+      objects: [pointObj],
+      config: makeConfig(),
+      options: createGcodeOptions({ optimisePaths: false }),
+    });
+
+    const msg = await waitForMsg("complete");
+    const gcode = msg.gcode as string;
+    expect(gcode).toContain("; Point taps (1 points)");
+    expect(gcode).toContain("; Point rapid");
+    expect(gcode).toContain("; Point tap");
+    expect(gcode).toContain("M3S0 ; Pen up");
+  });
+
   it("emits G0 rapid (pen up) before drawing and G1 feed (pen down) for cuts", async () => {
     dispatch({
       type: "generate",

--- a/tests/unit/svgWorker.test.ts
+++ b/tests/unit/svgWorker.test.ts
@@ -186,7 +186,7 @@ describe("svgWorker — G-code body", () => {
 
     const msg = await waitForMsg("complete");
     const gcode = msg.gcode as string;
-    expect(gcode).toContain("; Point taps (1 points)");
+    expect(gcode).toContain("; -- Point taps (1 points)");
     expect(gcode).toContain("; Point rapid");
     expect(gcode).toContain("; Point tap");
     expect(gcode).toContain("M3S0 ; Pen up");


### PR DESCRIPTION
This pull request introduces support for "point tap" actions, enabling the system to recognize, display, and generate G-code for points (such as circles) that should be tapped with the pen/plotter. The feature includes UI controls to toggle point plotting, updates to the data model and import logic, and enhancements to the G-code worker to emit appropriate commands for these points. Tests have been added to ensure correct behavior throughout the stack.

**Point Tap Support and Data Flow**

* Added a `pointTap` property to `SvgPath`, `SvgImport`, and `VectorObject` types, and updated the import pipeline to detect and store tap points for SVG `circle` elements (`useImportActions.ts`, `index.ts`) [[1]](diffhunk://#diff-8242a49f0bb2c970f0385368985d98571118b80b2cd2771aca211801f817f105R201-R211) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R286-R287) [[3]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R346-R347) [[4]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R213-R214).
* Introduced an import-level toggle `plotPointsEnabled` (default: false) to control emission of point taps, persisted through the import and vector object pipeline (`useImportActions.ts`, `importSlice.ts`, `index.ts`) [[1]](diffhunk://#diff-8242a49f0bb2c970f0385368985d98571118b80b2cd2771aca211801f817f105R301) [[2]](diffhunk://#diff-9c518680231d538e1c5c2f3a9822bc16c36267cf4fe200fa115857fc79e0bb89R42) [[3]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R346-R347).

**UI Enhancements**

* Added a `PlotPointsSection` component to the properties panel, allowing users to enable or disable point plotting for an import. This section is only shown if any paths have a `pointTap` (`PlotPointsSection.tsx`, `ImportPropertiesForm.tsx`) [[1]](diffhunk://#diff-902ae33642553560f6c61ae120cc794eabcdbb5acacc86b892f5f8677b9d45a7R1-R41) [[2]](diffhunk://#diff-f6b3ffaa8c0466f987a2384f42e9a452fe9a57948353b7205352300afb7936d1R10) [[3]](diffhunk://#diff-f6b3ffaa8c0466f987a2384f42e9a452fe9a57948353b7205352300afb7936d1R135-R136).
* Included tests for the new UI section to ensure correct rendering and toggle behavior (`PlotPointsSection.test.tsx`).

**G-code Generation and Worker Logic**

* Updated the G-code worker to collect, transform, and emit G-code for point tap operations, including correct progress reporting, pen up/down commands, and comments in the output. Point taps are handled alongside regular subpaths and included in operation counts and ink service logic (`svgWorker.ts`) [[1]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R67-R73) [[2]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R109-R139) [[3]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R714) [[4]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R728-R744) [[5]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R859-R863) [[6]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5R888) [[7]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5L852-R920) [[8]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5L969-R1106) [[9]](diffhunk://#diff-92eba0dcb797e9f1e6ec6089f7061f285c69cfb9a739c71767d7cd5aebbc7cb5L983-R1120).

**Testing**

* Added and updated tests to verify that point tap vector objects are correctly projected and that G-code is generated as expected for point taps (`vectorObjects.test.ts`, `svgWorker.test.ts`) [[1]](diffhunk://#diff-a45db9279aacc346c33f2b16346ba336b81b0f1da917cf36370d55af476e113eR131-R154) [[2]](diffhunk://#diff-11518be555d19257dae91f958b424b543cb806f18b56b296a946ea899f566adfR164-R194).