### PR TITLE
Feature: Add hide and collapse side panels feature

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,6 +30,8 @@ export default function App() {
   }, [theme]);
 
   const [showJog, setShowJog] = useState(true);
+  const [showFileBrowser, setShowFileBrowser] = useState(true);
+  const [showProperties, setShowProperties] = useState(true);
   // null = use CSS default (aligned with right panel + 16px gap); set when user first drags
   const [jogPos, setJogPos] = useState<{ x: number; y: number } | null>(null);
   const jogPanelRef = useRef<HTMLDivElement>(null);
@@ -129,8 +131,27 @@ export default function App() {
       {/* Main work area */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left panel — SD card file browser */}
-        <aside className="w-60 bg-panel border-r border-border-ui overflow-y-auto shrink-0">
-          <FileBrowserPanel />
+        <aside
+          className={`${showFileBrowser ? "w-60" : "w-8"} bg-panel border-r border-border-ui overflow-hidden shrink-0 transition-[width] duration-200 ease-in-out`}
+        >
+          {showFileBrowser ? (
+            <FileBrowserPanel onHide={() => setShowFileBrowser(false)} />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowFileBrowser(true)}
+              aria-label="Show file browser panel"
+              title="Show file browser"
+              className="h-full w-full flex flex-col items-stretch text-content-muted hover:text-content transition-colors"
+            >
+              <span className="h-8 w-full flex items-center justify-center hover:bg-secondary border-b border-border-ui">
+                <span aria-hidden="true" className="text-xs font-semibold">
+                  &gt;
+                </span>
+              </span>
+              <span className="flex-1" />
+            </button>
+          )}
         </aside>
 
         {/* Centre — plot canvas */}
@@ -141,8 +162,27 @@ export default function App() {
         </main>
 
         {/* Right panel — object properties */}
-        <aside className="w-64 bg-panel border-l border-border-ui overflow-y-auto shrink-0">
-          <PropertiesPanel />
+        <aside
+          className={`${showProperties ? "w-64" : "w-8"} bg-panel border-l border-border-ui overflow-hidden shrink-0 transition-[width] duration-200 ease-in-out`}
+        >
+          {showProperties ? (
+            <PropertiesPanel onHide={() => setShowProperties(false)} />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowProperties(true)}
+              aria-label="Show properties panel"
+              title="Show properties"
+              className="h-full w-full flex flex-col items-stretch text-content-muted hover:text-content transition-colors"
+            >
+              <span className="h-8 w-full flex items-center justify-center hover:bg-secondary border-b border-border-ui">
+                <span aria-hidden="true" className="text-xs font-semibold">
+                  &lt;
+                </span>
+              </span>
+              <span className="flex-1" />
+            </button>
+          )}
         </aside>
       </div>
 

--- a/src/renderer/src/components/FileBrowserPanel/FileBrowserPanel.tsx
+++ b/src/renderer/src/components/FileBrowserPanel/FileBrowserPanel.tsx
@@ -7,7 +7,11 @@ import { useVerticalSplit } from "./hooks/useVerticalSplit";
 
 // ── Main panel ─────────────────────────────────────────────────────────────────
 
-export function FileBrowserPanel() {
+interface FileBrowserPanelProps {
+  onHide?: () => void;
+}
+
+export function FileBrowserPanel({ onHide }: FileBrowserPanelProps = {}) {
   const connected = useMachineStore((s) => s.connected);
   const activeConfig = useMachineStore((s) => s.activeConfig);
   const serialMode = connected && activeConfig()?.connection.type === "usb";
@@ -32,10 +36,21 @@ export function FileBrowserPanel() {
   return (
     <div className="flex flex-col h-full">
       {/* Title */}
-      <div className="flex items-center px-3 py-2 border-b border-border-ui shrink-0">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border-ui shrink-0">
         <span className="text-xs font-semibold uppercase tracking-wider text-content-muted">
           File Browser
         </span>
+        {onHide && (
+          <button
+            type="button"
+            onClick={onHide}
+            aria-label="Hide file browser panel"
+            title="Hide file browser"
+            className="text-xs text-content-muted hover:text-content transition-colors"
+          >
+            &lt;
+          </button>
+        )}
       </div>
 
       {/* Pane container */}

--- a/src/renderer/src/components/PropertiesPanel.tsx
+++ b/src/renderer/src/components/PropertiesPanel.tsx
@@ -2,16 +2,20 @@ import { PanelHeading } from "../features/properties-panel/components/PanelHeadi
 import { PanelContainer } from "../features/properties-panel/components/PanelContainer";
 import { LayersPanelContent } from "../features/properties-panel/components/LayersPanelContent";
 
+interface PropertiesPanelProps {
+  onHide?: () => void;
+}
+
 /**
  * Properties panel — the right-side sidebar.
  *
  * Delegates all hook orchestration and rendering to LayersPanelContent
  * (in the properties-panel feature domain) to keep this entry point thin.
  */
-export function PropertiesPanel() {
+export function PropertiesPanel({ onHide }: PropertiesPanelProps = {}) {
   return (
     <PanelContainer>
-      <PanelHeading />
+      <PanelHeading onHide={onHide} />
       <LayersPanelContent />
     </PanelContainer>
   );

--- a/src/renderer/src/features/properties-panel/components/PanelHeading.tsx
+++ b/src/renderer/src/features/properties-panel/components/PanelHeading.tsx
@@ -1,10 +1,25 @@
 /** Fixed heading strip shown at the top of the Properties panel. */
-export function PanelHeading() {
+interface PanelHeadingProps {
+  onHide?: () => void;
+}
+
+export function PanelHeading({ onHide }: PanelHeadingProps = {}) {
   return (
-    <div className="px-3 py-2 border-b border-border-ui shrink-0">
+    <div className="px-3 py-2 border-b border-border-ui shrink-0 flex items-center justify-between">
       <span className="text-xs font-semibold uppercase tracking-wider text-content-muted">
         Properties
       </span>
+      {onHide && (
+        <button
+          type="button"
+          onClick={onHide}
+          aria-label="Hide properties panel"
+          title="Hide properties"
+          className="text-xs text-content-muted hover:text-content transition-colors"
+        >
+          &gt;
+        </button>
+      )}
     </div>
   );
 }

--- a/tests/component/App.test.tsx
+++ b/tests/component/App.test.tsx
@@ -66,6 +66,28 @@ describe("App", () => {
     expect(screen.getByText("Properties")).toBeInTheDocument();
   });
 
+  it("collapses and re-expands the file browser panel", async () => {
+    render(<App />);
+    await act(async () => {});
+
+    await userEvent.click(screen.getByLabelText("Hide file browser panel"));
+    expect(screen.queryByText("File Browser")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Show file browser panel"));
+    expect(screen.getByText("File Browser")).toBeInTheDocument();
+  });
+
+  it("collapses and re-expands the properties panel", async () => {
+    render(<App />);
+    await act(async () => {});
+
+    await userEvent.click(screen.getByLabelText("Hide properties panel"));
+    expect(screen.queryByText("Properties")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Show properties panel"));
+    expect(screen.getByText("Properties")).toBeInTheDocument();
+  });
+
   it("subscribes to IPC channels on mount", async () => {
     render(<App />);
     await act(async () => {});


### PR DESCRIPTION
This pull request adds collapsible left (file browser) and right (properties) panels to the main app UI, allowing users to hide and show these panels for a more flexible workspace. The implementation includes new toggle buttons, updates to component props, and tests to ensure the panels behave as expected.

**UI/UX Improvements:**

* Added state and UI logic in `App.tsx` to allow the file browser and properties panels to be collapsed and expanded, with animated transitions and toggle buttons when hidden. [[1]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR33-R34) [[2]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL132-R154) [[3]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL144-R185)

**Component Updates:**

* Updated `FileBrowserPanel` and `PropertiesPanel` to accept an optional `onHide` prop, rendering a hide button in their headers when provided. [[1]](diffhunk://#diff-37787a1ffab671b4e31b383f4d7a1c8d5e8daa67b737d0b20b41aa3e8cf345c6L10-R14) [[2]](diffhunk://#diff-37787a1ffab671b4e31b383f4d7a1c8d5e8daa67b737d0b20b41aa3e8cf345c6L35-R53) [[3]](diffhunk://#diff-495a5392542d25f73dc96ab8da8c9088a6c571d7829a2f1bcf37bd2f96107ae0R5-R18)
* Modified `PanelHeading` to accept an `onHide` prop and render a hide button when applicable.

**Testing:**

* Added tests in `App.test.tsx` to verify that both panels can be collapsed and re-expanded via their respective toggle buttons.