### PR TITLE
Move job control to left panel, add mini state buttons

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,22 +1,50 @@
 import { useEffect, useState, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { Pause, Play, X } from "lucide-react";
 import { Toolbar } from "./components/Toolbar";
 import { FileBrowserPanel } from "./components/FileBrowserPanel";
+import { JobControls } from "./components/JobControls";
 import { PlotCanvas } from "./components/PlotCanvas";
 import { PropertiesPanel } from "./components/PropertiesPanel";
 import { ConsolePanel } from "./components/ConsolePanel";
 import { TaskBar } from "./components/TaskBar";
 import { JogControls } from "./components/JogControls";
+import { ConfirmDialog } from "./components/ConfirmDialog";
+import { useJobStartHandler } from "./components/JobControls/useJobStartHandler";
 import { useMachineStore } from "./store/machineStore";
+import { useCanvasStore } from "./store/canvasStore";
+import { selectJobControlsCanvasState } from "./store/canvasSelectors";
 import { useTaskStore } from "./store/taskStore";
 import { useConsoleStore } from "./store/consoleStore";
 import { useAppConfigStore } from "./store/appConfigStore";
 import { useThemeStore, applyTheme } from "./store/themeStore";
+
+const GCODE_EXTS = [
+  ".gcode",
+  ".nc",
+  ".g",
+  ".gc",
+  ".gco",
+  ".ngc",
+  ".ncc",
+  ".cnc",
+  ".tap",
+];
+
+const isGcodeFile = (name: string) =>
+  GCODE_EXTS.some((ext) => name.toLowerCase().endsWith(ext));
 
 export default function App() {
   const setConfigs = useMachineStore((s) => s.setConfigs);
   const setStatus = useMachineStore((s) => s.setStatus);
   const setWsLive = useMachineStore((s) => s.setWsLive);
   const setFwInfo = useMachineStore((s) => s.setFwInfo);
+  const connected = useMachineStore((s) => s.connected);
+  const status = useMachineStore((s) => s.status);
+  const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
+  const { toolpathSelected, gcodeSource, gcodePreviewLoading } = useCanvasStore(
+    useShallow(selectJobControlsCanvasState),
+  );
   const upsertTask = useTaskStore((s) => s.upsertTask);
   const appendLine = useConsoleStore((s) => s.appendLine);
   const setDebugLoggingEnabled = useAppConfigStore(
@@ -35,6 +63,8 @@ export default function App() {
   const [showJog, setShowJog] = useState(true);
   const [showFileBrowser, setShowFileBrowser] = useState(true);
   const [showProperties, setShowProperties] = useState(true);
+  const [showCollapsedAbortConfirm, setShowCollapsedAbortConfirm] =
+    useState(false);
   // null = use CSS default (aligned with right panel + 16px gap); set when user first drags
   const [jogPos, setJogPos] = useState<{ x: number; y: number } | null>(null);
   const jogPanelRef = useRef<HTMLDivElement>(null);
@@ -75,6 +105,56 @@ export default function App() {
   };
   const onJogDragEnd = () => {
     jogDragRef.current = null;
+  };
+
+  const startJob = useJobStartHandler();
+
+  const effectiveJobFile =
+    selectedJobFile ??
+    (toolpathSelected && gcodeSource
+      ? {
+          path: gcodeSource.path,
+          source: gcodeSource.source,
+          name: gcodeSource.name,
+        }
+      : null);
+
+  const jobFileValid =
+    effectiveJobFile != null && isGcodeFile(effectiveJobFile.name);
+
+  const isJobRunning = status?.state === "Run";
+  const isJobHeld = status?.state === "Hold";
+  const isJobActive = isJobRunning || isJobHeld;
+  const lineNum = status?.lineNum;
+  const lineTotal = status?.lineTotal;
+  const jobProgress =
+    lineNum != null && lineTotal != null && lineTotal > 0
+      ? Math.round((lineNum / lineTotal) * 100)
+      : null;
+  const collapsedPrimaryButtonTone = isJobRunning
+    ? "bg-secondary hover:bg-secondary-hover text-content"
+    : "bg-accent hover:bg-accent-hover text-white";
+
+  const handleCollapsedPrimaryAction = async (
+    e: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    e.stopPropagation();
+    if (isJobRunning) {
+      await window.terraForge.fluidnc.pauseJob();
+      return;
+    }
+    if (isJobHeld) {
+      await window.terraForge.fluidnc.resumeJob();
+      return;
+    }
+    if (effectiveJobFile && jobFileValid) {
+      await startJob(effectiveJobFile);
+    }
+  };
+
+  const handleCollapsedAbort = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setShowCollapsedAbortConfirm(true);
   };
 
   // ─── Bootstrap ─────────────────────────────────────────────────────────────
@@ -135,18 +215,45 @@ export default function App() {
       {/* Top toolbar */}
       <Toolbar showJog={showJog} onToggleJog={() => setShowJog((v) => !v)} />
 
+      {showCollapsedAbortConfirm && (
+        <ConfirmDialog
+          title="Abort Job"
+          message="Abort the current job? The machine will stop immediately and remaining moves will be cancelled."
+          confirmLabel="Abort"
+          onConfirm={async () => {
+            setShowCollapsedAbortConfirm(false);
+            await window.terraForge.fluidnc.abortJob();
+          }}
+          onCancel={() => setShowCollapsedAbortConfirm(false)}
+        />
+      )}
+
       {/* Main work area */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left panel — SD card file browser */}
         <aside
-          className={`${showFileBrowser ? "w-60" : "w-8"} bg-panel border-r border-border-ui overflow-hidden shrink-0 transition-[width] duration-200 ease-in-out`}
+          className={`${showFileBrowser ? "w-60 overflow-hidden" : "w-9 overflow-visible"} bg-panel border-r border-border-ui shrink-0 transition-[width] duration-200 ease-in-out`}
         >
           {showFileBrowser ? (
-            <FileBrowserPanel onHide={() => setShowFileBrowser(false)} />
+            <div className="h-full flex flex-col">
+              <div className="flex-1 min-h-0">
+                <FileBrowserPanel onHide={() => setShowFileBrowser(false)} />
+              </div>
+              <div className="h-40 border-t border-border-ui shrink-0">
+                <JobControls />
+              </div>
+            </div>
           ) : (
-            <button
-              type="button"
+            <div
+              role="button"
+              tabIndex={0}
               onClick={() => setShowFileBrowser(true)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setShowFileBrowser(true);
+                }
+              }}
               aria-label="Show file browser panel"
               title="Show file browser"
               className="h-full w-full flex flex-col items-stretch text-content-muted hover:text-content transition-colors"
@@ -157,20 +264,114 @@ export default function App() {
                 </span>
               </span>
               <span className="flex-1" />
-            </button>
+
+              {/* Collapsed job zone keeps same visual split as expanded file/job layout */}
+              <div className="h-40 border-t border-border-ui shrink-0 flex flex-col items-end justify-end pl-1 pr-1.5 pb-2 gap-1.5">
+                {isJobActive && (
+                  <div
+                    className="relative group"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      type="button"
+                      aria-label="Collapsed job progress"
+                      title="Show job progress"
+                      className="w-6 h-2 rounded bg-secondary border border-border-ui overflow-hidden"
+                    >
+                      <span
+                        className="block h-full bg-accent transition-all duration-300"
+                        style={{ width: `${jobProgress ?? 30}%` }}
+                      />
+                    </button>
+
+                    <div className="hidden group-hover:block group-focus-within:block absolute left-full ml-2 bottom-0 w-44 rounded border border-border-ui bg-panel shadow-xl p-2 text-[10px] text-content z-20">
+                      <div className="font-semibold uppercase tracking-wide text-content-muted mb-1">
+                        {isJobHeld ? "Paused" : "Running"}
+                      </div>
+                      <div className="truncate mb-1" title={effectiveJobFile?.name}>
+                        {effectiveJobFile?.name ?? "Current job"}
+                      </div>
+                      <div className="h-2 rounded bg-secondary overflow-hidden mb-1">
+                        <div
+                          className="h-full bg-accent transition-all duration-300"
+                          style={{ width: `${jobProgress ?? 30}%` }}
+                        />
+                      </div>
+                      <div className="text-content-faint">
+                        {lineNum != null && lineTotal != null
+                          ? `line ${lineNum.toLocaleString()} / ${lineTotal.toLocaleString()}${jobProgress != null ? ` (${jobProgress}%)` : ""}`
+                          : "Progress pending..."}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <button
+                  type="button"
+                  aria-label={
+                    isJobRunning
+                      ? "Pause job"
+                      : isJobHeld
+                        ? "Resume job"
+                        : "Start job"
+                  }
+                  title={
+                    isJobRunning
+                      ? "Pause job"
+                      : isJobHeld
+                        ? "Resume job"
+                        : jobFileValid
+                          ? "Start job"
+                          : "Select a G-code file to start"
+                  }
+                  onClick={(e) => void handleCollapsedPrimaryAction(e)}
+                  disabled={
+                    !connected ||
+                    (!isJobActive && (!jobFileValid || gcodePreviewLoading))
+                  }
+                  className={`h-6 w-6 inline-flex items-center justify-center rounded border border-border-ui ${collapsedPrimaryButtonTone} disabled:opacity-40 disabled:cursor-not-allowed transition-colors`}
+                >
+                  {isJobRunning ? (
+                    <Pause className="h-3.5 w-3.5" strokeWidth={2.25} />
+                  ) : (
+                    <Play className="h-3.5 w-3.5" strokeWidth={2.25} />
+                  )}
+                </button>
+                {isJobActive && (
+                  <button
+                    type="button"
+                    aria-label="Abort job"
+                    title="Abort job"
+                    onClick={handleCollapsedAbort}
+                    disabled={!connected}
+                    className="h-6 w-6 inline-flex items-center justify-center rounded border border-border-ui bg-red-800 hover:bg-red-700 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <X className="h-3.5 w-3.5" strokeWidth={2.25} />
+                  </button>
+                )}
+              </div>
+            </div>
           )}
         </aside>
 
-        {/* Centre — plot canvas */}
-        <main className="flex-1 overflow-visible relative">
-          <PlotCanvas />
-          {/* Toast stack — absolute within canvas area, clear of side panels */}
-          <TaskBar />
-        </main>
+        {/* Centre column — canvas + bottom console/job row */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <main className="flex-1 overflow-visible relative">
+            <PlotCanvas />
+            {/* Toast stack — absolute within canvas area, clear of side panels */}
+            <TaskBar />
+          </main>
+
+          {/* Bottom — console */}
+          <div className="h-40 bg-panel border-t border-border-ui shrink-0">
+            <ConsolePanel />
+          </div>
+        </div>
 
         {/* Right panel — object properties */}
         <aside
-          className={`${showProperties ? "w-64" : "w-8"} bg-panel border-l border-border-ui overflow-hidden shrink-0 transition-[width] duration-200 ease-in-out`}
+          className={`${showProperties ? "w-64" : "w-9"} bg-panel border-l border-border-ui overflow-hidden shrink-0 transition-[width] duration-200 ease-in-out`}
         >
           {showProperties ? (
             <PropertiesPanel onHide={() => setShowProperties(false)} />
@@ -191,11 +392,6 @@ export default function App() {
             </button>
           )}
         </aside>
-      </div>
-
-      {/* Bottom — console + job progress */}
-      <div className="h-40 bg-panel border-t border-border-ui shrink-0">
-        <ConsolePanel />
       </div>
 
       {/* Jog panel — fixed to viewport, below modals/dialogs */}

--- a/src/renderer/src/components/ConfirmDialog.tsx
+++ b/src/renderer/src/components/ConfirmDialog.tsx
@@ -16,6 +16,7 @@
  */
 
 import React from "react";
+import { AlertTriangle } from "lucide-react";
 import { Button } from "./ui";
 
 interface Props {
@@ -63,7 +64,7 @@ export function ConfirmDialog({
       >
         {variant === "warning" && (
           <div className="flex items-center gap-2 px-5 py-3 bg-orange-500/10 border-b border-orange-500/30">
-            <span className="text-orange-400 text-base leading-none">⚠</span>
+            <AlertTriangle className="text-orange-400 shrink-0" size={16} strokeWidth={2.25} />
             <span className="text-xs font-semibold uppercase tracking-wider text-orange-400">
               Warning
             </span>

--- a/src/renderer/src/components/ConsolePanel.tsx
+++ b/src/renderer/src/components/ConsolePanel.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useConsoleStore } from "../store/consoleStore";
 import { useMachineStore } from "../store/machineStore";
 import { useAppConfigStore } from "../store/appConfigStore";
-import { JobControls } from "./JobControls";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { useStableMachineState } from "../hooks/useStableMachineState";
 import { ConsoleToolbar } from "./ConsolePanel/ConsoleToolbar";
@@ -51,7 +50,7 @@ export function ConsolePanel() {
   };
 
   return (
-    <div className="flex h-full">
+    <div className="h-full flex flex-col overflow-hidden">
       {showRestartConfirm && (
         <ConfirmDialog
           title="Restart Firmware?"
@@ -63,30 +62,22 @@ export function ConsolePanel() {
         />
       )}
 
-      {/* Console log + toolbar + input */}
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <ConsoleToolbar
-          status={status}
-          connected={connected}
-          isAlarm={isAlarm}
-          displayState={displayState}
-          showMachineCoordinates={showMachineCoordinates}
-          resetting={resetting}
-          showRestartConfirm={showRestartConfirm}
-          onFirmwareReset={() => setShowRestartConfirm(true)}
-          onClear={clear}
-          onAlarmClear={() => window.terraForge.fluidnc.sendCommand("$X")}
-        />
+      <ConsoleToolbar
+        status={status}
+        connected={connected}
+        isAlarm={isAlarm}
+        displayState={displayState}
+        showMachineCoordinates={showMachineCoordinates}
+        resetting={resetting}
+        showRestartConfirm={showRestartConfirm}
+        onFirmwareReset={() => setShowRestartConfirm(true)}
+        onClear={clear}
+        onAlarmClear={() => window.terraForge.fluidnc.sendCommand("$X")}
+      />
 
-        <ConsoleLog lines={lines} />
+      <ConsoleLog lines={lines} />
 
-        <ConsoleInput connected={connected} onSend={handleSend} />
-      </div>
-
-      {/* Job controls sidebar */}
-      <div className="w-48 border-l border-border-ui shrink-0">
-        <JobControls />
-      </div>
+      <ConsoleInput connected={connected} onSend={handleSend} />
     </div>
   );
 }

--- a/src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx
+++ b/src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../ui";
 import type { MachineStatus } from "../../../../types";
+import { AlertTriangle } from "lucide-react";
 
 interface ConsoleToolbarProps {
   status: MachineStatus | null;
@@ -44,7 +45,10 @@ export function ConsoleToolbar({
               title="Clear alarm ($X)"
               className="text-xs px-2 py-0.5 rounded bg-red-900 text-red-300 hover:bg-red-700 hover:text-white disabled:opacity-50 animate-pulse"
             >
-              ⚠ ALARM — click to unlock
+              <span className="inline-flex items-center gap-1">
+                <AlertTriangle size={12} strokeWidth={2.25} />
+                <span>ALARM — click to unlock</span>
+              </span>
             </Button>
           ) : (
             <span

--- a/src/renderer/src/components/FileBrowserPanel/components/FileRow.tsx
+++ b/src/renderer/src/components/FileBrowserPanel/components/FileRow.tsx
@@ -1,5 +1,15 @@
 import { formatFileSize, isGcodeFile } from "../utils/pathUtils";
 import type { RemoteFile } from "../../../../../types";
+import {
+  ArrowDownToLine,
+  ChevronRight,
+  Eye,
+  FileText,
+  Folder,
+  Pause,
+  Play,
+  Trash2,
+} from "lucide-react";
 import { Button } from "../../ui";
 
 interface FileRowProps {
@@ -54,7 +64,7 @@ export function FileRow({
       onClick={() => onRowClick(file)}
     >
       <span className="mr-1.5 text-[11px]">
-        {file.isDirectory ? "📁" : "📄"}
+        {file.isDirectory ? <Folder size={12} /> : <FileText size={12} />}
       </span>
       <span className="flex-1 text-[10px] truncate" title={file.name}>
         {file.name}
@@ -67,7 +77,7 @@ export function FileRow({
 
       {file.isDirectory ? (
         <span className="text-content-faint text-[9px] hidden group-hover:block shrink-0">
-          ›
+          <ChevronRight size={10} />
         </span>
       ) : (
         <div
@@ -82,10 +92,11 @@ export function FileRow({
                 e.stopPropagation();
                 onPreview(file);
               }}
+                aria-label="Preview toolpath"
               title="Preview toolpath"
               disabled={previewing === file.path || anyJobActive}
             >
-              {previewing === file.path ? "…" : "👁"}
+                {previewing === file.path ? "…" : <Eye size={12} />}
             </Button>
           )}
 
@@ -97,9 +108,10 @@ export function FileRow({
                 e.stopPropagation();
                 window.terraForge.fluidnc.pauseJob();
               }}
+                aria-label="Pause job"
               title="Pause job"
             >
-              ⏸
+                <Pause size={12} />
             </Button>
           ) : isGcode && isThisHeld ? (
             <Button
@@ -109,9 +121,10 @@ export function FileRow({
                 e.stopPropagation();
                 window.terraForge.fluidnc.resumeJob();
               }}
+                aria-label="Resume job"
               title="Resume job"
             >
-              ▶
+                <Play size={12} />
             </Button>
           ) : isGcode ? (
             <Button
@@ -121,6 +134,7 @@ export function FileRow({
                 e.stopPropagation();
                 onRun(file);
               }}
+                aria-label="Run job now"
               title={
                 hasRunningTransfer
                   ? "Unavailable while a file transfer is running"
@@ -130,7 +144,7 @@ export function FileRow({
               }
               disabled={isLoadingThis || anyJobActive || hasRunningTransfer}
             >
-              ▶
+              <Play size={12} />
             </Button>
           ) : null}
 
@@ -141,6 +155,7 @@ export function FileRow({
               e.stopPropagation();
               onDownload(file);
             }}
+            aria-label="Download file"
             disabled={serialMode || anyJobActive || hasRunningTransfer}
             title={
               hasRunningTransfer
@@ -152,7 +167,7 @@ export function FileRow({
                     : "Download"
             }
           >
-            ↓
+                  <ArrowDownToLine size={12} />
           </Button>
 
           <Button
@@ -162,12 +177,13 @@ export function FileRow({
               e.stopPropagation();
               onDelete(file);
             }}
+            aria-label="Delete file"
             disabled={anyJobActive}
             title={
               anyJobActive ? "Unavailable while a job is running" : "Delete"
             }
           >
-            ✕
+            <Trash2 size={12} />
           </Button>
         </div>
       )}

--- a/src/renderer/src/components/FileBrowserPanel/components/FsPane.tsx
+++ b/src/renderer/src/components/FileBrowserPanel/components/FsPane.tsx
@@ -3,6 +3,14 @@ import { Breadcrumb } from "./Breadcrumb";
 import { FileRow } from "./FileRow";
 import { parentPath } from "../utils/pathUtils";
 import {
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Folder,
+  RefreshCw,
+  Upload,
+} from "lucide-react";
+import {
   useFsPaneController,
   type FsPaneControllerProps,
 } from "../hooks/useFsPaneController";
@@ -121,7 +129,12 @@ export function FsPane({
         <span
           className={`text-[10px] font-bold uppercase tracking-widest ${labelColor}`}
         >
-          {open ? "▾" : "▸"} {label}
+          {open ? (
+            <ChevronDown size={10} className="inline-block align-middle" />
+          ) : (
+            <ChevronRight size={10} className="inline-block align-middle" />
+          )}{" "}
+          {label}
         </span>
         {open && (
           <button
@@ -138,7 +151,7 @@ export function FsPane({
             }
             className={`text-xs disabled:opacity-40 transition-colors ${btnColor}`}
           >
-            {loading ? "…" : "↻"}
+              {loading ? "…" : <RefreshCw size={12} />}
           </button>
         )}
       </div>
@@ -152,9 +165,10 @@ export function FsPane({
               onClick={() => void navigate(parentPath(path))}
               disabled={atRoot || !connected}
               title="Up"
+              aria-label="Up one level"
               className="text-content-muted hover:text-content disabled:opacity-30 mr-0.5 transition-colors leading-none"
             >
-              ↑
+              <ArrowUp size={12} />
             </button>
             <Breadcrumb
               path={path}
@@ -186,7 +200,7 @@ export function FsPane({
                 className="flex items-center px-3 py-1 hover:bg-app cursor-pointer border-b border-border-ui/20 text-content-faint"
                 onClick={() => void navigate(parentPath(path))}
               >
-                <span className="mr-2 text-[11px]">📁</span>
+                <span className="mr-2 text-[11px]"><Folder size={12} /></span>
                 <span className="text-[10px]">..</span>
               </div>
             )}
@@ -223,13 +237,14 @@ export function FsPane({
                     ? "File upload not available over serial"
                     : undefined
               }
+              aria-label="Upload file"
               className={`w-full text-[10px] py-1 rounded disabled:opacity-40 transition-colors ${
                 accentColor === "blue"
                   ? "bg-[var(--tf-fs-blue-border)] hover:bg-[var(--tf-fs-blue-bg)]"
                   : "bg-[var(--tf-fs-purple-border)] hover:bg-[var(--tf-fs-purple-bg)]"
               } text-content`}
             >
-              ↑ Upload to {path}
+              <Upload size={12} className="inline-block mr-1 align-text-bottom" /> Upload to {path}
             </button>
           </div>
         </div>

--- a/src/renderer/src/components/JobControls/JobControls.tsx
+++ b/src/renderer/src/components/JobControls/JobControls.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+import { Pause, Play, X } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "../ui";
 import type { ButtonVariant } from "../ui";
@@ -69,6 +70,7 @@ export function JobControls() {
     variant: ButtonVariant = "secondary",
     disabled = false,
     title?: string,
+    icon?: ReactNode,
   ) => (
     <Button
       variant={variant}
@@ -76,6 +78,7 @@ export function JobControls() {
       disabled={disabled || !connected}
       title={title}
       onClick={onClick}
+      icon={icon}
     >
       {label}
     </Button>
@@ -105,7 +108,7 @@ export function JobControls() {
       {/* Start — only when idle */}
       {!isActive &&
         btn(
-          "▶ Start job",
+          "Start job",
           () => {
             if (effectiveJobFile) startJob(effectiveJobFile);
           },
@@ -116,40 +119,44 @@ export function JobControls() {
               ? `Upload ${effectiveJobFile!.name} to SD card then run`
               : `Run ${effectiveJobFile!.name} on the machine`
             : "Select a G-code file in the File Browser first",
+          <Play className="h-3.5 w-3.5" strokeWidth={2.25} />,
         )}
 
       {/* Pause — only while running */}
       {isRunning &&
         btn(
-          "⏸ Pause",
+          "Pause",
           async () => {
             await window.terraForge.fluidnc.pauseJob();
           },
           "secondary",
           false,
-          "Pause the running job (resume with ▶ Resume)",
+          "Pause the running job (resume with Resume)",
+          <Pause className="h-3.5 w-3.5" strokeWidth={2.25} />,
         )}
 
       {/* Resume — only while held */}
       {isHeld &&
         btn(
-          "▶ Resume",
+          "Resume",
           async () => {
             await window.terraForge.fluidnc.resumeJob();
           },
           "primary",
           false,
           "Resume the paused job",
+          <Play className="h-3.5 w-3.5" strokeWidth={2.25} />,
         )}
 
       {/* Abort — while running or held */}
       {isActive &&
         btn(
-          "✕ Abort",
+          "Abort",
           () => setShowAbortConfirm(true),
           "danger",
           false,
           "Immediately stop the job and cancel remaining moves",
+          <X className="h-3.5 w-3.5" strokeWidth={2.25} />,
         )}
 
       {showAbortConfirm && (

--- a/src/renderer/src/components/JobControls/JobFileIndicator.tsx
+++ b/src/renderer/src/components/JobControls/JobFileIndicator.tsx
@@ -1,3 +1,5 @@
+import { AlertTriangle, FileText, Monitor } from "lucide-react";
+
 interface JobFileIndicatorProps {
   /** The effective job file (may come from file browser or canvas toolpath). */
   effectiveJobFile: {
@@ -33,7 +35,11 @@ export function JobFileIndicator({
         </span>
       ) : jobFileValid ? (
         <span className="text-content">
-          {effectiveJobFile.source === "local" ? "🖥" : "📄"}{" "}
+          {effectiveJobFile.source === "local" ? (
+            <Monitor className="inline-block align-text-bottom" size={12} />
+          ) : (
+            <FileText className="inline-block align-text-bottom" size={12} />
+          )}{" "}
           {effectiveJobFile.name}
           {effectiveJobFile.source === "local" && (
             <span className="text-content-faint ml-1">
@@ -43,7 +49,7 @@ export function JobFileIndicator({
         </span>
       ) : (
         <span className="text-amber-400">
-          ⚠ {effectiveJobFile.name} — not a G-code file
+          <AlertTriangle className="inline-block align-text-bottom" size={12} /> {effectiveJobFile.name} — not a G-code file
         </span>
       )}
     </div>

--- a/src/renderer/src/components/JogControls/JogControls.tsx
+++ b/src/renderer/src/components/JogControls/JogControls.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { X } from "lucide-react";
 import { isSolenoidPenType, type JogStep } from "../../../../types";
 import { useMachineStore } from "../../store/machineStore";
 import { Button } from "../ui";
@@ -76,8 +77,8 @@ export function JogControls({ onClose }: Props) {
           Jog Controls
         </span>
         {onClose && (
-          <Button variant="ghost" size="xs" onClick={onClose}>
-            ✕
+          <Button variant="ghost" size="xs" onClick={onClose} aria-label="Close jog controls" title="Close jog controls">
+            <X size={12} strokeWidth={2.25} />
           </Button>
         )}
       </div>

--- a/src/renderer/src/components/MachineConfigDialog/components/Machine/MachineConfigsSidebar.tsx
+++ b/src/renderer/src/components/MachineConfigDialog/components/Machine/MachineConfigsSidebar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Download, Upload } from "lucide-react";
 import { Button } from "../../../ui";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import {
@@ -108,7 +109,7 @@ export function MachineConfigsSidebar({
           onClick={handleExport}
           title="Export all configs to a JSON file"
         >
-          ↑ Export
+          <Upload className="mr-1 inline-block" size={12} /> Export
         </Button>
         <Button
           variant="secondary"
@@ -117,7 +118,7 @@ export function MachineConfigsSidebar({
           onClick={handleImport}
           title="Import configs from a JSON file"
         >
-          ↓ Import
+          <Download className="mr-1 inline-block" size={12} /> Import
         </Button>
       </div>
     </div>

--- a/src/renderer/src/components/MachineConfigDialog/components/SortableConfigItem.tsx
+++ b/src/renderer/src/components/MachineConfigDialog/components/SortableConfigItem.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Check, GripVertical } from "lucide-react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
@@ -45,7 +46,7 @@ export function SortableConfigItem({
         className="px-2 py-2 cursor-grab active:cursor-grabbing text-content-faint group-hover:text-content-muted flex-shrink-0 select-none"
         title="Drag to reorder"
       >
-        ⠿
+        <GripVertical size={14} />
       </span>
       <button
         onClick={onSelect}
@@ -54,7 +55,7 @@ export function SortableConfigItem({
         }`}
       >
         {config.name}
-        {isActive && <span className="ml-1 text-xs text-green-400">✓</span>}
+        {isActive && <Check className="ml-1 inline-block text-green-400" size={12} strokeWidth={2.5} />}
       </button>
     </div>
   );

--- a/src/renderer/src/components/PlotCanvas/components/PlotCanvasControls.tsx
+++ b/src/renderer/src/components/PlotCanvas/components/PlotCanvasControls.tsx
@@ -54,7 +54,7 @@ export function PlotCanvasControls({
           aria-keyshortcuts="Control+0"
           aria-pressed={fitted}
           onClick={onFit}
-          className="text-[11px] font-bold leading-none"
+          className="text-base font-bold leading-none"
         >
           ⊡
         </Button>

--- a/src/renderer/src/components/TaskBar.tsx
+++ b/src/renderer/src/components/TaskBar.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from "react";
+import { Check, CircleX, X } from "lucide-react";
 import { useTaskStore } from "../store/taskStore";
 import type { BackgroundTask } from "../../../../types";
 import { Button } from "./ui";
 
 /** Completed / cancelled toasts auto-dismiss after this delay. */
 const DISMISS_MS = 8000;
-/** Errors and warnings are never auto-dismissed — user must click ✕. */
+/** Errors and warnings are never auto-dismissed — user must click the close button. */
 const AUTO_DISMISS_STATUSES: ReadonlySet<string> = new Set([
   "completed",
   "cancelled",
@@ -70,10 +71,10 @@ function Toast({ task }: { task: BackgroundTask }) {
         </div>
       )}
       {isDone && (
-        <span className="text-green-400 text-sm shrink-0 leading-none">✓</span>
+        <Check className="text-green-400 shrink-0" size={14} strokeWidth={2.5} />
       )}
       {isCancelled && (
-        <span className="text-accent text-sm shrink-0 leading-none">✕</span>
+        <CircleX className="text-accent shrink-0" size={14} strokeWidth={2} />
       )}
       {isWarning && (
         <span className="text-yellow-400 text-xs shrink-0 leading-none font-bold">
@@ -119,7 +120,7 @@ function Toast({ task }: { task: BackgroundTask }) {
           title="Cancel task"
           className="text-xs shrink-0 leading-none ml-1 hover:text-accent"
         >
-          ✕
+          <X size={12} strokeWidth={2.25} />
         </Button>
       ) : (
         <Button
@@ -129,7 +130,7 @@ function Toast({ task }: { task: BackgroundTask }) {
           title="Dismiss"
           className="text-xs shrink-0 leading-none ml-1 hover:text-content-muted"
         >
-          ✕
+          <X size={12} strokeWidth={2.25} />
         </Button>
       )}
     </div>

--- a/src/renderer/src/components/Toolbar/ToolbarRightSection.tsx
+++ b/src/renderer/src/components/Toolbar/ToolbarRightSection.tsx
@@ -1,4 +1,4 @@
-import { Moon, Sun } from "lucide-react";
+import { Moon, Settings, Sun } from "lucide-react";
 import { Button } from "../ui";
 import { ConnectionStatus } from "./ConnectionStatus";
 
@@ -47,7 +47,7 @@ export function ToolbarRightSection({
         aria-label="Machine settings"
         title="Machine settings"
       >
-        ⚙
+        <Settings size={14} aria-hidden="true" />
       </Button>
     </div>
   );

--- a/src/renderer/src/features/properties-panel/components/GroupHeaderRow.tsx
+++ b/src/renderer/src/features/properties-panel/components/GroupHeaderRow.tsx
@@ -1,5 +1,5 @@
 import type { DragEvent } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
 import { Button } from "../../../components/ui";
 import type { LayerGroup } from "../../../../types";
 
@@ -112,9 +112,10 @@ export function GroupHeaderRow({
         variant="ghost"
         className="hover:text-accent shrink-0"
         title="Delete group (layers become ungrouped)"
+        aria-label="Delete group"
         onClick={() => onRemoveGroup(group.id)}
       >
-        ✕
+        <X size={12} strokeWidth={2.25} />
       </Button>
     </div>
   );

--- a/src/renderer/src/features/properties-panel/components/ImportHeaderRow.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportHeaderRow.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react";
+import { ChevronDown, ChevronRight, Eye, EyeOff, GripVertical, X } from "lucide-react";
 import { Button } from "../../../components/ui";
 import { useImportHeaderRowModel } from "../hooks/useImportHeaderRowModel";
 import { ImportNameField } from "./ImportNameField";
@@ -55,7 +55,7 @@ export function ImportHeaderRow({
         onDragStart={onDragHandleStart}
         onDragEnd={onDragHandleEnd}
       >
-        ⠿
+        <GripVertical size={10} />
       </span>
 
       <Button
@@ -95,9 +95,10 @@ export function ImportHeaderRow({
         size="icon-xs"
         className="ml-1 hover:text-accent shrink-0"
         title="Delete import"
+        aria-label="Delete import"
         onClick={onDeleteClick}
       >
-        ✕
+        <X size={12} strokeWidth={2.25} />
       </Button>
     </div>
   );

--- a/src/renderer/src/features/properties-panel/components/ImportPathsList.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/ImportPathsList.test.tsx
@@ -79,7 +79,7 @@ describe("ImportPathsList", () => {
     fireEvent.click(screen.getAllByLabelText("Disable path stroke")[0]);
     expect(onUpdatePathStroke).toHaveBeenCalledWith("imp-1", "p1", false);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "✕" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove path" })[0]);
     expect(onRemovePath).toHaveBeenCalledWith("imp-1", "p1");
 
     fireEvent.click(screen.getByText("loose"));

--- a/src/renderer/src/features/properties-panel/components/PathRow.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/PathRow.test.tsx
@@ -33,7 +33,7 @@ describe("PathRow", () => {
     fireEvent.click(screen.getByLabelText("Disable path stroke"));
     expect(onToggleStroke).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "✕" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove path" }));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 

--- a/src/renderer/src/features/properties-panel/components/PathRow.tsx
+++ b/src/renderer/src/features/properties-panel/components/PathRow.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, Repeat } from "lucide-react";
+import { Eye, EyeOff, Repeat, X } from "lucide-react";
 import { Button } from "../../../components/ui";
 
 interface PathRowProps {
@@ -77,9 +77,10 @@ export function PathRow({
         variant="ghost"
         className="hover:text-accent"
         title="Remove path"
+        aria-label="Remove path"
         onClick={onRemove}
       >
-        ✕
+        <X size={12} strokeWidth={2.25} />
       </Button>
     </div>
   );

--- a/src/renderer/src/features/properties-panel/components/ToolpathSection.tsx
+++ b/src/renderer/src/features/properties-panel/components/ToolpathSection.tsx
@@ -5,6 +5,7 @@ import {
   EyeOff,
   FileText,
   Palette,
+  X,
 } from "lucide-react";
 import { Button } from "../../../components/ui";
 import type { GcodeToolpath } from "../../../utils/gcodeParser";
@@ -137,7 +138,7 @@ export function ToolpathSection({
             onClear();
           }}
         >
-          ✕
+          <X size={12} strokeWidth={2.25} />
         </Button>
       </div>
 

--- a/tests/component/App.test.tsx
+++ b/tests/component/App.test.tsx
@@ -249,7 +249,7 @@ describe("App", () => {
   it("closing jog panel hides the drag handle", async () => {
     render(<App />);
     await act(async () => {});
-    const closeBtn = screen.getByText("✕");
+    const closeBtn = screen.getByLabelText("Close jog controls");
     await userEvent.click(closeBtn);
     expect(screen.queryByTitle("Drag to move")).not.toBeInTheDocument();
   });

--- a/tests/component/App.test.tsx
+++ b/tests/component/App.test.tsx
@@ -77,6 +77,59 @@ describe("App", () => {
     expect(screen.getByText("File Browser")).toBeInTheDocument();
   });
 
+  it("shows collapsed mini job controls when file browser is hidden and a job is active", async () => {
+    useMachineStore.setState({
+      connected: true,
+      selectedJobFile: {
+        path: "/demo.gcode",
+        source: "sd",
+        name: "demo.gcode",
+      },
+      status: {
+        raw: "<Run|MPos:0,0,0|Ln:25/100>",
+        state: "Run",
+        mpos: { x: 0, y: 0, z: 0 },
+        wpos: { x: 0, y: 0, z: 0 },
+        lineNum: 25,
+        lineTotal: 100,
+      },
+    });
+
+    render(<App />);
+    await act(async () => {});
+
+    await userEvent.click(screen.getByLabelText("Hide file browser panel"));
+    expect(screen.getByLabelText("Collapsed job progress")).toBeInTheDocument();
+    expect(screen.getByLabelText("Pause job")).toBeInTheDocument();
+    expect(screen.getByLabelText("Abort job")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Pause job"));
+    expect(window.terraForge.fluidnc.pauseJob).toHaveBeenCalled();
+  });
+
+  it("hides collapsed abort button when job is not active", async () => {
+    useMachineStore.setState({
+      connected: true,
+      selectedJobFile: {
+        path: "/demo.gcode",
+        source: "sd",
+        name: "demo.gcode",
+      },
+      status: {
+        raw: "<Idle|MPos:0,0,0>",
+        state: "Idle",
+        mpos: { x: 0, y: 0, z: 0 },
+        wpos: { x: 0, y: 0, z: 0 },
+      },
+    });
+
+    render(<App />);
+    await act(async () => {});
+
+    await userEvent.click(screen.getByLabelText("Hide file browser panel"));
+    expect(screen.queryByLabelText("Abort job")).not.toBeInTheDocument();
+  });
+
   it("collapses and re-expands the properties panel", async () => {
     render(<App />);
     await act(async () => {});

--- a/tests/component/ConsolePanel.test.tsx
+++ b/tests/component/ConsolePanel.test.tsx
@@ -251,10 +251,5 @@ describe("ConsolePanel", () => {
     expect(window.terraForge.fluidnc.disconnectWebSocket).toHaveBeenCalled();
   });
 
-  // ── JobControls rendered ────────────────────────────────────────────────
-
-  it("renders JobControls sidebar inside ConsolePanel", () => {
-    render(<ConsolePanel />);
-    expect(screen.getByText("Job")).toBeInTheDocument();
-  });
+  // Job controls are rendered in the left panel by App layout.
 });

--- a/tests/component/JobControls.test.tsx
+++ b/tests/component/JobControls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMachineStore } from "@renderer/store/machineStore";
 import { useTaskStore } from "@renderer/store/taskStore";
@@ -69,7 +69,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    const btn = screen.getByText("▶ Start job");
+    const btn = screen.getByText("Start job");
     expect(btn).toBeDisabled();
   });
 
@@ -101,7 +101,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    expect(screen.getByText("⏸ Pause")).toBeInTheDocument();
+    expect(screen.getByText("Pause")).toBeInTheDocument();
   });
 
   it("shows Resume button when held", () => {
@@ -115,7 +115,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    expect(screen.getByText("▶ Resume")).toBeInTheDocument();
+    expect(screen.getByText("Resume")).toBeInTheDocument();
     expect(screen.getByText(/Paused/)).toBeInTheDocument();
   });
 
@@ -130,7 +130,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    expect(screen.getByText("✕ Abort")).toBeInTheDocument();
+    expect(screen.getByText("Abort")).toBeInTheDocument();
   });
 
   it("keeps active controls visible through a brief Idle blip", async () => {
@@ -146,7 +146,7 @@ describe("JobControls", () => {
     });
 
     render(<JobControls />);
-    expect(screen.getByText("⏸ Pause")).toBeInTheDocument();
+    expect(screen.getByText("Pause")).toBeInTheDocument();
 
     act(() => {
       useMachineStore.setState({
@@ -159,18 +159,18 @@ describe("JobControls", () => {
       });
     });
 
-    expect(screen.getByText("⏸ Pause")).toBeInTheDocument();
-    expect(screen.queryByText("▶ Start job")).not.toBeInTheDocument();
+    expect(screen.getByText("Pause")).toBeInTheDocument();
+    expect(screen.queryByText("Start job")).not.toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(300);
     });
-    expect(screen.getByText("⏸ Pause")).toBeInTheDocument();
+    expect(screen.getByText("Pause")).toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(250);
     });
-    expect(screen.getByText("▶ Start job")).toBeInTheDocument();
+    expect(screen.getByText("Start job")).toBeInTheDocument();
   });
 
   it("calls pauseJob when Pause clicked", async () => {
@@ -184,7 +184,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    await userEvent.click(screen.getByText("⏸ Pause"));
+    await userEvent.click(screen.getByText("Pause"));
     expect(window.terraForge.fluidnc.pauseJob).toHaveBeenCalled();
   });
 
@@ -199,7 +199,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    await userEvent.click(screen.getByText("▶ Resume"));
+    await userEvent.click(screen.getByText("Resume"));
     expect(window.terraForge.fluidnc.resumeJob).toHaveBeenCalled();
   });
 
@@ -229,7 +229,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    await userEvent.click(screen.getByText("▶ Start job"));
+    await userEvent.click(screen.getByText("Start job"));
     // fetchFileText + 600ms cosmetic pause precede runFile — wait for it
     await waitFor(
       () =>
@@ -256,7 +256,7 @@ describe("JobControls", () => {
       window.terraForge.fluidnc.uploadFile as ReturnType<typeof vi.fn>
     ).mockResolvedValue(undefined);
     render(<JobControls />);
-    await userEvent.click(screen.getByText("▶ Start job"));
+    await userEvent.click(screen.getByText("Start job"));
     expect(window.terraForge.fluidnc.uploadFile).toHaveBeenCalled();
     expect(window.terraForge.fluidnc.runFile).toHaveBeenCalledWith(
       "/art.gcode",
@@ -277,10 +277,10 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    await userEvent.click(screen.getByText("✕ Abort"));
+    await userEvent.click(screen.getByText("Abort"));
     // Themed confirm dialog should appear
-    await screen.findByRole("dialog");
-    await userEvent.click(screen.getByRole("button", { name: "Abort" }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Abort" }));
     expect(window.terraForge.fluidnc.abortJob).toHaveBeenCalled();
   });
 
@@ -295,10 +295,10 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    await userEvent.click(screen.getByText("✕ Abort"));
+    await userEvent.click(screen.getByText("Abort"));
     // Themed confirm dialog should appear
-    await screen.findByRole("dialog");
-    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
     expect(window.terraForge.fluidnc.abortJob).not.toHaveBeenCalled();
   });
 
@@ -330,7 +330,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    expect(screen.getByText("▶ Start job")).toBeDisabled();
+    expect(screen.getByText("Start job")).toBeDisabled();
   });
 
   // ── Canvas toolpath selection ───────────────────────────────────────────
@@ -346,7 +346,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    expect(screen.getByText("▶ Start job")).not.toBeDisabled();
+    expect(screen.getByText("Start job")).not.toBeDisabled();
   });
 
   it("shows canvas toolpath file name in indicator when toolpath selected with no explicit job file", () => {
@@ -375,7 +375,7 @@ describe("JobControls", () => {
       },
     });
     render(<JobControls />);
-    expect(screen.getByText("▶ Start job")).toBeDisabled();
+    expect(screen.getByText("Start job")).toBeDisabled();
   });
 
   it("uploads then runs canvas-selected local toolpath when Start clicked", async () => {
@@ -392,7 +392,7 @@ describe("JobControls", () => {
       window.terraForge.fluidnc.uploadFile as ReturnType<typeof vi.fn>
     ).mockResolvedValue(undefined);
     render(<JobControls />);
-    await userEvent.click(screen.getByText("▶ Start job"));
+    await userEvent.click(screen.getByText("Start job"));
     expect(window.terraForge.fluidnc.uploadFile).toHaveBeenCalled();
     expect(window.terraForge.fluidnc.runFile).toHaveBeenCalledWith(
       "/art.gcode",

--- a/tests/component/JogControls.test.tsx
+++ b/tests/component/JogControls.test.tsx
@@ -132,12 +132,12 @@ describe("JogControls", () => {
   it("renders close button when onClose prop provided", () => {
     const onClose = vi.fn();
     render(<JogControls onClose={onClose} />);
-    expect(screen.getByText("✕")).toBeInTheDocument();
+    expect(screen.getByLabelText("Close jog controls")).toBeInTheDocument();
   });
 
   it("does not render close button when onClose not provided", () => {
     render(<JogControls />);
-    expect(screen.queryByText("✕")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Close jog controls")).not.toBeInTheDocument();
   });
 
   // ── Step selector ───────────────────────────────────────────────────────

--- a/tests/component/MachineConfigDialog.test.tsx
+++ b/tests/component/MachineConfigDialog.test.tsx
@@ -194,8 +194,8 @@ describe("MachineConfigDialog", () => {
   it("shows Export and Import buttons", async () => {
     render(<MachineConfigDialog onClose={onClose} />);
     await act(async () => {});
-    expect(screen.getByText("↑ Export")).toBeInTheDocument();
-    expect(screen.getByText("↓ Import")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Export/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Import/ })).toBeInTheDocument();
   });
 
   it("shows Set as Active button", async () => {
@@ -328,23 +328,21 @@ describe("MachineConfigDialog", () => {
       window.terraForge.config.exportConfigs as ReturnType<typeof vi.fn>
     ).mockResolvedValue(null);
     render(<MachineConfigDialog onClose={onClose} />);
-    await userEvent.click(screen.getByText("↑ Export"));
+    await userEvent.click(screen.getByRole("button", { name: /Export/ }));
     expect(window.terraForge.config.exportConfigs).toHaveBeenCalled();
   });
 
   // ── Import ──────────────────────────────────────────────────────────────
-
   it("calls importConfigs when Import clicked", async () => {
     (
       window.terraForge.config.importConfigs as ReturnType<typeof vi.fn>
     ).mockResolvedValue({ added: 0, skipped: 0 });
     render(<MachineConfigDialog onClose={onClose} />);
-    await userEvent.click(screen.getByText("↓ Import"));
+    await userEvent.click(screen.getByRole("button", { name: /Import/ }));
     expect(window.terraForge.config.importConfigs).toHaveBeenCalled();
   });
 
   // ── Set as Active ───────────────────────────────────────────────────────
-
   it("sets selected config as active", async () => {
     const c1 = createMachineConfig({ name: "First" });
     const c2 = createMachineConfig({ name: "Second" });
@@ -566,7 +564,7 @@ describe("MachineConfigDialog", () => {
         window.terraForge.config.exportConfigs as ReturnType<typeof vi.fn>
       ).mockResolvedValue("/home/user/configs.json");
       render(<MachineConfigDialog onClose={onClose} />);
-      await userEvent.click(screen.getByText("↑ Export"));
+      await userEvent.click(screen.getByRole("button", { name: /Export/ }));
       await screen.findByText("Configs Exported");
       expect(screen.getByText("Configs Exported")).toBeInTheDocument();
       expect(
@@ -586,7 +584,7 @@ describe("MachineConfigDialog", () => {
         window.terraForge.config.getMachineConfigs as ReturnType<typeof vi.fn>
       ).mockResolvedValue([newCfg]);
       render(<MachineConfigDialog onClose={onClose} />);
-      await userEvent.click(screen.getByText("↓ Import"));
+      await userEvent.click(screen.getByRole("button", { name: /Import/ }));
       await screen.findByText("Import Complete");
       expect(screen.getByText("Import Complete")).toBeInTheDocument();
       expect(screen.getByText(/2 configs imported/)).toBeInTheDocument();
@@ -598,7 +596,7 @@ describe("MachineConfigDialog", () => {
         window.terraForge.config.importConfigs as ReturnType<typeof vi.fn>
       ).mockRejectedValue(new Error("disk full"));
       render(<MachineConfigDialog onClose={onClose} />);
-      await userEvent.click(screen.getByText("↓ Import"));
+      await userEvent.click(screen.getByRole("button", { name: /Import/ }));
       await screen.findByText("Import Failed");
       expect(screen.getByText("Import Failed")).toBeInTheDocument();
     });
@@ -608,7 +606,7 @@ describe("MachineConfigDialog", () => {
         window.terraForge.config.exportConfigs as ReturnType<typeof vi.fn>
       ).mockRejectedValue(new Error("permission denied"));
       render(<MachineConfigDialog onClose={onClose} />);
-      await userEvent.click(screen.getByText("↑ Export"));
+      await userEvent.click(screen.getByRole("button", { name: /Export/ }));
       await screen.findByText("Export Failed");
       expect(screen.getByText("Export Failed")).toBeInTheDocument();
     });
@@ -645,7 +643,7 @@ describe("MachineConfigDialog", () => {
       window.terraForge.config.getMachineConfigs as ReturnType<typeof vi.fn>
     ).mockResolvedValue([existing, newCfg]);
     render(<MachineConfigDialog onClose={onClose} />);
-    await userEvent.click(screen.getByText("↓ Import"));
+    await userEvent.click(screen.getByRole("button", { name: /Import/ }));
     // After import, the newly imported config should appear in the list
     await screen.findByText("Newly Imported");
     expect(screen.getByText("Newly Imported")).toBeInTheDocument();

--- a/tests/component/TaskBar.test.tsx
+++ b/tests/component/TaskBar.test.tsx
@@ -39,7 +39,7 @@ describe("TaskBar", () => {
     expect(screen.getByText("75%")).toBeInTheDocument();
   });
 
-  it("shows checkmark for completed task", () => {
+  it("shows completed task controls", () => {
     const task = createBackgroundTask({
       id: "t1",
       label: "Done",
@@ -48,7 +48,8 @@ describe("TaskBar", () => {
     });
     useTaskStore.setState({ tasks: { t1: task } });
     render(<TaskBar />);
-    expect(screen.getByText("✓")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.getByTitle("Dismiss")).toBeInTheDocument();
   });
 
   it("shows error indicator and error message", () => {
@@ -199,9 +200,9 @@ describe("TaskBar", () => {
     vi.useRealTimers();
   });
 
-  // ── Cancelled task shows ✕ icon ────────────────────────────────────────
+  // ── Cancelled task remains visible in the task bar ──────────────────────
 
-  it("shows ✕ icon for cancelled task", () => {
+  it("shows cancelled task entry", () => {
     const task = createBackgroundTask({
       id: "t1",
       label: "Cancelled thing",
@@ -210,7 +211,6 @@ describe("TaskBar", () => {
     });
     useTaskStore.setState({ tasks: { t1: task } });
     render(<TaskBar />);
-    // The cancelled status icon is ✕ (different from dismiss button)
     expect(screen.getByText("Cancelled thing")).toBeInTheDocument();
   });
 });

--- a/tests/component/Toolbar.test.tsx
+++ b/tests/component/Toolbar.test.tsx
@@ -137,7 +137,7 @@ describe("Toolbar", () => {
 
   it("renders settings button", () => {
     render(<Toolbar />);
-    expect(screen.getByText("⚙")).toBeInTheDocument();
+    expect(screen.getByTitle("Machine settings")).toBeInTheDocument();
   });
 
   it("disables machine selector while connected", () => {
@@ -285,11 +285,11 @@ describe("Toolbar", () => {
 
   // ── Settings dialog toggle ────────────────────────────────────────────
 
-  it("⚙ button opens Machine Config dialog", async () => {
+  it("Machine settings button opens Machine Config dialog", async () => {
     const cfg = createMachineConfig({ name: "My Plotter" });
     useMachineStore.setState({ configs: [cfg], activeConfigId: cfg.id });
     render(<Toolbar />);
-    await userEvent.click(screen.getByText("⚙"));
+    await userEvent.click(screen.getByTitle("Machine settings"));
     expect(screen.getByText("Machine Configurations")).toBeInTheDocument();
   });
 

--- a/tests/e2e/connected-file-browser.spec.ts
+++ b/tests/e2e/connected-file-browser.spec.ts
@@ -157,7 +157,7 @@ test("file browser shows gcode files after connecting", async () => {
 test("file browser shows directories with a folder icon", async () => {
   const subdirRow = window.locator("[data-testid='file-row-subdir']");
   await expect(subdirRow).toBeVisible();
-  await expect(subdirRow.locator("text=📁")).toBeVisible();
+  await expect(subdirRow.locator("svg").first()).toBeVisible();
 });
 
 test("file browser shows file size labels for gcode files", async () => {
@@ -230,7 +230,7 @@ test("the '↑ Up' button navigates to the parent directory", async () => {
   });
 
   // Click the Up (↑) button in the breadcrumb bar.
-  await window.locator("button[title='Up']").first().click();
+  await window.locator("button[aria-label='Up one level']").first().click();
 
   await expect(window.locator("text=plot.gcode").first()).toBeVisible({
     timeout: 5_000,
@@ -257,8 +257,7 @@ test("clicking Refresh re-fetches the file listing", async () => {
 // ─── Group 5: Upload ────────────────────────────────────────────────────────
 
 test("Upload footer button is visible and enabled when connected", async () => {
-  // Upload button text includes "↑ Upload to"
-  const uploadBtn = window.locator("button:has-text('↑ Upload to')").first();
+  const uploadBtn = window.locator("button[aria-label='Upload file']").first();
   await expect(uploadBtn).toBeEnabled({ timeout: 3000 });
 });
 
@@ -266,7 +265,7 @@ test("clicking Upload triggers a file open dialog", async () => {
   // Mock the dialog to return sample.gcode.
   await mockOpenDialog(electronApp, fixturePath("sample.gcode"));
 
-  const uploadBtn = window.locator("button:has-text('↑ Upload to')").first();
+  const uploadBtn = window.locator("button[aria-label='Upload file']").first();
   await uploadBtn.click();
 
   // The mocked uploadFile IPC should be called.

--- a/tests/e2e/file-browser.spec.ts
+++ b/tests/e2e/file-browser.spec.ts
@@ -107,7 +107,7 @@ test("breadcrumb shows root path when offline", async () => {
 
 // ─── Job controls integration ───────────────────────────────────────────────
 
-test("Job controls section is visible in console area", async () => {
+test("Job controls section is visible in the left panel", async () => {
   const jobLabel = window.locator("text=Job").first();
   await expect(jobLabel).toBeVisible();
 });

--- a/tests/e2e/file-browser.spec.ts
+++ b/tests/e2e/file-browser.spec.ts
@@ -51,7 +51,7 @@ test("file browser shows 'Not connected' when offline", async () => {
 
 test("upload buttons are disabled when offline", async () => {
   // Both internal and sdcard panes have upload buttons
-  const uploadButtons = window.locator("button:has-text('Upload')");
+  const uploadButtons = window.locator("button[aria-label='Upload file']");
   const count = await uploadButtons.count();
   for (let i = 0; i < count; i++) {
     await expect(uploadButtons.nth(i)).toBeDisabled();
@@ -60,7 +60,7 @@ test("upload buttons are disabled when offline", async () => {
 
 test("refresh buttons are disabled when offline", async () => {
   // The ↻ refresh buttons should be disabled or not present
-  const refreshButtons = window.locator("button:has-text('↻')");
+  const refreshButtons = window.locator("button[aria-label='Refresh']");
   const count = await refreshButtons.count();
   for (let i = 0; i < count; i++) {
     await expect(refreshButtons.nth(i)).toBeDisabled();

--- a/tests/e2e/gcode-generation.spec.ts
+++ b/tests/e2e/gcode-generation.spec.ts
@@ -50,9 +50,11 @@ test("Generate G-code button is disabled with no imports", async () => {
 });
 
 test("no split-button dropdown — single Generate G-code button only", async () => {
-  // UI uses a single button that opens an options dialog; the old ▾ dropdown is gone
-  const dropdown = window.locator("button:has-text('▾')");
-  await expect(dropdown).toHaveCount(0);
+  const generateButtons = window.locator("button:has-text('Generate G-code')");
+  await expect(generateButtons).toHaveCount(1);
+
+  const menuTriggers = window.locator("button[aria-haspopup='menu']");
+  await expect(menuTriggers).toHaveCount(0);
 });
 
 // ─── Import an SVG to enable generation ──────────────────────────────────────

--- a/tests/e2e/gcode-preview.spec.ts
+++ b/tests/e2e/gcode-preview.spec.ts
@@ -384,12 +384,12 @@ test("Abort button is visible while a job is running", async () => {
   });
   await window.waitForTimeout(200);
 
-  const abortBtn = window.locator("button:has-text('✕ Abort')");
+  const abortBtn = window.locator("button:has-text('Abort')");
   await expect(abortBtn).toBeVisible({ timeout: 3_000 });
 });
 
 test("clicking Abort shows a confirmation dialog", async () => {
-  const abortBtn = window.locator("button:has-text('✕ Abort')");
+  const abortBtn = window.locator("button:has-text('Abort')");
   await expect(abortBtn).toBeVisible({ timeout: 3_000 });
   await abortBtn.click();
 
@@ -411,11 +411,11 @@ test("confirming Abort calls abortJob and machine returns to Idle", async () => 
   await window.waitForTimeout(300);
 
   // Abort button should be gone; Start job button should be visible.
-  await expect(window.locator("button:has-text('✕ Abort')")).not.toBeVisible({
+  await expect(window.locator("button:has-text('Abort')")).not.toBeVisible({
     timeout: 3_000,
   });
 
-  await expect(window.locator("button:has-text('▶ Start job')")).toBeVisible({
+  await expect(window.locator("button:has-text('Start job')")).toBeVisible({
     timeout: 3_000,
   });
 });
@@ -428,7 +428,7 @@ test("cancelling the Abort dialog keeps the job running", async () => {
   });
   await window.waitForTimeout(200);
 
-  const abortBtn = window.locator("button:has-text('✕ Abort')");
+  const abortBtn = window.locator("button:has-text('Abort')");
   await expect(abortBtn).toBeVisible({ timeout: 3_000 });
   await abortBtn.click();
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -61,6 +61,8 @@ export async function launchApp(): Promise<AppHandle> {
           "--disable-setuid-sandbox",
           "--disable-dev-shm-usage",
           "--disable-gpu",
+          "--disable-software-rasterizer",
+          "--ozone-platform=x11",
         ]
       : [];
 

--- a/tests/e2e/jog-controls.spec.ts
+++ b/tests/e2e/jog-controls.spec.ts
@@ -286,9 +286,9 @@ test("'Zero Z' button is disabled for solenoid pen type", async () => {
 // ─── Close button ─────────────────────────────────────────────────────────────
 
 test("closing Jog Controls via ✕ hides the panel", async () => {
-  // The close button has a small ✕ inside the panel header.
+  // The close button is the icon-only control in the panel header.
   await window
-    .locator("div:has(> span:text('Jog Controls')) button:has-text('✕')")
+    .locator("div:has(> span:text('Jog Controls')) button[aria-label='Close jog controls']")
     .click();
   await expect(window.locator("text=Jog Controls")).not.toBeVisible({
     timeout: 3000,

--- a/tests/e2e/launch.spec.ts
+++ b/tests/e2e/launch.spec.ts
@@ -87,7 +87,7 @@ test("Jog button is visible", async () => {
 });
 
 test("settings gear button is present", async () => {
-  const btn = window.locator("button:has-text('⚙')");
+  const btn = window.locator("button[title='Machine settings']");
   await expect(btn).toBeVisible();
 });
 

--- a/tests/e2e/machine-config.spec.ts
+++ b/tests/e2e/machine-config.spec.ts
@@ -274,7 +274,7 @@ test("Set as Active changes which config is active", async () => {
   // The active indicator (✓) should appear for this config in the sidebar
   const checkmark = sidebarEntry(window, "Test Machine E2E");
   await expect(checkmark).toBeVisible({ timeout: 3000 });
-  await expect(checkmark).toContainText("✓");
+  await expect(checkmark.locator("svg")).toBeVisible({ timeout: 3000 });
 });
 
 // ─── Export configs ─────────────────────────────────────────────────────────
@@ -285,7 +285,7 @@ test("Export button triggers save dialog and writes JSON", async () => {
   const exportPath = path.join(tempDir, "exported-configs.json");
   await mockSaveDialog(electronApp, exportPath);
 
-  const exportBtn = dialog(window).locator("button:has-text('↑ Export')");
+  const exportBtn = dialog(window).locator("button:has-text('Export')").first();
   await exportBtn.click();
 
   // Allow time for the IPC round-trip + file write
@@ -319,10 +319,13 @@ test("clicking Close dismisses the dialog", async () => {
 });
 
 test("machine selector in toolbar now shows the new active config", async () => {
-  const options = await window
-    .locator("select[aria-label='Machine selector'] option")
-    .allTextContents();
-  expect(options.some((t) => t.includes("Test Machine E2E"))).toBe(true);
+  const selectedName = await window
+    .locator("select[aria-label='Machine selector']")
+    .evaluate((select) => {
+      const option = select.selectedOptions[0];
+      return option?.textContent?.trim() ?? "";
+    });
+  expect(selectedName).toContain("Test Machine E2E");
 });
 
 // ─── Re-open and confirm persistence ────────────────────────────────────────


### PR DESCRIPTION
This pull request updates the UI layout and job controls for a more streamlined and intuitive experience, especially when the file browser panel is collapsed. It introduces a "mini" job controls area that remains accessible when the file browser is hidden, refines button icons and labels for job actions, and moves the job controls out of the console panel. The changes also improve accessibility and visual consistency across the app.

**UI and Layout Improvements:**
- Added a collapsed "mini job controls" area to the left panel, visible when the file browser is hidden and a job is active, allowing quick access to job progress, pause/resume, and abort actions. [[1]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR218-R256) [[2]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR267-R374) [[3]](diffhunk://#diff-2b73c5ff9f6c808f3afd3023c8d919ecef4b9480cde0d4ae98550fa14a41aa5aR80-R132)
- Moved `JobControls` out of the `ConsolePanel` and into the left panel below the file browser for a more logical layout. [[1]](diffhunk://#diff-79b903236fc2e0b1dbfaeb682da365583635a22e0b48a2748ca10e6217c0d6d9L5) [[2]](diffhunk://#diff-79b903236fc2e0b1dbfaeb682da365583635a22e0b48a2748ca10e6217c0d6d9L54-R53) [[3]](diffhunk://#diff-79b903236fc2e0b1dbfaeb682da365583635a22e0b48a2748ca10e6217c0d6d9L66-L67) [[4]](diffhunk://#diff-79b903236fc2e0b1dbfaeb682da365583635a22e0b48a2748ca10e6217c0d6d9L85-L90) [[5]](diffhunk://#diff-25d6c7ec2c630268e50946e9074b444e2d9f608261b57b05a25ec008a85829faL254-R254)

**Job Controls and Button Enhancements:**
- Updated job control buttons to use consistent icons (`Play`, `Pause`, `X`) and clearer labels, improving readability and accessibility. [[1]](diffhunk://#diff-3c2c243d8cdf493fed698bf07c930b30c858324bb0a9792811ec4e2550dcd193L1-R2) [[2]](diffhunk://#diff-3c2c243d8cdf493fed698bf07c930b30c858324bb0a9792811ec4e2550dcd193R73-R81) [[3]](diffhunk://#diff-3c2c243d8cdf493fed698bf07c930b30c858324bb0a9792811ec4e2550dcd193L108-R111) [[4]](diffhunk://#diff-3c2c243d8cdf493fed698bf07c930b30c858324bb0a9792811ec4e2550dcd193R122-R159)
- Added keyboard accessibility for expanding the file browser panel when collapsed.

**Testing:**
- Added and updated tests to verify the presence and behavior of collapsed job controls and their buttons when the file browser is hidden and a job is active. [[1]](diffhunk://#diff-2b73c5ff9f6c808f3afd3023c8d919ecef4b9480cde0d4ae98550fa14a41aa5aR80-R132) [[2]](diffhunk://#diff-25d6c7ec2c630268e50946e9074b444e2d9f608261b57b05a25ec008a85829faL254-R254)

**Visual and Icon Consistency:**
- Replaced the settings button text with a `Settings` icon and improved the fit canvas button styling for a more modern look. [[1]](diffhunk://#diff-ea885b90f60c0fc8457a3cd33c3435c8e082d9af57b8e92312210f992d00010eL1-R1) [[2]](diffhunk://#diff-ea885b90f60c0fc8457a3cd33c3435c8e082d9af57b8e92312210f992d00010eL50-R50) [[3]](diffhunk://#diff-12def4abcbe1521e62821ba3f80840155a65876edb82fea60fb012d3772f7e94L57-R57)

These changes collectively enhance the usability and clarity of job controls, especially in compact UI states