### PR TITLE
Jog control swapping based on machine origin

### DIFF
--- a/src/renderer/src/components/JogControls/JogControls.tsx
+++ b/src/renderer/src/components/JogControls/JogControls.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from "react";
 import { X } from "lucide-react";
-import { isSolenoidPenType, type JogStep } from "../../../../types";
+import {
+  isSolenoidPenType,
+  type JogStep,
+  type OriginType,
+} from "../../../../types";
 import { useMachineStore } from "../../store/machineStore";
 import { Button } from "../ui";
 import { StepSelector } from "./StepSelector";
@@ -10,6 +14,14 @@ import { JogSpeedInput } from "./JogSpeedInput";
 import { PositioningSection } from "./PositioningSection";
 
 const STEPS: JogStep[] = [0.1, 1, 10, 100];
+
+function usesTopOrigin(origin?: OriginType): boolean {
+  return origin === "top-left" || origin === "top-right";
+}
+
+function usesRightOrigin(origin?: OriginType): boolean {
+  return origin === "bottom-right" || origin === "top-right";
+}
 
 interface Props {
   onClose?: () => void;
@@ -32,6 +44,9 @@ export function JogControls({ onClose }: Props) {
   const penDown = activeConfig?.penDownCommand ?? "";
   const penType = activeConfig?.penType ?? "solenoid-hardware";
   const invertZJogControls = !!activeConfig?.invertZJogControls;
+  const origin = activeConfig?.origin;
+  const invertXJogControls = usesRightOrigin(origin);
+  const invertYJogControls = usesTopOrigin(activeConfig?.origin);
 
   const movePen = async (action: "up" | "down") => {
     if (isSolenoidPenType(penType)) {
@@ -90,6 +105,8 @@ export function JogControls({ onClose }: Props) {
         connected={connected}
         jog={jog}
         goToOrigin={goToOrigin}
+        invertXJogControls={invertXJogControls}
+        invertYJogControls={invertYJogControls}
       />
 
       <PenControls

--- a/src/renderer/src/components/JogControls/JogPad.tsx
+++ b/src/renderer/src/components/JogControls/JogPad.tsx
@@ -14,29 +14,43 @@ interface JogPadProps {
   connected: boolean;
   jog: (axis: string, dir: 1 | -1) => Promise<void>;
   goToOrigin: () => Promise<void>;
+  invertXJogControls: boolean;
+  invertYJogControls: boolean;
 }
 
 /**
  * A 3×3 directional pad for jogging X/Y axes, with a centre "go to origin" button.
  */
-export function JogPad({ step, connected, jog, goToOrigin }: JogPadProps) {
+export function JogPad({
+  step,
+  connected,
+  jog,
+  goToOrigin,
+  invertXJogControls,
+  invertYJogControls,
+}: JogPadProps) {
+  const leftDir: 1 | -1 = invertXJogControls ? 1 : -1;
+  const rightDir: 1 | -1 = invertXJogControls ? -1 : 1;
+  const upDir: 1 | -1 = invertYJogControls ? -1 : 1;
+  const downDir: 1 | -1 = invertYJogControls ? 1 : -1;
+
   return (
     <div className="grid grid-cols-3 gap-1 mb-4 w-36 mx-auto">
       <div />
       <JogBtn
         label={<ArrowBigUp size={16} />}
-        title={`Move Y +${step} mm`}
-        ariaLabel="Jog Y+"
-        onClick={() => jog("Y", 1)}
+        title={`Move Y ${upDir > 0 ? "+" : "-"}${step} mm`}
+        ariaLabel={`Jog Y${upDir > 0 ? "+" : "-"}`}
+        onClick={() => jog("Y", upDir)}
         disabled={!connected}
       />
       <div />
 
       <JogBtn
         label={<ArrowBigLeft size={16} />}
-        title={`Move X -${step} mm`}
-        ariaLabel="Jog X-"
-        onClick={() => jog("X", -1)}
+        title={`Move X ${leftDir > 0 ? "+" : "-"}${step} mm`}
+        ariaLabel={`Jog X${leftDir > 0 ? "+" : "-"}`}
+        onClick={() => jog("X", leftDir)}
         disabled={!connected}
       />
       <JogBtn
@@ -48,18 +62,18 @@ export function JogPad({ step, connected, jog, goToOrigin }: JogPadProps) {
       />
       <JogBtn
         label={<ArrowBigRight size={16} />}
-        title={`Move X +${step} mm`}
-        ariaLabel="Jog X+"
-        onClick={() => jog("X", 1)}
+        title={`Move X ${rightDir > 0 ? "+" : "-"}${step} mm`}
+        ariaLabel={`Jog X${rightDir > 0 ? "+" : "-"}`}
+        onClick={() => jog("X", rightDir)}
         disabled={!connected}
       />
 
       <div />
       <JogBtn
         label={<ArrowBigDown size={16} />}
-        title={`Move Y -${step} mm`}
-        ariaLabel="Jog Y-"
-        onClick={() => jog("Y", -1)}
+        title={`Move Y ${downDir > 0 ? "+" : "-"}${step} mm`}
+        ariaLabel={`Jog Y${downDir > 0 ? "+" : "-"}`}
+        onClick={() => jog("Y", downDir)}
         disabled={!connected}
       />
       <div />

--- a/tests/component/JogControls.test.tsx
+++ b/tests/component/JogControls.test.tsx
@@ -5,6 +5,34 @@ import { JogControls } from "@renderer/components/JogControls";
 import { useMachineStore } from "@renderer/store/machineStore";
 import { createMachineConfig } from "../helpers/factories";
 
+function setupOrigin(origin: "bottom-left" | "top-left" | "bottom-right" | "top-right") {
+  const cfg = createMachineConfig({ origin });
+  useMachineStore.setState({
+    configs: [cfg],
+    activeConfigId: cfg.id,
+    status: null,
+    connected: true,
+    wsLive: false,
+    selectedJobFile: null,
+  });
+}
+
+function getVisualJogButtons(container: HTMLElement) {
+  const jogPad = container.querySelector(".w-36.mx-auto") as HTMLElement | null;
+  if (!jogPad) throw new Error("Jog pad not found");
+
+  const buttons = jogPad.querySelectorAll("button");
+  if (buttons.length < 5) throw new Error("Expected jog pad to have 5 buttons");
+
+  return {
+    up: buttons[0] as HTMLButtonElement,
+    left: buttons[1] as HTMLButtonElement,
+    origin: buttons[2] as HTMLButtonElement,
+    right: buttons[3] as HTMLButtonElement,
+    down: buttons[4] as HTMLButtonElement,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   // Reset store to a clean state with no active config between tests
@@ -247,6 +275,77 @@ describe("JogControls", () => {
       expect.stringContaining("F6000"),
     );
   });
+});
+
+describe("JogControls — origin mapping proof", () => {
+  type VisualDir = "up" | "down" | "left" | "right";
+
+  const cases = [
+    {
+      origin: "bottom-left",
+      positiveY: "up",
+      negativeY: "down",
+      positiveX: "right",
+      negativeX: "left",
+    },
+    {
+      origin: "top-left",
+      positiveY: "down",
+      negativeY: "up",
+      positiveX: "right",
+      negativeX: "left",
+    },
+    {
+      origin: "bottom-right",
+      positiveY: "up",
+      negativeY: "down",
+      positiveX: "left",
+      negativeX: "right",
+    },
+    {
+      origin: "top-right",
+      positiveY: "down",
+      negativeY: "up",
+      positiveX: "left",
+      negativeX: "right",
+    },
+  ] as const satisfies ReadonlyArray<{
+    origin: "bottom-left" | "top-left" | "bottom-right" | "top-right";
+    positiveY: VisualDir;
+    negativeY: VisualDir;
+    positiveX: VisualDir;
+    negativeX: VisualDir;
+  }>;
+
+  for (const testCase of cases) {
+    it(`${testCase.origin}: +Y/+X buttons emit positive jogs, opposite buttons emit negative jogs`, async () => {
+      setupOrigin(testCase.origin);
+      const { container } = render(<JogControls />);
+      const pad = getVisualJogButtons(container);
+
+      await userEvent.click(pad[testCase.positiveY]);
+      await userEvent.click(pad[testCase.positiveX]);
+      await userEvent.click(pad[testCase.negativeY]);
+      await userEvent.click(pad[testCase.negativeX]);
+
+      expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+        1,
+        "$J=G91 G21 Y1.000 F3000",
+      );
+      expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+        2,
+        "$J=G91 G21 X1.000 F3000",
+      );
+      expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+        3,
+        "$J=G91 G21 Y-1.000 F3000",
+      );
+      expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+        4,
+        "$J=G91 G21 X-1.000 F3000",
+      );
+    });
+  }
 });
 
 // ── Z axis jog (servo / stepper) with explicit invert setting ───────────────

--- a/tests/component/JogControls.test.tsx
+++ b/tests/component/JogControls.test.tsx
@@ -159,6 +159,84 @@ describe("JogControls", () => {
     );
   });
 
+  it("swaps Y jog button mapping for top-origin machines", async () => {
+    const cfg = createMachineConfig({ origin: "top-left" });
+    useMachineStore.setState({
+      configs: [cfg],
+      activeConfigId: cfg.id,
+      status: null,
+      connected: true,
+      wsLive: false,
+      selectedJobFile: null,
+    });
+
+    render(<JogControls />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Jog Y-" }));
+    await userEvent.click(screen.getByRole("button", { name: "Jog Y+" }));
+
+    expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+      1,
+      "$J=G91 G21 Y-1.000 F3000",
+    );
+    expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+      2,
+      "$J=G91 G21 Y1.000 F3000",
+    );
+  });
+
+  it("swaps X jog button mapping for right-origin machines", async () => {
+    const cfg = createMachineConfig({ origin: "bottom-right" });
+    useMachineStore.setState({
+      configs: [cfg],
+      activeConfigId: cfg.id,
+      status: null,
+      connected: true,
+      wsLive: false,
+      selectedJobFile: null,
+    });
+
+    render(<JogControls />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Jog X+" }));
+    await userEvent.click(screen.getByRole("button", { name: "Jog X-" }));
+
+    expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+      1,
+      "$J=G91 G21 X1.000 F3000",
+    );
+    expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+      2,
+      "$J=G91 G21 X-1.000 F3000",
+    );
+  });
+
+  it("swaps both axes for top-right origin machines", async () => {
+    const cfg = createMachineConfig({ origin: "top-right" });
+    useMachineStore.setState({
+      configs: [cfg],
+      activeConfigId: cfg.id,
+      status: null,
+      connected: true,
+      wsLive: false,
+      selectedJobFile: null,
+    });
+
+    render(<JogControls />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Jog X-" }));
+    await userEvent.click(screen.getByRole("button", { name: "Jog Y-" }));
+
+    expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+      1,
+      "$J=G91 G21 X-1.000 F3000",
+    );
+    expect(window.terraForge.fluidnc.sendCommand).toHaveBeenNthCalledWith(
+      2,
+      "$J=G91 G21 Y-1.000 F3000",
+    );
+  });
+
   it("updates feedrate when input changes", async () => {
     render(<JogControls />);
     const input = screen.getByRole("spinbutton");


### PR DESCRIPTION
This pull request updates the jog controls to automatically invert the X and/or Y jog button directions based on the machine's configured origin, ensuring that the physical movement matches user expectations for different origin placements. The logic is encapsulated in utility functions and thoroughly tested with new unit tests.

**Jog Controls Axis Inversion Based on Origin:**

* Added `usesTopOrigin` and `usesRightOrigin` helper functions to determine when to invert Y and X jog controls, respectively, based on the `origin` property in the active machine configuration (`JogControls.tsx`).
* Updated `JogControls` to compute and pass `invertXJogControls` and `invertYJogControls` props to `JogPad` according to the machine's origin (`JogControls.tsx`). [[1]](diffhunk://#diff-9953ce2f405bfb487ed267ebaea975742a17c14f4466f45bfacdc5343ce29c36R47-R49) [[2]](diffhunk://#diff-9953ce2f405bfb487ed267ebaea975742a17c14f4466f45bfacdc5343ce29c36R108-R109)
* Modified `JogPad` to use these props to dynamically adjust the direction and labeling of jog buttons, so that the UI always matches the physical axes regardless of origin (`JogPad.tsx`). [[1]](diffhunk://#diff-ae6884ce38f3091438a774ea3c038e6051c8a699c976509f420e07349368ec58R17-R53) [[2]](diffhunk://#diff-ae6884ce38f3091438a774ea3c038e6051c8a699c976509f420e07349368ec58L51-R76)

**Testing:**

* Added unit tests to verify that jog button directions are correctly swapped for top-origin, right-origin, and top-right-origin configurations, ensuring robust behavior (`JogControls.test.tsx`).