### PR TITLE
Chore/improve generate gcode dialog layer option text and fix invalid fill warning

### DIFF
--- a/src/renderer/src/features/gcode-options/components/OutputSection.tsx
+++ b/src/renderer/src/features/gcode-options/components/OutputSection.tsx
@@ -168,7 +168,7 @@ export function OutputSection({
               Export one file per colour group
             </div>
             <div className="text-[11px] text-content-muted">
-              Generate a separate G-code file for each detected path fill color
+              Generate a separate G-code file for each detected source color
               - ideal for pen-swap workflows.
             </div>
             {prefs.exportPerColor && colorGroupCount === 0 && (

--- a/src/renderer/src/store/canvasSelectors/shell.ts
+++ b/src/renderer/src/store/canvasSelectors/shell.ts
@@ -31,8 +31,8 @@ export const selectGcodeOptionsDialogCanvasState = (state: CanvasState) => ({
   colorGroupCount: new Set(
     state.imports.flatMap((imp) =>
       imp.paths
-        .filter((p) => p.hasFill && !!p.fillColor)
-        .map((p) => normalizeSvgColor(p.fillColor ?? "")),
+        .map((p) => normalizeSvgColor(p.sourceColor ?? ""))
+        .filter((color): color is string => !!color),
     ),
   ).size,
   pageTemplate: state.pageTemplate,


### PR DESCRIPTION
Change text from "detected path fill" to "detected source colour" and fix warning that was not counting stroke colours (only fill).

<img width="760" height="1039" alt="image" src="https://github.com/user-attachments/assets/d5b408c0-b14d-4711-8fac-7c0d53338f86" />
