### PR TITLE
Align Gcode and import layer styles

### DIFF
--- a/src/renderer/src/features/properties-panel/components/LayersPanelContent.tsx
+++ b/src/renderer/src/features/properties-panel/components/LayersPanelContent.tsx
@@ -161,23 +161,30 @@ export function LayersPanelContent() {
         <EmptyState message="No objects. Import an SVG." />
       ) : (
         <>
-          {/* G-code toolpath row — shown when a .gcode file has been loaded */}
+          {/* G-code section heading + row — shown when a .gcode file has been loaded */}
           {gcodeToolpath && (
-            <ToolpathSection
-              toolpath={gcodeToolpath}
-              fileName={toolpathFileName}
-              selected={toolpathSelected}
-              visible={toolpathVisible}
-              colorized={toolpathColorized}
-              opacity={toolpathOpacity}
-              isJobActive={isJobActive}
-              fallbackFeedrate={fallbackFeedrate}
-              onToggleSelected={() => selectToolpath(!toolpathSelected)}
-              onSetVisible={setToolpathVisible}
-              onSetColorized={setToolpathColorized}
-              onSetOpacity={setToolpathOpacity}
-              onClear={() => setGcodeToolpath(null)}
-            />
+            <>
+              <div className="flex items-center gap-1 px-2 py-1 border-b border-border-ui/50">
+                <span className="text-[10px] text-content-faint uppercase tracking-wider flex-1">
+                  GCODE
+                </span>
+              </div>
+              <ToolpathSection
+                toolpath={gcodeToolpath}
+                fileName={toolpathFileName}
+                selected={toolpathSelected}
+                visible={toolpathVisible}
+                colorized={toolpathColorized}
+                opacity={toolpathOpacity}
+                isJobActive={isJobActive}
+                fallbackFeedrate={fallbackFeedrate}
+                onToggleSelected={() => selectToolpath(!toolpathSelected)}
+                onSetVisible={setToolpathVisible}
+                onSetColorized={setToolpathColorized}
+                onSetOpacity={setToolpathOpacity}
+                onClear={() => setGcodeToolpath(null)}
+              />
+            </>
           )}
 
           {/* "Layers" section heading + add-group button */}

--- a/src/renderer/src/features/properties-panel/components/ToolpathSection.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/ToolpathSection.test.tsx
@@ -45,7 +45,7 @@ describe("ToolpathSection", () => {
     );
     expect(onToggleSelected).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "✕" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear toolpath" }));
     expect(onClear).toHaveBeenCalledTimes(1);
 
     expect(screen.getByText("sample.gcode")).toBeDefined();

--- a/src/renderer/src/features/properties-panel/components/ToolpathSection.tsx
+++ b/src/renderer/src/features/properties-panel/components/ToolpathSection.tsx
@@ -49,25 +49,67 @@ export function ToolpathSection({
         className={`flex items-center gap-1 px-2 py-1.5 cursor-pointer hover:bg-secondary/20 ${selected ? "bg-secondary/20" : ""}`}
         onClick={onToggleSelected}
       >
-        <Button
-          aria-expanded={selected}
-          aria-label={
-            selected ? "Collapse toolpath details" : "Expand toolpath details"
-          }
-          variant="ghost"
-          className="w-4 shrink-0"
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleSelected();
-          }}
-        >
-          {selected ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
-        </Button>
+        <div className="flex items-center gap-0.5 shrink-0">
+          <Button
+            aria-expanded={selected}
+            aria-label={
+              selected ? "Collapse toolpath details" : "Expand toolpath details"
+            }
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSelected();
+            }}
+          >
+            {selected ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+          </Button>
 
-        <FileText className="shrink-0 text-sky-400" size={11} strokeWidth={2} />
+          <FileText className="shrink-0 text-sky-400" size={11} strokeWidth={2} />
+
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0"
+            title={
+              colorized
+                ? "Disable colorized toolpath"
+                : "Enable colorized toolpath"
+            }
+            aria-label={
+              colorized
+                ? "Disable colorized toolpath"
+                : "Enable colorized toolpath"
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              onSetColorized(!colorized);
+            }}
+          >
+            <Palette
+              size={11}
+              className={colorized ? "text-sky-400" : "text-content-faint"}
+            />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0"
+            title={visible ? "Hide toolpath" : "Show toolpath"}
+            aria-label={visible ? "Hide toolpath" : "Show toolpath"}
+            onClick={(e) => {
+              e.stopPropagation();
+              onSetVisible(!visible);
+            }}
+          >
+            {visible ? <Eye size={11} /> : <EyeOff size={11} />}
+          </Button>
+        </div>
 
         <span
-          className="flex-1 min-w-0 text-[10px] truncate text-content"
+          className="flex-1 min-w-0 text-[10px] truncate font-semibold text-content ml-1"
           title={fileName}
         >
           {fileName}
@@ -75,47 +117,16 @@ export function ToolpathSection({
 
         <Button
           variant="ghost"
-          className="ml-1 shrink-0"
-          title={
-            colorized
-              ? "Disable colorized toolpath"
-              : "Enable colorized toolpath"
-          }
-          aria-label={
-            colorized
-              ? "Disable colorized toolpath"
-              : "Enable colorized toolpath"
-          }
-          onClick={(e) => {
-            e.stopPropagation();
-            onSetColorized(!colorized);
-          }}
-        >
-          <Palette
-            size={11}
-            className={colorized ? "text-sky-400" : "text-content-faint"}
-          />
-        </Button>
-
-        <Button
-          variant="ghost"
-          className="ml-1 shrink-0"
-          title={visible ? "Hide toolpath" : "Show toolpath"}
-          aria-label={visible ? "Hide toolpath" : "Show toolpath"}
-          onClick={(e) => {
-            e.stopPropagation();
-            onSetVisible(!visible);
-          }}
-        >
-          {visible ? <Eye size={11} /> : <EyeOff size={11} />}
-        </Button>
-
-        <Button
-          variant="ghost"
-          className={`ml-1 shrink-0 ${
+          size="icon-xs"
+          className={`shrink-0 ml-1 ${
             isJobActive ? "opacity-30 cursor-not-allowed" : "hover:text-accent"
           }`}
           title={
+            isJobActive
+              ? "Cannot clear toolpath while job is running"
+              : "Clear toolpath"
+          }
+          aria-label={
             isJobActive
               ? "Cannot clear toolpath while job is running"
               : "Clear toolpath"

--- a/tests/component/PropertiesPanel.test.tsx
+++ b/tests/component/PropertiesPanel.test.tsx
@@ -343,7 +343,9 @@ describe("PropertiesPanel", () => {
       },
     });
     render(<PropertiesPanel />);
+    expect(screen.getByText("GCODE")).toBeInTheDocument();
     expect(screen.getByText("test.gcode")).toBeInTheDocument();
+    expect(screen.getByText("test.gcode")).toHaveClass("font-semibold");
   });
 
   it("shows gcode properties expanded by default", () => {


### PR DESCRIPTION
Add a section header for the gcode layer.
Make icon sizes match.
Move icons to left to free up room for gcode filename.

<img width="405" height="277" alt="image" src="https://github.com/user-attachments/assets/92e2aace-ea46-4c69-b3d6-37c6f7af379e" />
