### PR TITLE
Fix/missing layer row expansion button

### DIFF
--- a/src/renderer/src/components/ui/Button.tsx
+++ b/src/renderer/src/components/ui/Button.tsx
@@ -15,6 +15,7 @@ export type ButtonSize =
   | "sm" // text-xs px-2 py-1 rounded
   | "md" // text-sm px-3 py-1.5 rounded (default)
   | "lg" // text-sm px-4 py-2 rounded-lg
+  | "icon-xs" // w-4 h-4 rounded (compact icon-only square)
   | "icon-sm" // w-7 h-7 rounded (icon-only square)
   | "icon-md"; // w-8 h-8 rounded (icon-only square, larger)
 
@@ -46,6 +47,7 @@ const sizeClasses: Record<ButtonSize, string> = {
   sm: "text-xs px-2 py-1 rounded",
   md: "text-sm px-3 py-1.5 rounded",
   lg: "text-sm px-4 py-2 rounded-lg",
+  "icon-xs": "w-4 h-4 rounded inline-flex items-center justify-center",
   "icon-sm": "w-7 h-7 rounded inline-flex items-center justify-center",
   "icon-md": "w-8 h-8 rounded inline-flex items-center justify-center",
 };

--- a/src/renderer/src/features/properties-panel/components/ImportHeaderRow.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportHeaderRow.test.tsx
@@ -70,6 +70,36 @@ describe("ImportHeaderRow", () => {
     expect(onDeleteImport).toHaveBeenCalledWith("imp-1");
   });
 
+  it("selects import when row is clicked without expanding", () => {
+    const onSelectImport = vi.fn();
+    const onToggleExpand = vi.fn();
+
+    render(
+      <ImportHeaderRow
+        imp={buildImport()}
+        indented={false}
+        isExpanded={false}
+        isEditingName={false}
+        editingNameValue="sample"
+        onSelectImport={onSelectImport}
+        onToggleExpand={onToggleExpand}
+        onToggleVisibility={() => {}}
+        onStartRename={() => {}}
+        onEditingNameChange={() => {}}
+        onCommitName={() => {}}
+        onCancelName={() => {}}
+        onDeleteImport={() => {}}
+        onDragStart={() => {}}
+        onDragEnd={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("sample"));
+
+    expect(onSelectImport).toHaveBeenCalledWith("imp-1");
+    expect(onToggleExpand).not.toHaveBeenCalled();
+  });
+
   it("commits and cancels rename in edit mode", () => {
     const onCommitName = vi.fn();
     const onCancelName = vi.fn();

--- a/src/renderer/src/features/properties-panel/components/ImportHeaderRow.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportHeaderRow.tsx
@@ -62,7 +62,8 @@ export function ImportHeaderRow({
         aria-expanded={isExpanded}
         aria-label={isExpanded ? "Collapse paths" : "Expand paths"}
         variant="ghost"
-        className="w-4 shrink-0"
+        size="icon-xs"
+        className="shrink-0"
         onClick={onExpandClick}
       >
         {isExpanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
@@ -91,6 +92,7 @@ export function ImportHeaderRow({
       </span>
       <Button
         variant="ghost"
+        size="icon-xs"
         className="ml-1 hover:text-accent shrink-0"
         title="Delete import"
         onClick={onDeleteClick}

--- a/src/renderer/src/features/properties-panel/components/ImportPathsList.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportPathsList.test.tsx
@@ -109,6 +109,53 @@ describe("ImportPathsList", () => {
     expect(screen.getByText("path p3")).toBeDefined();
   });
 
+  it("falls back to path-derived layer rows when SVG layer metadata is missing", () => {
+    const onToggleLayerCollapse = vi.fn();
+    const onUpdatePathVisibility = vi.fn();
+    const imp = buildImport({
+      paths: [
+        {
+          id: "p1",
+          d: "M0 0",
+          svgSource: "<path />",
+          visible: true,
+          layer: "layer-a",
+        },
+        {
+          id: "p2",
+          d: "M1 1",
+          svgSource: "<path />",
+          visible: false,
+          layer: "layer-a",
+        },
+      ],
+    });
+
+    render(
+      <ImportPathsList
+        imp={imp}
+        expandedLayerKeys={new Set(["imp-1:layer-a"])}
+        onSelectImport={() => {}}
+        onToggleLayerCollapse={onToggleLayerCollapse}
+        onUpdateLayerVisibility={() => {}}
+        onUpdatePathVisibility={onUpdatePathVisibility}
+        onUpdatePathFillEnabled={() => {}}
+        onUpdatePathStroke={() => {}}
+        onUpdatePath={() => {}}
+        onRemovePath={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("layer-a")).toBeDefined();
+
+    fireEvent.click(screen.getByTitle("Collapse layer"));
+    expect(onToggleLayerCollapse).toHaveBeenCalledWith("imp-1", "layer-a");
+
+    fireEvent.click(screen.getByTitle("Toggle layer visibility"));
+    expect(onUpdatePathVisibility).toHaveBeenCalledWith("imp-1", "p1", false);
+    expect(onUpdatePathVisibility).toHaveBeenCalledWith("imp-1", "p2", false);
+  });
+
   it("toggles color-group expansion using color-scoped key format", () => {
     const onToggleLayerCollapse = vi.fn();
     const imp = buildImport({

--- a/src/renderer/src/features/properties-panel/components/ImportPathsList.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportPathsList.tsx
@@ -8,6 +8,13 @@ import { GroupPassSettings } from "./GroupPassSettings";
 import { PathPassSettings } from "./PathPassSettings";
 import { useColorGroups } from "../hooks/useColorGroupsModel";
 
+type LayerView = {
+  id: string;
+  name: string;
+  visible: boolean;
+  synthetic: boolean;
+};
+
 function hasVisibleStroke(imp: SvgImport, path: SvgImport["paths"][number]) {
   const sourceOutlineVisible =
     typeof path.sourceOutlineVisible === "boolean"
@@ -29,6 +36,31 @@ function deriveGroupPass(paths: SvgImport["paths"]): {
     passCount: paths[0].passCount ?? 1,
     passMode: paths[0].passMode ?? "repeat",
   };
+}
+
+function deriveLayerViews(imp: SvgImport): LayerView[] {
+  if (imp.layers && imp.layers.length > 0) {
+    return imp.layers.map((layer) => ({
+      ...layer,
+      synthetic: false,
+    }));
+  }
+
+  const fallbackLayers = new Map<string, Array<SvgImport["paths"][number]>>();
+
+  for (const path of imp.paths) {
+    if (!path.layer) continue;
+    const paths = fallbackLayers.get(path.layer) ?? [];
+    paths.push(path);
+    fallbackLayers.set(path.layer, paths);
+  }
+
+  return Array.from(fallbackLayers.entries()).map(([layerId, paths]) => ({
+    id: layerId,
+    name: layerId,
+    visible: paths.some((path) => path.visible),
+    synthetic: true,
+  }));
 }
 
 interface ImportPathsListProps {
@@ -81,6 +113,7 @@ export function ImportPathsList({
   onRemovePath,
 }: ImportPathsListProps) {
   const colorGroups = useColorGroups(imp);
+  const layerViews = deriveLayerViews(imp);
   const [openPassFlyoutKey, setOpenPassFlyoutKey] = useState<string | null>(
     null,
   );
@@ -317,9 +350,9 @@ export function ImportPathsList({
             );
           })
         )
-      ) : imp.layers && imp.layers.length > 0 ? (
+      ) : layerViews.length > 0 ? (
         <>
-          {imp.layers.map((layer) => {
+          {layerViews.map((layer) => {
             const layerPaths = imp.paths.filter((p) => p.layer === layer.id);
             const layerKey = `${imp.id}:${layer.id}`;
             const isLayerExpanded = expandedLayerKeys.has(layerKey);
@@ -339,7 +372,19 @@ export function ImportPathsList({
                     onToggleLayerCollapse(imp.id, layer.id)
                   }
                   onToggleVisible={() =>
-                    onUpdateLayerVisibility(imp.id, layer.id, !layer.visible)
+                    layer.synthetic
+                      ? layerPaths.forEach((path) =>
+                          onUpdatePathVisibility(
+                            imp.id,
+                            path.id,
+                            !layer.visible,
+                          ),
+                        )
+                      : onUpdateLayerVisibility(
+                          imp.id,
+                          layer.id,
+                          !layer.visible,
+                        )
                   }
                 />
 

--- a/src/renderer/src/features/properties-panel/components/ImportPathsList.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportPathsList.tsx
@@ -466,7 +466,7 @@ export function ImportPathsList({
 
           {imp.paths
             .filter(
-              (p) => !p.layer || !imp.layers!.some((l) => l.id === p.layer),
+              (p) => !p.layer || !layerViews.some((l) => l.id === p.layer),
             )
             .map((p) => {
               const label = p.label ?? p.layer ?? `path ${p.id.slice(0, 6)}`;

--- a/tests/component/PropertiesPanel.test.tsx
+++ b/tests/component/PropertiesPanel.test.tsx
@@ -124,6 +124,7 @@ describe("PropertiesPanel", () => {
     render(<PropertiesPanel />);
     // Expand first
     await userEvent.click(screen.getByRole("button", { name: "Expand paths" }));
+    await userEvent.click(screen.getByTitle("Expand layer"));
     // Toggle path visibility
     await userEvent.click(screen.getByTitle("Toggle path visibility"));
     expect(useCanvasStore.getState().imports[0].paths[0].visible).toBe(false);
@@ -139,6 +140,10 @@ describe("PropertiesPanel", () => {
     render(<PropertiesPanel />);
     // Expand
     await userEvent.click(screen.getByRole("button", { name: "Expand paths" }));
+    const layerExpandButtons = screen.getAllByTitle("Expand layer");
+    for (const button of layerExpandButtons) {
+      await userEvent.click(button);
+    }
     expect(screen.getByText("remove")).toBeInTheDocument();
     // Click the Remove path button for "remove" path
     const removeBtns = screen.getAllByTitle("Remove path");


### PR DESCRIPTION
This pull request improves the handling of SVG import layers in the properties panel, especially when layer metadata is missing, and introduces a new compact icon button size for UI consistency. It also adds tests to ensure correct behavior when falling back to path-derived layers.

**Improvements to SVG Import Layer Handling:**

* Added a `deriveLayerViews` function to generate synthetic layer objects from path data when SVG layer metadata is missing, ensuring layers are always displayed in the UI (`ImportPathsList.tsx`).
* Updated the layer visibility toggle logic to handle synthetic layers by updating the visibility of all associated paths, instead of relying on non-existent layer metadata (`ImportPathsList.tsx`).
* Modified the rendering logic to use the new `layerViews` abstraction for consistent layer display, whether real or synthetic (`ImportPathsList.tsx`).

**UI Enhancements:**

* Introduced a new `icon-xs` button size in the `Button` component for compact icon-only buttons, and applied it to relevant buttons in the import header row for improved alignment and appearance (`Button.tsx`, `ImportHeaderRow.tsx`). [[1]](diffhunk://#diff-a74e24ca459f18c186dcfcd98ce11005a7861d2d95cbd0f60a18b78b7ffd0401R18) [[2]](diffhunk://#diff-a74e24ca459f18c186dcfcd98ce11005a7861d2d95cbd0f60a18b78b7ffd0401R50) [[3]](diffhunk://#diff-c6aa834cb57b53af01f1fddf0ec0c02188597b9377a6822a226fb55f64f85c7bL65-R66) [[4]](diffhunk://#diff-c6aa834cb57b53af01f1fddf0ec0c02188597b9377a6822a226fb55f64f85c7bR95)

**Test Additions:**

* Added tests to verify selection behavior in the import header row and to ensure fallback to path-derived layer rows when SVG layer metadata is missing (`ImportHeaderRow.test.tsx`, `ImportPathsList.test.tsx`). [[1]](diffhunk://#diff-bdd2771ca8b5656b616ca251619c5b2d96961df2d12095effcf05d363fa2d8aeR73-R102) [[2]](diffhunk://#diff-778dfe46e0ce8be6b27a1dcd01ac58dee8533ea76267cf2c6b1b1727f9722f3bR112-R158)