### PR TITLE
Add timestamp to console output as simple string

### DIFF
--- a/docs/terraForge-features.md
+++ b/docs/terraForge-features.md
@@ -154,6 +154,7 @@
 - [x] Scrollable, monospaced log panel
 - [x] Clear button
 - [x] Command input (send raw G-code commands)
+- [x] Console timestamp display toggle — **Application Configuration → Console Display** includes "Show date and time on console lines"; when enabled, each console entry is prefixed with a local `YYYY-MM-DD HH:mm:ss` timestamp
 - [x] Alarm state badge becomes a clickable button — sends `$X` to clear the alarm
 - [x] Firmware restart button — "⚠ Restart FW" button visible in console header when connected; sends `[ESP444]RESTART` to reboot the ESP32; automatically disconnects the app and shows a reconnect prompt; confirms with the user before firing
 

--- a/src/main/config/persistence.ts
+++ b/src/main/config/persistence.ts
@@ -64,6 +64,7 @@ export const BUILT_IN_PAGE_SIZES: PageSize[] = [
 
 export const DEFAULT_APP_CONFIG: AppConfig = {
   debugLoggingEnabled: false,
+  showConsoleTimestamps: true,
 };
 
 function cloneMachineConfigs(configs: MachineConfig[]): MachineConfig[] {
@@ -184,6 +185,10 @@ export function createPersistence(userDataPath: string): MainPersistence {
           typeof parsed.debugLoggingEnabled === "boolean"
             ? parsed.debugLoggingEnabled
             : DEFAULT_APP_CONFIG.debugLoggingEnabled,
+        showConsoleTimestamps:
+          typeof parsed.showConsoleTimestamps === "boolean"
+            ? parsed.showConsoleTimestamps
+            : DEFAULT_APP_CONFIG.showConsoleTimestamps,
       };
     } catch {
       return { ...DEFAULT_APP_CONFIG };

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -22,6 +22,9 @@ export default function App() {
   const setDebugLoggingEnabled = useAppConfigStore(
     (s) => s.setDebugLoggingEnabled,
   );
+  const setShowConsoleTimestamps = useAppConfigStore(
+    (s) => s.setShowConsoleTimestamps,
+  );
   const theme = useThemeStore((s) => s.theme);
 
   // Keep <html> class in sync with theme store
@@ -79,7 +82,10 @@ export default function App() {
     window.terraForge.config.getMachineConfigs().then(setConfigs);
     window.terraForge.config
       .getAppConfig()
-      .then((cfg) => setDebugLoggingEnabled(cfg.debugLoggingEnabled))
+      .then((cfg) => {
+        setDebugLoggingEnabled(cfg.debugLoggingEnabled);
+        setShowConsoleTimestamps(cfg.showConsoleTimestamps);
+      })
       .catch(() => {});
 
     // Subscribe to status updates pushed from main process
@@ -119,6 +125,7 @@ export default function App() {
     upsertTask,
     appendLine,
     setDebugLoggingEnabled,
+    setShowConsoleTimestamps,
   ]);
 
   return (

--- a/src/renderer/src/components/MachineConfigDialog/components/Application/AppTogglesSections.tsx
+++ b/src/renderer/src/components/MachineConfigDialog/components/Application/AppTogglesSections.tsx
@@ -10,11 +10,13 @@ export function AppTogglesSections({ controller }: AppTogglesSectionsProps) {
   const {
     appConfig,
     handleDebugLoggingChange,
+    handleShowConsoleTimestampsChange,
   } = controller;
 
   const {
     enablePerPathPasses,
     debugLoggingEnabled,
+    showConsoleTimestamps,
     showMachineCoordinates,
     respectSvgColorsOnCanvas,
     setEnablePerPathPasses,
@@ -65,6 +67,25 @@ export function AppTogglesSections({ controller }: AppTogglesSectionsProps) {
       </Section>
 
       <Section title="Console Display">
+        <label className="flex items-start gap-3 cursor-pointer mb-4">
+          <input
+            type="checkbox"
+            checked={showConsoleTimestamps}
+            onChange={(e) =>
+              handleShowConsoleTimestampsChange(e.currentTarget.checked)
+            }
+            className="mt-0.5 accent-accent"
+          />
+          <div className="space-y-1">
+            <div className="text-sm text-content">
+              Show date and time on console lines
+            </div>
+            <p className="text-xs text-content-faint">
+              Prefixes each console entry with the local date and time.
+            </p>
+          </div>
+        </label>
+
         <label className="flex items-start gap-3 cursor-pointer">
           <input
             type="checkbox"

--- a/src/renderer/src/components/MachineConfigDialog/hooks/useMachineConfigDialogController.ts
+++ b/src/renderer/src/components/MachineConfigDialog/hooks/useMachineConfigDialogController.ts
@@ -3,6 +3,7 @@ import { PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import type {
+  AppConfig,
   InkServiceStation,
   InkServiceStationAction,
   MachineConfig,
@@ -230,11 +231,22 @@ export function useMachineConfigDialogController() {
     if (selectedId) setActiveConfig(selectedId);
   };
 
+  const saveAppConfig = (overrides: Partial<AppConfig>) => {
+    void window.terraForge.config.saveAppConfig({
+      debugLoggingEnabled: appConfig.debugLoggingEnabled,
+      showConsoleTimestamps: appConfig.showConsoleTimestamps,
+      ...overrides,
+    });
+  };
+
   const handleDebugLoggingChange = (enabled: boolean) => {
     appConfig.setDebugLoggingEnabled(enabled);
-    void window.terraForge.config.saveAppConfig({
-      debugLoggingEnabled: enabled,
-    });
+    saveAppConfig({ debugLoggingEnabled: enabled });
+  };
+
+  const handleShowConsoleTimestampsChange = (enabled: boolean) => {
+    appConfig.setShowConsoleTimestamps(enabled);
+    saveAppConfig({ showConsoleTimestamps: enabled });
   };
 
   const updateStationField = <K extends keyof InkServiceStation>(
@@ -342,6 +354,7 @@ export function useMachineConfigDialogController() {
     handleDragEnd,
     handleActivate,
     handleDebugLoggingChange,
+    handleShowConsoleTimestampsChange,
     updateStationField,
     updateStationActionField,
     handleTestStationLocation,

--- a/src/renderer/src/components/MachineConfigDialog/hooks/useMachineConfigDialogStores.ts
+++ b/src/renderer/src/components/MachineConfigDialog/hooks/useMachineConfigDialogStores.ts
@@ -8,6 +8,9 @@ export function useMachineConfigDialogStores() {
   const debugLoggingEnabled = useAppConfigStore(
     (state) => state.debugLoggingEnabled,
   );
+  const showConsoleTimestamps = useAppConfigStore(
+    (state) => state.showConsoleTimestamps,
+  );
   const showMachineCoordinates = useAppConfigStore(
     (state) => state.showMachineCoordinates,
   );
@@ -37,6 +40,9 @@ export function useMachineConfigDialogStores() {
   );
   const setDebugLoggingEnabled = useAppConfigStore(
     (state) => state.setDebugLoggingEnabled,
+  );
+  const setShowConsoleTimestamps = useAppConfigStore(
+    (state) => state.setShowConsoleTimestamps,
   );
   const setShowMachineCoordinates = useAppConfigStore(
     (state) => state.setShowMachineCoordinates,
@@ -75,6 +81,7 @@ export function useMachineConfigDialogStores() {
     appConfig: {
       enablePerPathPasses,
       debugLoggingEnabled,
+      showConsoleTimestamps,
       showMachineCoordinates,
       respectSvgColorsOnCanvas,
       vinylCuttingEnabled,
@@ -85,6 +92,7 @@ export function useMachineConfigDialogStores() {
       inkServiceStations,
       setEnablePerPathPasses,
       setDebugLoggingEnabled,
+      setShowConsoleTimestamps,
       setShowMachineCoordinates,
       setRespectSvgColorsOnCanvas,
       setVinylCuttingEnabled,

--- a/src/renderer/src/store/appConfigStore.ts
+++ b/src/renderer/src/store/appConfigStore.ts
@@ -70,6 +70,7 @@ function normalizeStation(station: InkServiceStation): InkServiceStation {
 interface AppConfigState {
   enablePerPathPasses: boolean;
   debugLoggingEnabled: boolean;
+  showConsoleTimestamps: boolean;
   showMachineCoordinates: boolean;
   respectSvgColorsOnCanvas: boolean;
   vinylCuttingEnabled: boolean;
@@ -80,6 +81,7 @@ interface AppConfigState {
   inkServiceStations: InkServiceStation[];
   setEnablePerPathPasses: (enabled: boolean) => void;
   setDebugLoggingEnabled: (enabled: boolean) => void;
+  setShowConsoleTimestamps: (enabled: boolean) => void;
   setShowMachineCoordinates: (enabled: boolean) => void;
   setRespectSvgColorsOnCanvas: (enabled: boolean) => void;
   setVinylCuttingEnabled: (enabled: boolean) => void;
@@ -101,6 +103,7 @@ export const useAppConfigStore = create<AppConfigState>()(
     (set) => ({
       enablePerPathPasses: false,
       debugLoggingEnabled: false,
+      showConsoleTimestamps: true,
       showMachineCoordinates: false,
       respectSvgColorsOnCanvas: false,
       vinylCuttingEnabled: false,
@@ -113,6 +116,8 @@ export const useAppConfigStore = create<AppConfigState>()(
         set({ enablePerPathPasses: enabled }),
       setDebugLoggingEnabled: (enabled) =>
         set({ debugLoggingEnabled: enabled }),
+      setShowConsoleTimestamps: (enabled) =>
+        set({ showConsoleTimestamps: enabled }),
       setShowMachineCoordinates: (enabled) =>
         set({ showMachineCoordinates: enabled }),
       setRespectSvgColorsOnCanvas: (enabled) =>

--- a/src/renderer/src/store/consoleStore.ts
+++ b/src/renderer/src/store/consoleStore.ts
@@ -1,5 +1,16 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { useAppConfigStore } from "./appConfigStore";
+
+function formatConsoleTimestamp(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate(),
+  )} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(
+    date.getSeconds(),
+  )}`;
+}
 
 interface ConsoleState {
   lines: string[];
@@ -15,7 +26,13 @@ export const useConsoleStore = create<ConsoleState>()(
 
     appendLine: (line) =>
       set((state) => {
-        state.lines.push(line);
+        const showConsoleTimestamps =
+          useAppConfigStore.getState().showConsoleTimestamps;
+        state.lines.push(
+          showConsoleTimestamps
+            ? `[${formatConsoleTimestamp(new Date())}] ${line}`
+            : line,
+        );
         if (state.lines.length > state.maxLines) {
           state.lines.splice(0, state.lines.length - state.maxLines);
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,8 @@ export interface MachineConfig {
 export interface AppConfig {
   /** Enables verbose debug command transport logs in the console panel. */
   debugLoggingEnabled: boolean;
+  /** Shows a local date/time prefix for each console line. */
+  showConsoleTimestamps: boolean;
 }
 
 export interface VinylCuttingSettings {

--- a/tests/component/ConsolePanel.test.tsx
+++ b/tests/component/ConsolePanel.test.tsx
@@ -8,7 +8,10 @@ import { ConsolePanel } from "@renderer/components/ConsolePanel";
 
 beforeEach(() => {
   useConsoleStore.setState({ lines: [], maxLines: 500 });
-  useAppConfigStore.setState({ showMachineCoordinates: false });
+  useAppConfigStore.setState({
+    showMachineCoordinates: false,
+    showConsoleTimestamps: false,
+  });
   useMachineStore.setState({
     configs: [],
     activeConfigId: null,
@@ -196,7 +199,7 @@ describe("ConsolePanel", () => {
     expect(window.terraForge.fluidnc.sendCommand).toHaveBeenCalledWith(
       "G0 X10",
     );
-    expect(useConsoleStore.getState().lines).toContain("> G0 X10");
+    expect(useConsoleStore.getState().lines.some((l) => l.endsWith("> G0 X10"))).toBe(true);
   });
 
   it("sends command when Send button clicked", async () => {

--- a/tests/component/MachineConfigDialog.test.tsx
+++ b/tests/component/MachineConfigDialog.test.tsx
@@ -28,6 +28,7 @@ beforeEach(() => {
   useAppConfigStore.setState({
     enablePerPathPasses: false,
     debugLoggingEnabled: false,
+    showConsoleTimestamps: true,
     showMachineCoordinates: false,
     respectSvgColorsOnCanvas: false,
     vinylCuttingEnabled: false,
@@ -124,6 +125,22 @@ describe("MachineConfigDialog", () => {
     expect(useAppConfigStore.getState().debugLoggingEnabled).toBe(true);
     expect(window.terraForge.config.saveAppConfig).toHaveBeenCalledWith({
       debugLoggingEnabled: true,
+      showConsoleTimestamps: true,
+    });
+  });
+
+  it("saves console timestamp setting when toggled", async () => {
+    render(<MachineConfigDialog onClose={onClose} />);
+    await userEvent.click(screen.getByText("Application Configuration"));
+    const checkbox = screen.getByRole("checkbox", {
+      name: /Show date and time on console lines/i,
+    });
+    expect(checkbox).toBeChecked();
+    await userEvent.click(checkbox);
+    expect(useAppConfigStore.getState().showConsoleTimestamps).toBe(false);
+    expect(window.terraForge.config.saveAppConfig).toHaveBeenCalledWith({
+      debugLoggingEnabled: false,
+      showConsoleTimestamps: false,
     });
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -187,7 +187,10 @@ if (typeof window !== "undefined") {
       getMachineConfigs: vi.fn().mockResolvedValue([]),
       saveMachineConfig: vi.fn().mockResolvedValue(undefined),
       deleteMachineConfig: vi.fn().mockResolvedValue(undefined),
-      getAppConfig: vi.fn().mockResolvedValue({ debugLoggingEnabled: false }),
+      getAppConfig: vi.fn().mockResolvedValue({
+        debugLoggingEnabled: false,
+        showConsoleTimestamps: true,
+      }),
       saveAppConfig: vi.fn().mockResolvedValue(undefined),
       exportConfigs: vi.fn().mockResolvedValue(null),
       importConfigs: vi.fn().mockResolvedValue({ added: 0, skipped: 0 }),

--- a/tests/unit/stores/consoleStore.test.ts
+++ b/tests/unit/stores/consoleStore.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useConsoleStore } from "../../../src/renderer/src/store/consoleStore";
+import { useAppConfigStore } from "../../../src/renderer/src/store/appConfigStore";
 
 beforeEach(() => {
   useConsoleStore.setState({ lines: [], maxLines: 500 });
+  useAppConfigStore.setState({ showConsoleTimestamps: false });
 });
 
 describe("consoleStore", () => {


### PR DESCRIPTION
<img width="675" height="167" alt="image" src="https://github.com/user-attachments/assets/be093f1e-ca55-415f-bd41-044d5c996e7f" />

Added timestamp as simple string.

Option is configurable in application settings.