### PR TITLE
Handle jog panel and canvas fit buttons positioning for right rulers

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { Pause, Play, X } from "lucide-react";
 import { Toolbar } from "./components/Toolbar";
@@ -18,6 +18,8 @@ import { useTaskStore } from "./store/taskStore";
 import { useConsoleStore } from "./store/consoleStore";
 import { useAppConfigStore } from "./store/appConfigStore";
 import { useThemeStore, applyTheme } from "./store/themeStore";
+import { RULER_W } from "./features/canvas";
+import type { OriginType } from "@types/index";
 
 const GCODE_EXTS = [
   ".gcode",
@@ -41,6 +43,8 @@ export default function App() {
   const setFwInfo = useMachineStore((s) => s.setFwInfo);
   const connected = useMachineStore((s) => s.connected);
   const status = useMachineStore((s) => s.status);
+  const activeConfigId = useMachineStore((s) => s.activeConfigId);
+  const machineConfigs = useMachineStore((s) => s.configs);
   const selectedJobFile = useMachineStore((s) => s.selectedJobFile);
   const { toolpathSelected, gcodeSource, gcodePreviewLoading } = useCanvasStore(
     useShallow(selectJobControlsCanvasState),
@@ -75,6 +79,30 @@ export default function App() {
     startY: number;
   } | null>(null);
 
+  const origin = useMemo<OriginType>(() => {
+    const active = machineConfigs.find((cfg) => cfg.id === activeConfigId);
+    return active?.origin ?? "bottom-left";
+  }, [activeConfigId, machineConfigs]);
+  const isRightOrigin = origin === "bottom-right" || origin === "top-right";
+  const rightPanelWidth = showProperties ? 256 : 36;
+  // Keep jog panel offset to the left of the properties edge by 16px,
+  // and add ruler width when the ruler is on the right side.
+  const jogMinRightInset =
+    Math.max(12, rightPanelWidth - 16) + (isRightOrigin ? RULER_W : 0);
+
+  // Keep dragged jog panel clear of the right-side reserved UI area when
+  // panel widths or machine origin change (which moves the ruler side).
+  useEffect(() => {
+    if (!jogPos || !jogPanelRef.current) return;
+    const width =
+      jogPanelRef.current.offsetWidth ||
+      jogPanelRef.current.getBoundingClientRect().width;
+    const maxX = Math.max(0, window.innerWidth - width - jogMinRightInset);
+    if (jogPos.x > maxX) {
+      setJogPos((prev) => (prev ? { ...prev, x: maxX } : prev));
+    }
+  }, [jogMinRightInset, jogPos]);
+
   const startJogDrag = (e: React.PointerEvent<HTMLDivElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
     // Resolve current pixel position from either state or the element's bounding rect
@@ -99,7 +127,7 @@ export default function App() {
     const newY =
       jogDragRef.current.startY + e.clientY - jogDragRef.current.mouseY;
     setJogPos({
-      x: Math.max(0, Math.min(window.innerWidth - w, newX)),
+      x: Math.max(0, Math.min(window.innerWidth - w - jogMinRightInset, newX)),
       y: Math.max(0, Math.min(window.innerHeight - h, newY)),
     });
   };
@@ -402,7 +430,7 @@ export default function App() {
           style={
             jogPos
               ? { left: jogPos.x, top: jogPos.y }
-              : { right: 240, top: 124 }
+              : { right: jogMinRightInset, top: 124 }
           }
           onPointerMove={onJogDragMove}
           onPointerUp={onJogDragEnd}

--- a/src/renderer/src/components/PlotCanvas/PlotCanvas.tsx
+++ b/src/renderer/src/components/PlotCanvas/PlotCanvas.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef } from "react";
 import { usePlotProgress } from "../../utils/usePlotProgress";
 import { useMachineStore } from "../../store/machineStore";
 import {
+  RULER_W,
   RulerOverlay,
   ToolpathSelectionOverlay,
   PenCrosshairOverlay,
@@ -385,6 +386,7 @@ export function PlotCanvas() {
         fitted={fitted}
         zoom={vp.zoom}
         spaceDown={spaceDown}
+        rightInsetPx={16 + (isRight ? RULER_W : 0)}
         onZoomIn={onZoomIn}
         onZoomOut={onZoomOut}
         onFit={onFit}

--- a/src/renderer/src/components/PlotCanvas/components/PlotCanvasControls.tsx
+++ b/src/renderer/src/components/PlotCanvas/components/PlotCanvasControls.tsx
@@ -4,6 +4,7 @@ type PlotCanvasControlsProps = {
   fitted: boolean;
   zoom: number;
   spaceDown: boolean;
+  rightInsetPx?: number;
   onZoomIn: (e: React.MouseEvent) => void;
   onZoomOut: (e: React.MouseEvent) => void;
   onFit: (e: React.MouseEvent) => void;
@@ -13,6 +14,7 @@ export function PlotCanvasControls({
   fitted,
   zoom,
   spaceDown,
+  rightInsetPx = 16,
   onZoomIn,
   onZoomOut,
   onFit,
@@ -20,7 +22,8 @@ export function PlotCanvasControls({
   return (
     <>
       <div
-        className="absolute bottom-9 right-4 flex flex-col gap-1 z-10"
+        className="absolute bottom-9 flex flex-col gap-1 z-10"
+        style={{ right: `${rightInsetPx}px` }}
         onMouseDown={(e) => e.stopPropagation()}
       >
         <Button

--- a/tests/component/App.test.tsx
+++ b/tests/component/App.test.tsx
@@ -283,4 +283,40 @@ describe("App", () => {
     // After drag, the panel should have explicit position style set (left/top from setJogPos)
     expect(jogPanel.getAttribute("style")).toMatch(/left/);
   });
+
+  it("updates jog panel right inset when active profile origin switches", async () => {
+    const leftOrigin = createMachineConfig({
+      id: "cfg-left",
+      name: "Left Origin",
+      origin: "bottom-left",
+    });
+    const rightOrigin = createMachineConfig({
+      id: "cfg-right",
+      name: "Right Origin",
+      origin: "bottom-right",
+    });
+
+    (
+      window.terraForge.config.getMachineConfigs as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([leftOrigin, rightOrigin]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(useMachineStore.getState().activeConfigId).toBe(leftOrigin.id);
+    });
+
+    const dragHandle = screen.getByTitle("Drag to move");
+    const jogPanel = dragHandle.parentElement!;
+
+    // Properties panel visible by default: 256 - 16 = 240.
+    expect(jogPanel).toHaveStyle({ right: "240px" });
+
+    act(() => {
+      useMachineStore.getState().setActiveConfigId(rightOrigin.id);
+    });
+
+    // Right-origin adds ruler spacing: (256 - 16) + 20 = 260.
+    expect(jogPanel).toHaveStyle({ right: "260px" });
+  });
 });


### PR DESCRIPTION
This pull request improves the layout responsiveness of the jog panel and canvas controls by dynamically adjusting their right-side insets based on the active machine profile's origin and the visibility of the properties panel. This ensures that UI elements do not overlap with the ruler or reserved UI space when the machine origin changes or when the properties panel is toggled.

**Dynamic UI layout adjustments:**

* The jog panel's right inset is now calculated dynamically, accounting for the properties panel width and whether the machine's origin places the ruler on the right side. This prevents overlap with the ruler and ensures correct positioning when the active machine profile changes (`src/renderer/src/App.tsx`). [[1]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR46-R47) [[2]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR82-R105) [[3]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL102-R130) [[4]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL405-R433)
* The canvas controls (`PlotCanvasControls`) now accept a `rightInsetPx` prop, allowing their right offset to be adjusted based on the ruler's position, providing consistent spacing and avoiding UI collisions (`src/renderer/src/components/PlotCanvas/PlotCanvas.tsx`, `src/renderer/src/components/PlotCanvas/components/PlotCanvasControls.tsx`). [[1]](diffhunk://#diff-cc37cee5beeb3191101ef32fa5122a5b91b9fb1f41a0faccc6a9c2cfd3ddda5bR389) [[2]](diffhunk://#diff-12def4abcbe1521e62821ba3f80840155a65876edb82fea60fb012d3772f7e94R7) [[3]](diffhunk://#diff-12def4abcbe1521e62821ba3f80840155a65876edb82fea60fb012d3772f7e94R17-R26)

**Testing improvements:**

* Added a component test to verify that the jog panel's right inset updates correctly when switching between machine profiles with different origin settings, ensuring correct UI behavior (`tests/component/App.test.tsx`).

**Supporting changes:**

* Imported `RULER_W` and `OriginType` where needed to support the new layout calculations (`src/renderer/src/App.tsx`, `src/renderer/src/components/PlotCanvas/PlotCanvas.tsx`). [[1]](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abR21-R22) [[2]](diffhunk://#diff-cc37cee5beeb3191101ef32fa5122a5b91b9fb1f41a0faccc6a9c2cfd3ddda5bR18)