### PR TITLE
Add e-stop button to console header

### DIFF
--- a/docs/terraForge-features.md
+++ b/docs/terraForge-features.md
@@ -156,6 +156,7 @@
 - [x] Command input (send raw G-code commands)
 - [x] Console timestamp display toggle — **Application Configuration → Console Display** includes "Show date and time on console lines"; when enabled, each console entry is prefixed with a local `YYYY-MM-DD HH:mm:ss` timestamp
 - [x] Alarm state badge becomes a clickable button — sends `$X` to clear the alarm
+- [x] Emergency-stop button — persistent button in the console header; sends realtime Feed Hold (`!`) to halt motion without a confirmation dialog
 - [x] Firmware restart button — "⚠ Restart FW" button visible in console header when connected; sends `[ESP444]RESTART` to reboot the ESP32; automatically disconnects the app and shows a reconnect prompt; confirms with the user before firing
 
 ### Background Task UX

--- a/docs/terraForge-user-guide.md
+++ b/docs/terraForge-user-guide.md
@@ -939,6 +939,12 @@ The console header shows:
 - **Machine state** badge (`Idle`, `Run`, `Hold`, `Alarm`, etc.)
 - **Position** `X:0.00 Y:0.00 Z:0.00` (work coordinates)
 
+### Emergency Stop
+
+The always-visible **E-STOP** button uses the red/yellow emergency-stop styling and is disabled only while disconnected. Click it to issue realtime Feed Hold (`!`), which decelerates the machine to a stop and flushes the motion planner or pauses a running job. It halts drawing, rapid moves, and jogs.
+
+> **Warning:** Feed Hold cannot recover the flushed motion. There is no confirmation dialog so the control remains useful when motion must stop immediately.
+
 ### Alarm Handling
 
 When the machine enters **Alarm** state, the state badge becomes a pulsing red button:

--- a/src/renderer/src/components/ConsolePanel.tsx
+++ b/src/renderer/src/components/ConsolePanel.tsx
@@ -76,6 +76,7 @@ export function ConsolePanel({ collapsed = false }: ConsolePanelProps) {
           resetting={resetting}
           showRestartConfirm={showRestartConfirm}
           collapsed={collapsed}
+          onEmergencyStop={() => void window.terraForge.fluidnc.pauseJob()}
           onFirmwareReset={() => setShowRestartConfirm(true)}
           onClear={clear}
           onAlarmClear={() => window.terraForge.fluidnc.sendCommand("$X")}

--- a/src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx
+++ b/src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx
@@ -37,7 +37,7 @@ export function ConsoleToolbar({
 }: ConsoleToolbarProps) {
   return (
     <div
-      className={`flex items-center justify-between px-3 py-1 ${collapsed ? "" : "border-b border-border-ui"}`}
+      className={`relative flex items-center justify-between px-3 py-1 ${collapsed ? "" : "border-b border-border-ui"}`}
       style={{ height: 28, minHeight: 28, maxHeight: 28 }}
     >
       <div className="flex items-center gap-3">
@@ -83,17 +83,19 @@ export function ConsoleToolbar({
           </span>
         )}
       </div>
-      <div className="flex items-center gap-2">
+      <div className="absolute left-1/2 -translate-x-1/2 flex items-center">
         <Button
+          variant="danger"
           size="xs"
           onClick={onEmergencyStop}
           disabled={!connected}
           title="Emergency stop: immediately halt all motion (Feed Hold)"
-          className="h-[18px] border border-yellow-400 bg-red-700 px-1.5 font-bold uppercase leading-none text-white hover:border-yellow-300 hover:bg-red-600 disabled:border-yellow-400"
           icon={<CircleStop size={12} strokeWidth={2.5} />}
         >
           E-STOP
         </Button>
+      </div>
+      <div className="flex items-center gap-2">
         {connected && (
           <Button
             variant="secondary"

--- a/src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx
+++ b/src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button } from "../ui";
 import type { MachineStatus } from "../../../../types";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, CircleStop } from "lucide-react";
 
 interface ConsoleToolbarProps {
   status: MachineStatus | null;
@@ -11,6 +11,7 @@ interface ConsoleToolbarProps {
   resetting: boolean;
   showRestartConfirm: boolean;
   collapsed?: boolean;
+  onEmergencyStop: () => void;
   onFirmwareReset: () => void;
   onClear: () => void;
   onAlarmClear: () => void;
@@ -29,6 +30,7 @@ export function ConsoleToolbar({
   resetting,
   showRestartConfirm,
   collapsed = false,
+  onEmergencyStop,
   onFirmwareReset,
   onClear,
   onAlarmClear,
@@ -82,6 +84,16 @@ export function ConsoleToolbar({
         )}
       </div>
       <div className="flex items-center gap-2">
+        <Button
+          size="xs"
+          onClick={onEmergencyStop}
+          disabled={!connected}
+          title="Emergency stop: immediately halt all motion (Feed Hold)"
+          className="h-[18px] border border-yellow-400 bg-red-700 px-1.5 font-bold uppercase leading-none text-white hover:border-yellow-300 hover:bg-red-600 disabled:border-yellow-400"
+          icon={<CircleStop size={12} strokeWidth={2.5} />}
+        >
+          E-STOP
+        </Button>
         {connected && (
           <Button
             variant="secondary"

--- a/tests/component/ConsolePanel.test.tsx
+++ b/tests/component/ConsolePanel.test.tsx
@@ -176,6 +176,18 @@ describe("ConsolePanel", () => {
     expect(screen.queryByText(/Restart FW/)).not.toBeInTheDocument();
   });
 
+  it("keeps e-stop visible but disabled when disconnected", () => {
+    render(<ConsolePanel />);
+    expect(screen.getByRole("button", { name: /e-stop/i })).toBeDisabled();
+  });
+
+  it("sends Feed Hold immediately when e-stop clicked", async () => {
+    useMachineStore.setState({ connected: true });
+    render(<ConsolePanel />);
+    await userEvent.click(screen.getByRole("button", { name: /e-stop/i }));
+    expect(window.terraForge.fluidnc.pauseJob).toHaveBeenCalledTimes(1);
+  });
+
   // ── Auto-scroll ─────────────────────────────────────────────────────────
 
   it("auto-scrolls when new lines are added", async () => {


### PR DESCRIPTION
This pull request introduces an always-visible Emergency Stop (E-STOP) button to the console interface, enabling users to immediately halt all machine motion via a realtime Feed Hold command. The button is styled for high visibility, remains accessible (but disabled when disconnected), and is thoroughly documented in both user and feature guides. Associated tests ensure correct functionality and UI behavior.

<img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/30d0d651-9535-4a18-904b-9b7103023a06" />


**Emergency Stop Feature:**

* Added a persistent E-STOP button to the console header, which sends a realtime Feed Hold (`!`) to halt motion without a confirmation dialog; the button is styled for emergency visibility and is only disabled when disconnected (`src/renderer/src/components/ConsolePanel/ConsoleToolbar.tsx`, `src/renderer/src/components/ConsolePanel.tsx`, [[1]](diffhunk://#diff-4684c00ce6b547f0050e3c62de5c5fcdd708d425a658f474b14e8a2822ebd6d5R87-R96) [[2]](diffhunk://#diff-4684c00ce6b547f0050e3c62de5c5fcdd708d425a658f474b14e8a2822ebd6d5L3-R3) [[3]](diffhunk://#diff-4684c00ce6b547f0050e3c62de5c5fcdd708d425a658f474b14e8a2822ebd6d5R14) [[4]](diffhunk://#diff-4684c00ce6b547f0050e3c62de5c5fcdd708d425a658f474b14e8a2822ebd6d5R33) [[5]](diffhunk://#diff-79b903236fc2e0b1dbfaeb682da365583635a22e0b48a2748ca10e6217c0d6d9R79).
* Updated the feature documentation to describe the new Emergency Stop button and its behavior (`docs/terraForge-features.md`, [docs/terraForge-features.mdR159](diffhunk://#diff-0b325508323a699320946e0286eee0fc5a9d7925c57535eb08f34e89103986b3R159)).
* Expanded the user guide with a dedicated section explaining the E-STOP button, its effects, and safety notes (`docs/terraForge-user-guide.md`, [docs/terraForge-user-guide.mdR942-R947](diffhunk://#diff-8cba3a75e1bb39616334ea8f7e8bfd6ac4aaf72e4b6b3c2f28b7563342007eb9R942-R947)).

**Testing:**

* Added component tests to verify that the E-STOP button is always visible (but disabled when disconnected) and that clicking it when connected issues the correct Feed Hold command (`tests/component/ConsolePanel.test.tsx`, [tests/component/ConsolePanel.test.tsxR179-R190](diffhunk://#diff-25d6c7ec2c630268e50946e9074b444e2d9f608261b57b05a25ec008a85829faR179-R190)).