### PR TITLE
Fix label wrapping on Mac

### DIFF
--- a/src/renderer/src/features/properties-panel/components/AlignmentControls.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/AlignmentControls.test.tsx
@@ -68,4 +68,31 @@ describe("AlignmentControls", () => {
     );
     expect(onTemplateAlignEnabledChange).toHaveBeenCalledWith(false);
   });
+
+  it("keeps template alignment labels on one line", () => {
+    render(
+      <AlignmentControls
+        objW={20}
+        objH={10}
+        bedW={200}
+        bedH={100}
+        origin="bottom-left"
+        pageW={210}
+        pageH={297}
+        marginMM={20}
+        canAlignToTemplate={true}
+        templateAlignEnabled={true}
+        templateAlignTarget="page"
+        onTemplateAlignEnabledChange={() => {}}
+        onTemplateAlignTargetChange={() => {}}
+        onAlignX={() => {}}
+        onAlignY={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Align to template").closest("label")?.className)
+      .toContain("whitespace-nowrap");
+    expect(screen.getByRole("radio", { name: "Page" }).closest("label")?.className)
+      .toContain("whitespace-nowrap");
+  });
 });

--- a/src/renderer/src/features/properties-panel/components/AlignmentControls.tsx
+++ b/src/renderer/src/features/properties-panel/components/AlignmentControls.tsx
@@ -84,19 +84,19 @@ export function AlignmentControls({
         onAlignBottom={onAlignBottom}
       />
 
-      <div className="flex items-center gap-2 mt-1">
-        <label className="inline-flex items-center gap-1 text-[10px] text-content-muted">
+      <div className="mt-1 flex items-center justify-between gap-1">
+        <label className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-[10px] text-content-muted">
           <input
             type="checkbox"
             checked={templateAlignEnabled}
             disabled={!canAlignToTemplate}
             onChange={(e) => onTemplateAlignEnabledChange(e.target.checked)}
-            className="accent-accent"
+            className="h-3.5 w-3.5 shrink-0 accent-accent"
           />
           Align to template
         </label>
         <label
-          className={`inline-flex items-center gap-1 text-[10px] ${targetControlToneClass}`}
+          className={`inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-[10px] ${targetControlToneClass}`}
         >
           <input
             type="radio"
@@ -105,12 +105,12 @@ export function AlignmentControls({
             checked={templateAlignTarget === "page"}
             disabled={targetControlDisabled}
             onChange={() => onTemplateAlignTargetChange("page")}
-            className="accent-accent"
+            className="h-3.5 w-3.5 shrink-0 accent-accent"
           />
           Page
         </label>
         <label
-          className={`inline-flex items-center gap-1 text-[10px] ${targetControlToneClass}`}
+          className={`inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-[10px] ${targetControlToneClass}`}
         >
           <input
             type="radio"
@@ -119,7 +119,7 @@ export function AlignmentControls({
             checked={templateAlignTarget === "margin"}
             disabled={targetControlDisabled}
             onChange={() => onTemplateAlignTargetChange("margin")}
-            className="accent-accent"
+            className="h-3.5 w-3.5 shrink-0 accent-accent"
           />
           Margin
         </label>

--- a/src/renderer/src/features/properties-panel/components/TransformShortcuts.test.tsx
+++ b/src/renderer/src/features/properties-panel/components/TransformShortcuts.test.tsx
@@ -108,4 +108,43 @@ describe("TransformShortcuts", () => {
     fireEvent.click(backdrop);
     expect(onCloseStepFlyout).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps template scale labels on one line", () => {
+    render(
+      <TransformShortcuts
+        fitScale={2}
+        fitScaleX={2}
+        fitScaleY={2}
+        rotStep={45}
+        rotSteps={[1, 5, 15, 45, 90]}
+        stepFlyoutOpen={false}
+        showCentreMarker={false}
+        ratioLocked={true}
+        snapPresetTitle="snap"
+        canScaleToTemplate={true}
+        templateScaleEnabled={true}
+        templateScaleTarget="page"
+        onFitToBed={() => {}}
+        onFitHorizontal={() => {}}
+        onFitVertical={() => {}}
+        onResetScale={() => {}}
+        onTemplateScaleEnabledChange={() => {}}
+        onTemplateScaleTargetChange={() => {}}
+        onRotateCcw={() => {}}
+        onRotateCw={() => {}}
+        onToggleStepFlyout={() => {}}
+        onCloseStepFlyout={() => {}}
+        onSelectRotStep={() => {}}
+        onToggleCentreMarker={() => {}}
+        onSnapToNextPreset={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Scale to template").closest("label")?.className)
+      .toContain("whitespace-nowrap");
+    expect(
+      screen.getByRole("radio", { name: "Scale to template page" }).closest("label")
+        ?.className,
+    ).toContain("whitespace-nowrap");
+  });
 });

--- a/src/renderer/src/features/properties-panel/components/TransformShortcuts.tsx
+++ b/src/renderer/src/features/properties-panel/components/TransformShortcuts.tsx
@@ -95,19 +95,19 @@ export function TransformShortcuts({
               <ScaleVerticalIcon className="h-3.5 w-3.5" />
             </TransformIconButton>
           </div>
-          <div className="flex items-center gap-2 mb-2">
-            <label className="inline-flex items-center gap-1 text-[10px] text-content-muted">
+          <div className="mb-2 flex items-center justify-between gap-1">
+            <label className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-[10px] text-content-muted">
               <input
                 type="checkbox"
                 checked={templateScaleEnabled}
                 disabled={!canScaleToTemplate}
                 onChange={(e) => onTemplateScaleEnabledChange(e.target.checked)}
-                className="accent-accent"
+                className="h-3.5 w-3.5 shrink-0 accent-accent"
               />
               Scale to template
             </label>
             <label
-              className={`inline-flex items-center gap-1 text-[10px] ${
+              className={`inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-[10px] ${
                 templateScaleEnabled && canScaleToTemplate
                   ? "text-content-default"
                   : "text-content-muted"
@@ -121,12 +121,12 @@ export function TransformShortcuts({
                 checked={templateScaleTarget === "page"}
                 disabled={!templateScaleEnabled || !canScaleToTemplate}
                 onChange={() => onTemplateScaleTargetChange("page")}
-                className="accent-accent"
+                className="h-3.5 w-3.5 shrink-0 accent-accent"
               />
               Page
             </label>
             <label
-              className={`inline-flex items-center gap-1 text-[10px] ${
+              className={`inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-[10px] ${
                 templateScaleEnabled && canScaleToTemplate
                   ? "text-content-default"
                   : "text-content-muted"
@@ -140,7 +140,7 @@ export function TransformShortcuts({
                 checked={templateScaleTarget === "margin"}
                 disabled={!templateScaleEnabled || !canScaleToTemplate}
                 onChange={() => onTemplateScaleTargetChange("margin")}
-                className="accent-accent"
+                className="h-3.5 w-3.5 shrink-0 accent-accent"
               />
               Margin
             </label>


### PR DESCRIPTION
This pull request improves the layout and accessibility of the template alignment and scale controls in the properties panel by ensuring their labels remain on a single line and that input elements are consistently sized and styled. It also adds tests to verify these UI behaviors.

**UI improvements for label layout and input sizing:**

* Updated `AlignmentControls` and `TransformShortcuts` components to add the `whitespace-nowrap` class to relevant label elements, ensuring that template alignment and scale labels stay on one line. Also added `shrink-0` and explicit sizing classes to checkbox and radio inputs for consistent appearance. [[1]](diffhunk://#diff-c69ee1f574be314e63c69e45530854c9f75cfb81197146fadf405f0a21717d38L87-R99) [[2]](diffhunk://#diff-c69ee1f574be314e63c69e45530854c9f75cfb81197146fadf405f0a21717d38L108-R113) [[3]](diffhunk://#diff-c69ee1f574be314e63c69e45530854c9f75cfb81197146fadf405f0a21717d38L122-R122) [[4]](diffhunk://#diff-256d50a623b42f373cc07d280260bb220a771f5ec525371cf5ab67ad00baea57L98-R110) [[5]](diffhunk://#diff-256d50a623b42f373cc07d280260bb220a771f5ec525371cf5ab67ad00baea57L124-R129) [[6]](diffhunk://#diff-256d50a623b42f373cc07d280260bb220a771f5ec525371cf5ab67ad00baea57L143-R143)

**Testing enhancements:**

* Added tests in `AlignmentControls.test.tsx` and `TransformShortcuts.test.tsx` to assert that the template alignment and scale labels have the `whitespace-nowrap` class, verifying the labels remain on a single line. [[1]](diffhunk://#diff-62b77abd3fc03504463d1a10f954580db7f24812755f2b8d70ad12bd29af9fcfR71-R97) [[2]](diffhunk://#diff-449f42a803fe2795a6fa478257d7f0007f9e356ba5746f716100c8283e38c320R111-R149)